### PR TITLE
[1.7] Set up multiplatform settings/preferences

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
             implementation(libs.compose.material3.adaptive.layout)
             implementation(libs.compose.material3.adaptive.navigation)
             implementation(libs.okio)
+            implementation(libs.datastore.preferences.core)
             implementation(libs.napier)
         }
         commonTest.dependencies {

--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.android.kt
@@ -1,0 +1,7 @@
+package org.github.keepasscompose.core.common
+
+actual fun dataStoreFilePath(): String =
+    AndroidContextHolder.applicationContext.filesDir
+        .resolve("datastore")
+        .resolve(DATA_STORE_FILE_NAME)
+        .absolutePath

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.kt
@@ -1,0 +1,15 @@
+package org.github.keepasscompose.core.common
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import okio.Path.Companion.toPath
+
+internal const val DATA_STORE_FILE_NAME = "app_settings.preferences_pb"
+
+fun createDataStore(producePath: () -> String): DataStore<Preferences> =
+    PreferenceDataStoreFactory.createWithPath(
+        produceFile = { producePath().toPath() }
+    )
+
+expect fun dataStoreFilePath(): String

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
@@ -1,0 +1,59 @@
+package org.github.keepasscompose.core.common
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AppSettings(private val dataStore: DataStore<Preferences>) {
+
+    private companion object {
+        val LAST_OPENED_DATABASE_PATH = stringPreferencesKey("last_opened_database_path")
+        val AUTO_LOCK_TIMEOUT_SECONDS = intPreferencesKey("auto_lock_timeout_seconds")
+        val THEME_PREFERENCE = stringPreferencesKey("theme_preference")
+        val CLIPBOARD_CLEAR_TIMEOUT_SECONDS = intPreferencesKey("clipboard_clear_timeout_seconds")
+    }
+
+    object Defaults {
+        const val AUTO_LOCK_TIMEOUT_SECONDS = 300       // 5 minutes
+        const val THEME_PREFERENCE = "system"            // "system", "light", "dark"
+        const val CLIPBOARD_CLEAR_TIMEOUT_SECONDS = 30   // 30 seconds
+    }
+
+    val lastOpenedDatabasePath: Flow<String?>
+        get() = dataStore.data.map { it[LAST_OPENED_DATABASE_PATH] }
+
+    val autoLockTimeoutSeconds: Flow<Int>
+        get() = dataStore.data.map { it[AUTO_LOCK_TIMEOUT_SECONDS] ?: Defaults.AUTO_LOCK_TIMEOUT_SECONDS }
+
+    val themePreference: Flow<String>
+        get() = dataStore.data.map { it[THEME_PREFERENCE] ?: Defaults.THEME_PREFERENCE }
+
+    val clipboardClearTimeoutSeconds: Flow<Int>
+        get() = dataStore.data.map { it[CLIPBOARD_CLEAR_TIMEOUT_SECONDS] ?: Defaults.CLIPBOARD_CLEAR_TIMEOUT_SECONDS }
+
+    suspend fun setLastOpenedDatabasePath(path: String?) {
+        dataStore.edit { prefs ->
+            if (path != null) {
+                prefs[LAST_OPENED_DATABASE_PATH] = path
+            } else {
+                prefs.remove(LAST_OPENED_DATABASE_PATH)
+            }
+        }
+    }
+
+    suspend fun setAutoLockTimeoutSeconds(seconds: Int) {
+        dataStore.edit { it[AUTO_LOCK_TIMEOUT_SECONDS] = seconds }
+    }
+
+    suspend fun setThemePreference(theme: String) {
+        dataStore.edit { it[THEME_PREFERENCE] = theme }
+    }
+
+    suspend fun setClipboardClearTimeoutSeconds(seconds: Int) {
+        dataStore.edit { it[CLIPBOARD_CLEAR_TIMEOUT_SECONDS] = seconds }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/AppModule.kt
@@ -1,9 +1,14 @@
 package org.github.keepasscompose.di
 
+import org.github.keepasscompose.core.common.AppSettings
 import org.github.keepasscompose.core.common.FileSystem
 import org.github.keepasscompose.core.common.PlatformFileSystem
+import org.github.keepasscompose.core.common.createDataStore
+import org.github.keepasscompose.core.common.dataStoreFilePath
 import org.koin.dsl.module
 
 val appModule = module {
     single<FileSystem> { PlatformFileSystem() }
+    single { createDataStore { dataStoreFilePath() } }
+    single { AppSettings(get()) }
 }

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.ios.kt
@@ -1,0 +1,13 @@
+package org.github.keepasscompose.core.common
+
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+actual fun dataStoreFilePath(): String {
+    val paths = NSSearchPathForDirectoriesInDomains(
+        NSDocumentDirectory, NSUserDomainMask, true
+    )
+    val documentsDir = paths.first() as String
+    return "$documentsDir/$DATA_STORE_FILE_NAME"
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/AppDataStore.jvm.kt
@@ -1,0 +1,6 @@
+package org.github.keepasscompose.core.common
+
+import java.io.File
+
+actual fun dataStoreFilePath(): String =
+    File(System.getProperty("user.home"), ".keepasscompose${File.separator}$DATA_STORE_FILE_NAME").absolutePath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ material3 = "1.10.0-alpha05"
 napier = "2.7.1"
 okio = "3.10.2"
 compose-material3-adaptive = "1.2.0"
+datastore = "1.1.2"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -51,6 +52,7 @@ kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.re
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastore" }
 compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "compose-material3-adaptive" }
 compose-material3-adaptive-layout = { module = "org.jetbrains.compose.material3.adaptive:adaptive-layout", version.ref = "compose-material3-adaptive" }
 compose-material3-adaptive-navigation = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation", version.ref = "compose-material3-adaptive" }


### PR DESCRIPTION
## Summary
- Add `androidx.datastore:datastore-preferences-core` (1.1.2) as a multiplatform DataStore dependency
- Create `AppSettings` class with Flow-based getters and suspend setters for: last opened database path, auto-lock timeout (default 300s), theme preference (default "system"), clipboard clear timeout (default 30s)
- Use `expect fun dataStoreFilePath()` with platform actuals (Android via `AndroidContextHolder`, JVM via `~/.keepasscompose/`, iOS via `NSDocumentDirectory`)
- Register `DataStore<Preferences>` and `AppSettings` as Koin singletons in `appModule`

Closes #8

## Test plan
- [x] JVM and Android targets compile successfully
- [x] Existing tests pass
- [ ] Verify preferences persist and load correctly on Android
- [ ] Verify preferences persist and load correctly on Desktop
- [ ] Verify preferences persist and load correctly on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)