### PR TITLE
[2.1] Define KDBX domain models

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/CompositeKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/CompositeKey.kt
@@ -1,0 +1,30 @@
+package org.github.keepasscompose.core.model
+
+data class CompositeKey(
+    val password: String? = null,
+    val keyFileData: ByteArray? = null,
+    val hardwareKeyChallenge: ByteArray? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CompositeKey) return false
+        return password == other.password &&
+            keyFileData.contentEquals(other.keyFileData) &&
+            hardwareKeyChallenge.contentEquals(other.hardwareKeyChallenge)
+    }
+
+    override fun hashCode(): Int {
+        var result = password?.hashCode() ?: 0
+        result = 31 * result + (keyFileData?.contentHashCode() ?: 0)
+        result = 31 * result + (hardwareKeyChallenge?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+private fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    if (this === other) return true
+    if (this == null || other == null) return false
+    return this.contentEquals(other)
+}
+
+private fun ByteArray?.contentHashCode(): Int = this?.contentHashCode() ?: 0

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxAttachment.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxAttachment.kt
@@ -1,0 +1,22 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxAttachment(
+    val id: Int,
+    val name: String,
+    val data: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KdbxAttachment) return false
+        return id == other.id &&
+            name == other.name &&
+            data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = id
+        result = 31 * result + name.hashCode()
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxDatabase.kt
@@ -1,0 +1,7 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxDatabase(
+    val meta: KdbxMeta = KdbxMeta(),
+    val header: KdbxHeader = KdbxHeader(),
+    val rootGroup: KdbxGroup,
+)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxEntry.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxEntry.kt
@@ -1,0 +1,34 @@
+package org.github.keepasscompose.core.model
+
+import kotlinx.datetime.Instant
+
+data class KdbxEntry(
+    val uuid: String,
+    val icon: KdbxIcon = KdbxIcon(),
+    val tags: List<String> = emptyList(),
+    val fields: List<KdbxEntryField> = emptyList(),
+    val attachments: List<KdbxAttachment> = emptyList(),
+    val history: List<KdbxEntry> = emptyList(),
+    val creationTime: Instant? = null,
+    val lastModificationTime: Instant? = null,
+    val lastAccessTime: Instant? = null,
+    val expiryTime: Instant? = null,
+    val expires: Boolean = false,
+) {
+    val title: String get() = field(FIELD_TITLE)
+    val userName: String get() = field(FIELD_USER_NAME)
+    val password: String get() = field(FIELD_PASSWORD)
+    val url: String get() = field(FIELD_URL)
+    val notes: String get() = field(FIELD_NOTES)
+
+    fun field(key: String): String =
+        fields.firstOrNull { it.key == key }?.value.orEmpty()
+
+    companion object {
+        const val FIELD_TITLE = "Title"
+        const val FIELD_USER_NAME = "UserName"
+        const val FIELD_PASSWORD = "Password"
+        const val FIELD_URL = "URL"
+        const val FIELD_NOTES = "Notes"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxEntryField.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxEntryField.kt
@@ -1,0 +1,7 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxEntryField(
+    val key: String,
+    val value: String,
+    val isProtected: Boolean = false,
+)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxGroup.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxGroup.kt
@@ -1,0 +1,10 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxGroup(
+    val uuid: String,
+    val name: String,
+    val icon: KdbxIcon = KdbxIcon(),
+    val notes: String = "",
+    val groups: List<KdbxGroup> = emptyList(),
+    val entries: List<KdbxEntry> = emptyList(),
+)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxHeader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxHeader.kt
@@ -1,0 +1,84 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxHeader(
+    val cipher: CipherId = CipherId.AES_256,
+    val compression: CompressionAlgorithm = CompressionAlgorithm.GZIP,
+    val masterSeed: ByteArray = ByteArray(0),
+    val encryptionIv: ByteArray = ByteArray(0),
+    val kdfParameters: KdfParameters = KdfParameters.AesKdf(),
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KdbxHeader) return false
+        return cipher == other.cipher &&
+            compression == other.compression &&
+            masterSeed.contentEquals(other.masterSeed) &&
+            encryptionIv.contentEquals(other.encryptionIv) &&
+            kdfParameters == other.kdfParameters
+    }
+
+    override fun hashCode(): Int {
+        var result = cipher.hashCode()
+        result = 31 * result + compression.hashCode()
+        result = 31 * result + masterSeed.contentHashCode()
+        result = 31 * result + encryptionIv.contentHashCode()
+        result = 31 * result + kdfParameters.hashCode()
+        return result
+    }
+}
+
+enum class CipherId {
+    AES_256,
+    CHACHA20,
+}
+
+enum class CompressionAlgorithm {
+    NONE,
+    GZIP,
+}
+
+sealed class KdfParameters {
+    data class AesKdf(
+        val rounds: Long = 60000,
+        val seed: ByteArray = ByteArray(0),
+    ) : KdfParameters() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is AesKdf) return false
+            return rounds == other.rounds && seed.contentEquals(other.seed)
+        }
+
+        override fun hashCode(): Int {
+            var result = rounds.hashCode()
+            result = 31 * result + seed.contentHashCode()
+            return result
+        }
+    }
+
+    data class Argon2(
+        val version: Int = 0x13,
+        val salt: ByteArray = ByteArray(0),
+        val parallelism: Int = 2,
+        val memory: Long = 65536,
+        val iterations: Long = 3,
+    ) : KdfParameters() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Argon2) return false
+            return version == other.version &&
+                salt.contentEquals(other.salt) &&
+                parallelism == other.parallelism &&
+                memory == other.memory &&
+                iterations == other.iterations
+        }
+
+        override fun hashCode(): Int {
+            var result = version
+            result = 31 * result + salt.contentHashCode()
+            result = 31 * result + parallelism
+            result = 31 * result + memory.hashCode()
+            result = 31 * result + iterations.hashCode()
+            return result
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxIcon.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxIcon.kt
@@ -1,0 +1,22 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxIcon(
+    val standardIndex: Int = 0,
+    val customUuid: String? = null,
+    val customData: ByteArray? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KdbxIcon) return false
+        return standardIndex == other.standardIndex &&
+            customUuid == other.customUuid &&
+            customData.contentEquals(other.customData)
+    }
+
+    override fun hashCode(): Int {
+        var result = standardIndex
+        result = 31 * result + (customUuid?.hashCode() ?: 0)
+        result = 31 * result + (customData?.contentHashCode() ?: 0)
+        return result
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxMeta.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxMeta.kt
@@ -1,0 +1,14 @@
+package org.github.keepasscompose.core.model
+
+data class KdbxMeta(
+    val databaseName: String = "",
+    val description: String = "",
+    val defaultUserName: String = "",
+    val recycleBinEnabled: Boolean = true,
+    val recycleBinUuid: String? = null,
+    val protectTitle: Boolean = false,
+    val protectUserName: Boolean = false,
+    val protectPassword: Boolean = true,
+    val protectUrl: Boolean = false,
+    val protectNotes: Boolean = false,
+)


### PR DESCRIPTION
## Summary
- Add 9 Kotlin data classes in `core/model/` representing the KDBX database format
- `KdbxDatabase` — top-level container with root group, metadata, and header
- `KdbxGroup` — hierarchical group with child groups and entries
- `KdbxEntry` — entry with fields, attachments, history, timestamps, and convenience accessors for standard fields (Title, UserName, Password, URL, Notes)
- `KdbxEntryField` — key/value pair with `isProtected` flag for sensitive data
- `KdbxAttachment` — binary attachment with id, name, and data
- `KdbxIcon` — standard icon index with optional custom icon (UUID + PNG data)
- `KdbxMeta` — database metadata including recycle bin and memory protection settings
- `KdbxHeader` — cipher, compression, master seed, IV, and KDF parameters (AES-KDF / Argon2)
- `CompositeKey` — password, key file, and hardware key components

## Ticket
Closes #9

## Test plan
- [x] JVM compilation succeeds
- [x] Existing tests pass
- [ ] Verify data classes correctly model KDBX 4.x format fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)