### PR TITLE
[2.3] Implement KDBX file header writing

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxHeaderReader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxHeaderReader.kt
@@ -314,5 +314,9 @@ class KdbxHeaderReader {
 private fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
     if (this === other) return true
     if (this == null || other == null) return false
-    return this.contentEquals(other)
+    if (this.size != other.size) return false
+    for (i in this.indices) {
+        if (this[i] != other[i]) return false
+    }
+    return true
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxHeaderWriter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxHeaderWriter.kt
@@ -1,0 +1,222 @@
+package org.github.keepasscompose.core.database
+
+import okio.Buffer
+import okio.BufferedSink
+import org.github.keepasscompose.core.model.Argon2Variant
+import org.github.keepasscompose.core.model.CipherId
+import org.github.keepasscompose.core.model.CompressionAlgorithm
+import org.github.keepasscompose.core.model.InnerStreamCipher
+import org.github.keepasscompose.core.model.KdbxHeader
+import org.github.keepasscompose.core.model.KdfParameters
+
+/**
+ * Result of writing a KDBX file header.
+ *
+ * @param rawHeaderBytes The raw bytes that were written (signatures through end-of-header),
+ *   needed for SHA-256 and HMAC-SHA-256 computation in KDBX 4.x.
+ */
+data class KdbxHeaderWriteResult(
+    val rawHeaderBytes: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KdbxHeaderWriteResult) return false
+        return rawHeaderBytes.contentEquals(other.rawHeaderBytes)
+    }
+
+    override fun hashCode(): Int = rawHeaderBytes.contentHashCode()
+}
+
+/**
+ * Serializes KDBX file headers to binary format, supporting both KDBX 3.1 and KDBX 4.x.
+ *
+ * The writer produces output that can be read back by [KdbxHeaderReader]. For KDBX 4.x,
+ * the caller is responsible for computing and appending the SHA-256 hash and HMAC-SHA-256
+ * after the header bytes (using the returned [KdbxHeaderWriteResult.rawHeaderBytes]).
+ */
+class KdbxHeaderWriter {
+
+    /**
+     * Writes the given [header] to [sink] in KDBX binary format.
+     *
+     * @return A [KdbxHeaderWriteResult] containing the raw header bytes for hash computation.
+     */
+    fun writeHeader(sink: BufferedSink, header: KdbxHeader): KdbxHeaderWriteResult {
+        val headerBytes = Buffer()
+
+        // 1. Write signatures
+        writeAndCapture(headerBytes, sink) { it.writeIntLe(SIGNATURE_1) }
+        writeAndCapture(headerBytes, sink) { it.writeIntLe(SIGNATURE_2) }
+
+        // 2. Write version
+        writeAndCapture(headerBytes, sink) { it.writeShortLe(header.version.minor) }
+        writeAndCapture(headerBytes, sink) { it.writeShortLe(header.version.major) }
+
+        // 3. Write header fields
+        writeField(headerBytes, sink, header.version.isV3, FIELD_CIPHER_ID, cipherIdBytes(header.cipher))
+        writeField(headerBytes, sink, header.version.isV3, FIELD_COMPRESSION_FLAGS, compressionBytes(header.compression))
+        writeField(headerBytes, sink, header.version.isV3, FIELD_MASTER_SEED, header.masterSeed)
+
+        if (header.version.isV3) {
+            val kdf = header.kdfParameters
+            if (kdf is KdfParameters.AesKdf) {
+                writeField(headerBytes, sink, true, FIELD_TRANSFORM_SEED, kdf.seed)
+                writeField(headerBytes, sink, true, FIELD_TRANSFORM_ROUNDS, longToBytes(kdf.rounds))
+            }
+        }
+
+        writeField(headerBytes, sink, header.version.isV3, FIELD_ENCRYPTION_IV, header.encryptionIv)
+
+        if (header.version.isV3) {
+            writeField(headerBytes, sink, true, FIELD_INNER_RANDOM_STREAM_KEY, header.innerRandomStreamKey)
+            writeField(headerBytes, sink, true, FIELD_STREAM_START_BYTES, header.streamStartBytes)
+            writeField(headerBytes, sink, true, FIELD_INNER_RANDOM_STREAM_ID, intToBytes(innerStreamCipherId(header.innerRandomStreamId)))
+        }
+
+        if (header.version.isV4) {
+            writeField(headerBytes, sink, false, FIELD_KDF_PARAMETERS, serializeKdfParameters(header.kdfParameters))
+        }
+
+        // 4. Write end-of-header
+        writeField(headerBytes, sink, header.version.isV3, FIELD_END_OF_HEADER, END_OF_HEADER_DATA)
+
+        return KdbxHeaderWriteResult(rawHeaderBytes = headerBytes.readByteArray())
+    }
+
+    private fun writeField(
+        headerBytes: Buffer,
+        sink: BufferedSink,
+        isV3: Boolean,
+        fieldId: Int,
+        data: ByteArray,
+    ) {
+        writeAndCapture(headerBytes, sink) { it.writeByte(fieldId) }
+        if (isV3) {
+            writeAndCapture(headerBytes, sink) { it.writeShortLe(data.size) }
+        } else {
+            writeAndCapture(headerBytes, sink) { it.writeIntLe(data.size) }
+        }
+        writeAndCapture(headerBytes, sink) { it.write(data) }
+    }
+
+    private inline fun writeAndCapture(
+        headerBytes: Buffer,
+        sink: BufferedSink,
+        block: (BufferedSink) -> Unit,
+    ) {
+        val capture = Buffer()
+        block(capture)
+        val bytes = capture.readByteArray()
+        headerBytes.write(bytes)
+        sink.write(bytes)
+    }
+
+    private fun cipherIdBytes(cipher: CipherId): ByteArray = when (cipher) {
+        CipherId.AES_256 -> CIPHER_AES_UUID
+        CipherId.TWOFISH -> CIPHER_TWOFISH_UUID
+        CipherId.CHACHA20 -> CIPHER_CHACHA20_UUID
+    }
+
+    private fun compressionBytes(compression: CompressionAlgorithm): ByteArray {
+        val flag = when (compression) {
+            CompressionAlgorithm.NONE -> 0
+            CompressionAlgorithm.GZIP -> 1
+        }
+        return intToBytes(flag)
+    }
+
+    private fun innerStreamCipherId(cipher: InnerStreamCipher): Int = when (cipher) {
+        InnerStreamCipher.NONE -> 0
+        InnerStreamCipher.ARC4 -> 1
+        InnerStreamCipher.SALSA20 -> 2
+        InnerStreamCipher.CHACHA20 -> 3
+    }
+
+    private fun serializeKdfParameters(kdf: KdfParameters): ByteArray {
+        val buf = Buffer()
+
+        // Variant dictionary version
+        buf.writeShortLe(VARIANT_DICTIONARY_VERSION)
+
+        when (kdf) {
+            is KdfParameters.AesKdf -> {
+                writeVariantEntry(buf, TYPE_BYTE_ARRAY, "\$UUID", KDF_AES_UUID)
+                writeVariantEntry(buf, TYPE_UINT64, "R", longToBytes(kdf.rounds))
+                writeVariantEntry(buf, TYPE_BYTE_ARRAY, "S", kdf.seed)
+            }
+            is KdfParameters.Argon2 -> {
+                val uuidBytes = when (kdf.variant) {
+                    Argon2Variant.ARGON2D -> KDF_ARGON2D_UUID
+                    Argon2Variant.ARGON2ID -> KDF_ARGON2ID_UUID
+                }
+                writeVariantEntry(buf, TYPE_BYTE_ARRAY, "\$UUID", uuidBytes)
+                writeVariantEntry(buf, TYPE_UINT32, "V", intToBytes(kdf.version))
+                writeVariantEntry(buf, TYPE_BYTE_ARRAY, "S", kdf.salt)
+                writeVariantEntry(buf, TYPE_UINT32, "P", intToBytes(kdf.parallelism))
+                writeVariantEntry(buf, TYPE_UINT64, "M", longToBytes(kdf.memory))
+                writeVariantEntry(buf, TYPE_UINT64, "I", longToBytes(kdf.iterations))
+            }
+        }
+
+        // Terminator
+        buf.writeByte(0x00)
+
+        return buf.readByteArray()
+    }
+
+    private fun writeVariantEntry(buf: Buffer, type: Int, key: String, value: ByteArray) {
+        buf.writeByte(type)
+        val keyBytes = key.encodeToByteArray()
+        buf.writeIntLe(keyBytes.size)
+        buf.write(keyBytes)
+        buf.writeIntLe(value.size)
+        buf.write(value)
+    }
+
+    private fun intToBytes(value: Int): ByteArray =
+        Buffer().apply { writeIntLe(value) }.readByteArray()
+
+    private fun longToBytes(value: Long): ByteArray =
+        Buffer().apply { writeLongLe(value) }.readByteArray()
+
+    companion object {
+        // KDBX file signatures
+        private val SIGNATURE_1 = 0x9AA2D903.toInt()
+        private val SIGNATURE_2 = 0xB54BFB67.toInt()
+
+        // Outer header field IDs
+        private const val FIELD_END_OF_HEADER = 0
+        private const val FIELD_CIPHER_ID = 2
+        private const val FIELD_COMPRESSION_FLAGS = 3
+        private const val FIELD_MASTER_SEED = 4
+        private const val FIELD_TRANSFORM_SEED = 5
+        private const val FIELD_TRANSFORM_ROUNDS = 6
+        private const val FIELD_ENCRYPTION_IV = 7
+        private const val FIELD_INNER_RANDOM_STREAM_KEY = 8
+        private const val FIELD_STREAM_START_BYTES = 9
+        private const val FIELD_INNER_RANDOM_STREAM_ID = 10
+        private const val FIELD_KDF_PARAMETERS = 11
+
+        // Variant dictionary
+        private const val VARIANT_DICTIONARY_VERSION = 0x0100
+        private const val TYPE_UINT32 = 0x04
+        private const val TYPE_UINT64 = 0x05
+        private const val TYPE_BYTE_ARRAY = 0x42
+
+        // End-of-header data: 4 bytes of CR LF CR LF for KDBX 4.x, empty for 3.1
+        private val END_OF_HEADER_DATA = byteArrayOf(0x0D, 0x0A, 0x0D, 0x0A)
+
+        // Cipher UUIDs (16 bytes, RFC 4122 byte order)
+        private val CIPHER_AES_UUID = hexToBytes("31c1f2e6bf714350be5805216afc5aff")
+        private val CIPHER_TWOFISH_UUID = hexToBytes("ad68f29f576f4bb9a36ad47af965346c")
+        private val CIPHER_CHACHA20_UUID = hexToBytes("d6038a2b8b6f4cb5a524339a31dbb59a")
+
+        // KDF UUIDs
+        private val KDF_AES_UUID = hexToBytes("c9d9f39a628a4460bf740d08c18a4fea")
+        private val KDF_ARGON2D_UUID = hexToBytes("ef636ddf8c29444b91f7a9a403e30a0c")
+        private val KDF_ARGON2ID_UUID = hexToBytes("9e298b1956db4773b23dfc3ec6f0a1e6")
+
+        private fun hexToBytes(hex: String): ByteArray =
+            hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxHeaderWriterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxHeaderWriterTest.kt
@@ -1,0 +1,257 @@
+package org.github.keepasscompose.core.database
+
+import okio.Buffer
+import org.github.keepasscompose.core.model.Argon2Variant
+import org.github.keepasscompose.core.model.CipherId
+import org.github.keepasscompose.core.model.CompressionAlgorithm
+import org.github.keepasscompose.core.model.InnerStreamCipher
+import org.github.keepasscompose.core.model.KdbxHeader
+import org.github.keepasscompose.core.model.KdbxVersion
+import org.github.keepasscompose.core.model.KdfParameters
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KdbxHeaderWriterTest {
+
+    private val writer = KdbxHeaderWriter()
+    private val reader = KdbxHeaderReader()
+
+    // -- KDBX 3.1 round-trip tests --
+
+    @Test
+    fun roundTrip_v3_aesKdf_defaults() {
+        val header = KdbxHeader(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { it.toByte() },
+            encryptionIv = ByteArray(16) { (it + 100).toByte() },
+            kdfParameters = KdfParameters.AesKdf(
+                rounds = 60000,
+                seed = ByteArray(32) { (it + 50).toByte() },
+            ),
+            innerRandomStreamKey = ByteArray(32) { (it + 200).toByte() },
+            innerRandomStreamId = InnerStreamCipher.SALSA20,
+            streamStartBytes = ByteArray(32) { (it + 150).toByte() },
+        )
+
+        val result = writeAndReadBack(header)
+
+        assertEquals(header, result.header)
+        assertNull(result.headerHash)
+        assertNull(result.headerHmac)
+    }
+
+    @Test
+    fun roundTrip_v3_twofish_noCompression() {
+        val header = KdbxHeader(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.TWOFISH,
+            compression = CompressionAlgorithm.NONE,
+            masterSeed = ByteArray(32) { 0xAB.toByte() },
+            encryptionIv = ByteArray(16) { 0xCD.toByte() },
+            kdfParameters = KdfParameters.AesKdf(
+                rounds = 100000,
+                seed = ByteArray(32) { 0xEF.toByte() },
+            ),
+            innerRandomStreamKey = ByteArray(32) { 0x11.toByte() },
+            innerRandomStreamId = InnerStreamCipher.ARC4,
+            streamStartBytes = ByteArray(32) { 0x22.toByte() },
+        )
+
+        val result = writeAndReadBack(header)
+
+        assertEquals(header, result.header)
+    }
+
+    @Test
+    fun roundTrip_v3_chacha20Cipher() {
+        val header = KdbxHeader(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.CHACHA20,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { (it * 3).toByte() },
+            encryptionIv = ByteArray(12) { (it * 7).toByte() },
+            kdfParameters = KdfParameters.AesKdf(
+                rounds = 1,
+                seed = ByteArray(32) { 0xFF.toByte() },
+            ),
+            innerRandomStreamKey = ByteArray(64) { it.toByte() },
+            innerRandomStreamId = InnerStreamCipher.CHACHA20,
+            streamStartBytes = ByteArray(32) { 0x00 },
+        )
+
+        val result = writeAndReadBack(header)
+
+        assertEquals(header, result.header)
+    }
+
+    // -- KDBX 4.x round-trip tests --
+
+    @Test
+    fun roundTrip_v4_aesKdf() {
+        val header = KdbxHeader(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { it.toByte() },
+            encryptionIv = ByteArray(16) { (it + 100).toByte() },
+            kdfParameters = KdfParameters.AesKdf(
+                rounds = 60000,
+                seed = ByteArray(32) { (it + 50).toByte() },
+            ),
+        )
+
+        val result = writeAndReadBack(header, appendV4Hashes = true)
+
+        assertEquals(header.version, result.header.version)
+        assertEquals(header.cipher, result.header.cipher)
+        assertEquals(header.compression, result.header.compression)
+        assertTrue(header.masterSeed.contentEquals(result.header.masterSeed))
+        assertTrue(header.encryptionIv.contentEquals(result.header.encryptionIv))
+        assertEquals(header.kdfParameters, result.header.kdfParameters)
+        assertNotNull(result.headerHash)
+        assertNotNull(result.headerHmac)
+    }
+
+    @Test
+    fun roundTrip_v4_argon2d() {
+        val header = KdbxHeader(
+            version = KdbxVersion(4, 1),
+            cipher = CipherId.CHACHA20,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { (it * 2).toByte() },
+            encryptionIv = ByteArray(12) { (it + 10).toByte() },
+            kdfParameters = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2D,
+                version = 0x13,
+                salt = ByteArray(32) { (it + 80).toByte() },
+                parallelism = 4,
+                memory = 131072,
+                iterations = 10,
+            ),
+        )
+
+        val result = writeAndReadBack(header, appendV4Hashes = true)
+
+        assertEquals(header.version, result.header.version)
+        assertEquals(header.cipher, result.header.cipher)
+        assertEquals(header.compression, result.header.compression)
+        assertTrue(header.masterSeed.contentEquals(result.header.masterSeed))
+        assertTrue(header.encryptionIv.contentEquals(result.header.encryptionIv))
+        assertEquals(header.kdfParameters, result.header.kdfParameters)
+    }
+
+    @Test
+    fun roundTrip_v4_argon2id() {
+        val header = KdbxHeader(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.TWOFISH,
+            compression = CompressionAlgorithm.NONE,
+            masterSeed = ByteArray(32) { 0x55 },
+            encryptionIv = ByteArray(16) { 0xAA.toByte() },
+            kdfParameters = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2ID,
+                version = 0x13,
+                salt = ByteArray(32) { 0xBB.toByte() },
+                parallelism = 2,
+                memory = 65536,
+                iterations = 3,
+            ),
+        )
+
+        val result = writeAndReadBack(header, appendV4Hashes = true)
+
+        assertEquals(header.version, result.header.version)
+        assertEquals(header.cipher, result.header.cipher)
+        assertEquals(header.compression, result.header.compression)
+        assertEquals(header.kdfParameters, result.header.kdfParameters)
+    }
+
+    // -- Raw header bytes tests --
+
+    @Test
+    fun rawHeaderBytes_matchBetweenWriteAndRead_v3() {
+        val header = KdbxHeader(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { it.toByte() },
+            encryptionIv = ByteArray(16) { it.toByte() },
+            kdfParameters = KdfParameters.AesKdf(rounds = 6000, seed = ByteArray(32) { it.toByte() }),
+            innerRandomStreamKey = ByteArray(32) { it.toByte() },
+            innerRandomStreamId = InnerStreamCipher.SALSA20,
+            streamStartBytes = ByteArray(32) { it.toByte() },
+        )
+
+        val output = Buffer()
+        val writeResult = writer.writeHeader(output, header)
+
+        val readResult = reader.readHeader(Buffer().apply { write(output.readByteArray()) })
+
+        assertTrue(writeResult.rawHeaderBytes.contentEquals(readResult.rawHeaderBytes))
+    }
+
+    @Test
+    fun rawHeaderBytes_matchBetweenWriteAndRead_v4() {
+        val header = KdbxHeader(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { it.toByte() },
+            encryptionIv = ByteArray(16) { it.toByte() },
+            kdfParameters = KdfParameters.AesKdf(rounds = 6000, seed = ByteArray(32) { it.toByte() }),
+        )
+
+        val output = Buffer()
+        val writeResult = writer.writeHeader(output, header)
+
+        // Append dummy hashes so the reader can parse the v4 post-header
+        output.write(ByteArray(32)) // dummy SHA-256
+        output.write(ByteArray(32)) // dummy HMAC
+
+        val readResult = reader.readHeader(Buffer().apply { write(output.readByteArray()) })
+
+        assertTrue(writeResult.rawHeaderBytes.contentEquals(readResult.rawHeaderBytes))
+    }
+
+    // -- Signature verification --
+
+    @Test
+    fun writtenHeader_startsWithCorrectSignatures() {
+        val header = KdbxHeader(
+            version = KdbxVersion(4, 0),
+            masterSeed = ByteArray(32),
+            encryptionIv = ByteArray(16),
+        )
+
+        val output = Buffer()
+        writer.writeHeader(output, header)
+
+        val sig1 = output.readIntLe()
+        val sig2 = output.readIntLe()
+
+        assertEquals(0x9AA2D903.toInt(), sig1)
+        assertEquals(0xB54BFB67.toInt(), sig2)
+    }
+
+    // -- Helper --
+
+    private fun writeAndReadBack(
+        header: KdbxHeader,
+        appendV4Hashes: Boolean = false,
+    ): KdbxHeaderReadResult {
+        val output = Buffer()
+        writer.writeHeader(output, header)
+
+        if (appendV4Hashes) {
+            output.write(ByteArray(32)) // dummy SHA-256 hash
+            output.write(ByteArray(32)) // dummy HMAC-SHA-256
+        }
+
+        return reader.readHeader(Buffer().apply { write(output.readByteArray()) })
+    }
+}


### PR DESCRIPTION
## Summary
- Add `KdbxHeaderWriter` that serializes `KdbxHeader` to KDBX binary format, supporting both KDBX 3.1 (2-byte field sizes, transform seed/rounds fields) and KDBX 4.x (4-byte field sizes, variant dictionary for KDF parameters including AES-KDF, Argon2d, and Argon2id)
- Fix StackOverflowError in `KdbxHeaderReader`'s nullable `ByteArray?.contentEquals` extension which recursed infinitely instead of performing element-wise comparison
- Add round-trip tests verifying write-then-read produces identical headers for all cipher, compression, KDF, and version combinations

Closes #11

## Test plan
- [x] Round-trip tests for KDBX 3.1 with AES-KDF (AES-256, Twofish, ChaCha20 ciphers)
- [x] Round-trip tests for KDBX 4.x with AES-KDF, Argon2d, and Argon2id
- [x] Raw header bytes match between writer output and reader capture
- [x] File signatures verified in written output
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)