### PR TITLE
[2.4] Implement XML payload parsing

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -60,9 +60,11 @@ kotlin {
             implementation(libs.okio)
             implementation(libs.datastore.preferences.core)
             implementation(libs.napier)
+            implementation(libs.xmlutil.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.datetime)
         }
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/InnerStreamDecryptor.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/InnerStreamDecryptor.kt
@@ -1,0 +1,14 @@
+package org.github.keepasscompose.core.database
+
+/**
+ * Stateful decryptor for protected field values in the KDBX XML payload.
+ *
+ * The inner random stream (Salsa20 for KDBX 3.1, ChaCha20 for KDBX 4.x) is a stream cipher,
+ * so each call to [decrypt] consumes the next chunk of the keystream. Protected values must
+ * therefore be decrypted in the order they appear in the XML.
+ *
+ * The actual cipher implementation is provided by the cryptography layer (Epic 3).
+ */
+fun interface InnerStreamDecryptor {
+    fun decrypt(ciphertext: ByteArray): ByteArray
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlReader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlReader.kt
@@ -1,0 +1,510 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.time.Instant
+import nl.adaptivity.xmlutil.EventType
+import nl.adaptivity.xmlutil.XmlReader
+import nl.adaptivity.xmlutil.xmlStreaming
+import okio.Buffer
+import okio.GzipSource
+import okio.buffer
+import org.github.keepasscompose.core.model.DeletedObject
+import org.github.keepasscompose.core.model.KdbxAttachment
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.KdbxIcon
+import org.github.keepasscompose.core.model.KdbxMeta
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Result of parsing the KDBX XML payload.
+ *
+ * @param meta The parsed database metadata.
+ * @param rootGroup The root group containing all groups and entries.
+ * @param deletedObjects Objects that were deleted from the database.
+ * @param binaries Binary attachment pool (ID to data) parsed from Meta/Binaries (KDBX 3.1).
+ */
+data class KdbxXmlReadResult(
+    val meta: KdbxMeta,
+    val rootGroup: KdbxGroup,
+    val deletedObjects: List<DeletedObject> = emptyList(),
+    val binaries: Map<Int, ByteArray> = emptyMap(),
+)
+
+/**
+ * Parses the decrypted and decompressed KDBX XML payload into domain models.
+ *
+ * The XML payload contains the database metadata, group/entry tree, and deleted objects.
+ * Protected field values (e.g., passwords) are base64-encoded ciphertext that must be
+ * decrypted using the inner random stream cipher.
+ *
+ * @param isV4 Whether the source file is KDBX 4.x (affects timestamp format).
+ * @param innerStreamDecryptor Optional decryptor for protected field values.
+ *   If null, protected values are left as raw base64 strings.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class KdbxXmlReader(
+    private val isV4: Boolean = true,
+    private val innerStreamDecryptor: InnerStreamDecryptor? = null,
+) {
+
+    private var binariesPool: Map<Int, ByteArray> = emptyMap()
+
+    fun readXml(xml: String): KdbxXmlReadResult {
+        val reader = xmlStreaming.newReader(xml)
+
+        reader.nextTag()
+        reader.requireStart("KeePassFile")
+
+        var meta = KdbxMeta()
+        var rootGroup: KdbxGroup? = null
+        var deletedObjects = emptyList<DeletedObject>()
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "Meta" -> meta = parseMeta(reader)
+                "Root" -> {
+                    val result = parseRoot(reader)
+                    rootGroup = result.first
+                    deletedObjects = result.second
+                }
+                else -> reader.skipElement()
+            }
+        }
+
+        reader.close()
+
+        return KdbxXmlReadResult(
+            meta = meta,
+            rootGroup = rootGroup ?: throw KdbxParseException("Missing Root/Group element"),
+            deletedObjects = deletedObjects,
+            binaries = binariesPool,
+        )
+    }
+
+    // -- Meta parsing --
+
+    private fun parseMeta(reader: XmlReader): KdbxMeta {
+        reader.requireStart("Meta")
+
+        var databaseName = ""
+        var description = ""
+        var defaultUserName = ""
+        var recycleBinEnabled = true
+        var recycleBinUuid: String? = null
+        var protectTitle = false
+        var protectUserName = false
+        var protectPassword = true
+        var protectUrl = false
+        var protectNotes = false
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "DatabaseName" -> databaseName = reader.readElementText()
+                "DatabaseDescription" -> description = reader.readElementText()
+                "DefaultUserName" -> defaultUserName = reader.readElementText()
+                "RecycleBinEnabled" -> recycleBinEnabled = reader.readElementText().toBooleanKdbx()
+                "RecycleBinUUID" -> recycleBinUuid = reader.readElementText().ifBlank { null }
+                "MemoryProtection" -> {
+                    val mp = parseMemoryProtection(reader)
+                    protectTitle = mp.protectTitle
+                    protectUserName = mp.protectUserName
+                    protectPassword = mp.protectPassword
+                    protectUrl = mp.protectUrl
+                    protectNotes = mp.protectNotes
+                }
+                "Binaries" -> binariesPool = parseBinaries(reader)
+                else -> reader.skipElement()
+            }
+        }
+
+        return KdbxMeta(
+            databaseName = databaseName,
+            description = description,
+            defaultUserName = defaultUserName,
+            recycleBinEnabled = recycleBinEnabled,
+            recycleBinUuid = recycleBinUuid,
+            protectTitle = protectTitle,
+            protectUserName = protectUserName,
+            protectPassword = protectPassword,
+            protectUrl = protectUrl,
+            protectNotes = protectNotes,
+        )
+    }
+
+    private data class MemoryProtection(
+        val protectTitle: Boolean = false,
+        val protectUserName: Boolean = false,
+        val protectPassword: Boolean = true,
+        val protectUrl: Boolean = false,
+        val protectNotes: Boolean = false,
+    )
+
+    private fun parseMemoryProtection(reader: XmlReader): MemoryProtection {
+        reader.requireStart("MemoryProtection")
+
+        var protectTitle = false
+        var protectUserName = false
+        var protectPassword = true
+        var protectUrl = false
+        var protectNotes = false
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "ProtectTitle" -> protectTitle = reader.readElementText().toBooleanKdbx()
+                "ProtectUserName" -> protectUserName = reader.readElementText().toBooleanKdbx()
+                "ProtectPassword" -> protectPassword = reader.readElementText().toBooleanKdbx()
+                "ProtectURL" -> protectUrl = reader.readElementText().toBooleanKdbx()
+                "ProtectNotes" -> protectNotes = reader.readElementText().toBooleanKdbx()
+                else -> reader.skipElement()
+            }
+        }
+
+        return MemoryProtection(protectTitle, protectUserName, protectPassword, protectUrl, protectNotes)
+    }
+
+    private fun parseBinaries(reader: XmlReader): Map<Int, ByteArray> {
+        reader.requireStart("Binaries")
+        val pool = mutableMapOf<Int, ByteArray>()
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            if (reader.localName == "Binary") {
+                val id = reader.getAttributeValue(null, "ID")?.toIntOrNull()
+                val compressed = reader.getAttributeValue(null, "Compressed")?.toBooleanKdbx() ?: false
+                val base64Text = reader.readElementText()
+
+                if (id != null && base64Text.isNotBlank()) {
+                    var data = Base64.decode(base64Text)
+                    if (compressed) {
+                        data = decompressGzip(data)
+                    }
+                    pool[id] = data
+                }
+            } else {
+                reader.skipElement()
+            }
+        }
+
+        return pool
+    }
+
+    // -- Root parsing --
+
+    private fun parseRoot(reader: XmlReader): Pair<KdbxGroup?, List<DeletedObject>> {
+        reader.requireStart("Root")
+
+        var rootGroup: KdbxGroup? = null
+        var deletedObjects = emptyList<DeletedObject>()
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "Group" -> rootGroup = parseGroup(reader)
+                "DeletedObjects" -> deletedObjects = parseDeletedObjects(reader)
+                else -> reader.skipElement()
+            }
+        }
+
+        return rootGroup to deletedObjects
+    }
+
+    // -- Group parsing --
+
+    private fun parseGroup(reader: XmlReader): KdbxGroup {
+        reader.requireStart("Group")
+
+        var uuid = ""
+        var name = ""
+        var notes = ""
+        var iconId = 0
+        var customIconUuid: String? = null
+        val groups = mutableListOf<KdbxGroup>()
+        val entries = mutableListOf<KdbxEntry>()
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "UUID" -> uuid = reader.readElementText()
+                "Name" -> name = reader.readElementText()
+                "Notes" -> notes = reader.readElementText()
+                "IconID" -> iconId = reader.readElementText().toIntOrNull() ?: 0
+                "CustomIconUUID" -> customIconUuid = reader.readElementText().ifBlank { null }
+                "Group" -> groups.add(parseGroup(reader))
+                "Entry" -> entries.add(parseEntry(reader))
+                else -> reader.skipElement()
+            }
+        }
+
+        return KdbxGroup(
+            uuid = uuid,
+            name = name,
+            icon = KdbxIcon(standardIndex = iconId, customUuid = customIconUuid),
+            notes = notes,
+            groups = groups,
+            entries = entries,
+        )
+    }
+
+    // -- Entry parsing --
+
+    private fun parseEntry(reader: XmlReader): KdbxEntry {
+        reader.requireStart("Entry")
+
+        var uuid = ""
+        var iconId = 0
+        var customIconUuid: String? = null
+        var tags = emptyList<String>()
+        val fields = mutableListOf<KdbxEntryField>()
+        val attachments = mutableListOf<KdbxAttachment>()
+        val history = mutableListOf<KdbxEntry>()
+        var creationTime: Instant? = null
+        var lastModificationTime: Instant? = null
+        var lastAccessTime: Instant? = null
+        var expiryTime: Instant? = null
+        var expires = false
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "UUID" -> uuid = reader.readElementText()
+                "IconID" -> iconId = reader.readElementText().toIntOrNull() ?: 0
+                "CustomIconUUID" -> customIconUuid = reader.readElementText().ifBlank { null }
+                "Tags" -> {
+                    val tagText = reader.readElementText()
+                    tags = if (tagText.isBlank()) emptyList()
+                    else tagText.split(";").filter { it.isNotBlank() }
+                }
+                "Times" -> {
+                    val times = parseTimes(reader)
+                    creationTime = times.creationTime
+                    lastModificationTime = times.lastModificationTime
+                    lastAccessTime = times.lastAccessTime
+                    expiryTime = times.expiryTime
+                    expires = times.expires
+                }
+                "String" -> fields.add(parseStringField(reader))
+                "Binary" -> {
+                    val attachment = parseEntryBinary(reader)
+                    if (attachment != null) attachments.add(attachment)
+                }
+                "History" -> {
+                    while (reader.nextTag() == EventType.START_ELEMENT) {
+                        if (reader.localName == "Entry") {
+                            history.add(parseEntry(reader))
+                        } else {
+                            reader.skipElement()
+                        }
+                    }
+                }
+                else -> reader.skipElement()
+            }
+        }
+
+        return KdbxEntry(
+            uuid = uuid,
+            icon = KdbxIcon(standardIndex = iconId, customUuid = customIconUuid),
+            tags = tags,
+            fields = fields,
+            attachments = attachments,
+            history = history,
+            creationTime = creationTime,
+            lastModificationTime = lastModificationTime,
+            lastAccessTime = lastAccessTime,
+            expiryTime = expiryTime,
+            expires = expires,
+        )
+    }
+
+    private data class Times(
+        val creationTime: Instant? = null,
+        val lastModificationTime: Instant? = null,
+        val lastAccessTime: Instant? = null,
+        val expiryTime: Instant? = null,
+        val expires: Boolean = false,
+    )
+
+    private fun parseTimes(reader: XmlReader): Times {
+        reader.requireStart("Times")
+
+        var creationTime: Instant? = null
+        var lastModificationTime: Instant? = null
+        var lastAccessTime: Instant? = null
+        var expiryTime: Instant? = null
+        var expires = false
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "CreationTime" -> creationTime = parseTimestamp(reader.readElementText())
+                "LastModificationTime" -> lastModificationTime = parseTimestamp(reader.readElementText())
+                "LastAccessTime" -> lastAccessTime = parseTimestamp(reader.readElementText())
+                "ExpiryTime" -> expiryTime = parseTimestamp(reader.readElementText())
+                "Expires" -> expires = reader.readElementText().toBooleanKdbx()
+                else -> reader.skipElement()
+            }
+        }
+
+        return Times(creationTime, lastModificationTime, lastAccessTime, expiryTime, expires)
+    }
+
+    private fun parseStringField(reader: XmlReader): KdbxEntryField {
+        reader.requireStart("String")
+
+        var key = ""
+        var value = ""
+        var isProtected = false
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "Key" -> key = reader.readElementText()
+                "Value" -> {
+                    isProtected = reader.getAttributeValue(null, "Protected")
+                        ?.toBooleanKdbx() ?: false
+                    val rawText = reader.readElementText()
+
+                    value = if (isProtected && rawText.isNotBlank() && innerStreamDecryptor != null) {
+                        val ciphertext = Base64.decode(rawText)
+                        val plaintext = innerStreamDecryptor.decrypt(ciphertext)
+                        plaintext.decodeToString()
+                    } else {
+                        rawText
+                    }
+                }
+                else -> reader.skipElement()
+            }
+        }
+
+        return KdbxEntryField(key = key, value = value, isProtected = isProtected)
+    }
+
+    private fun parseEntryBinary(reader: XmlReader): KdbxAttachment? {
+        reader.requireStart("Binary")
+
+        var name = ""
+        var refId: Int? = null
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "Key" -> name = reader.readElementText()
+                "Value" -> {
+                    refId = reader.getAttributeValue(null, "Ref")?.toIntOrNull()
+                    reader.readElementText() // consume content (may be empty for Ref)
+                }
+                else -> reader.skipElement()
+            }
+        }
+
+        if (refId == null) return null
+
+        return KdbxAttachment(
+            id = refId,
+            name = name,
+            data = binariesPool[refId] ?: ByteArray(0),
+        )
+    }
+
+    // -- DeletedObjects parsing --
+
+    private fun parseDeletedObjects(reader: XmlReader): List<DeletedObject> {
+        reader.requireStart("DeletedObjects")
+        val objects = mutableListOf<DeletedObject>()
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            if (reader.localName == "DeletedObject") {
+                objects.add(parseDeletedObject(reader))
+            } else {
+                reader.skipElement()
+            }
+        }
+
+        return objects
+    }
+
+    private fun parseDeletedObject(reader: XmlReader): DeletedObject {
+        reader.requireStart("DeletedObject")
+
+        var uuid = ""
+        var deletionTime: Instant? = null
+
+        while (reader.nextTag() == EventType.START_ELEMENT) {
+            when (reader.localName) {
+                "UUID" -> uuid = reader.readElementText()
+                "DeletionTime" -> deletionTime = parseTimestamp(reader.readElementText())
+                else -> reader.skipElement()
+            }
+        }
+
+        return DeletedObject(uuid = uuid, deletionTime = deletionTime)
+    }
+
+    // -- Timestamp parsing --
+
+    private fun parseTimestamp(text: String): Instant? {
+        if (text.isBlank()) return null
+
+        return if (isV4) {
+            parseV4Timestamp(text)
+        } else {
+            parseV3Timestamp(text)
+        }
+    }
+
+    private fun parseV3Timestamp(text: String): Instant? = try {
+        Instant.parse(text)
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun parseV4Timestamp(text: String): Instant? = try {
+        val bytes = Base64.decode(text)
+        if (bytes.size != 8) return null
+        val seconds = Buffer().apply { write(bytes) }.readLongLe()
+        Instant.fromEpochSeconds(seconds - DOTNET_EPOCH_OFFSET)
+    } catch (_: Exception) {
+        null
+    }
+
+    // -- Utilities --
+
+    private fun decompressGzip(data: ByteArray): ByteArray {
+        val source = Buffer().apply { write(data) }
+        return GzipSource(source).buffer().readByteArray()
+    }
+
+    companion object {
+        /** Seconds between .NET epoch (0001-01-01) and Unix epoch (1970-01-01). */
+        private const val DOTNET_EPOCH_OFFSET = 62135596800L
+    }
+}
+
+// -- XmlReader extension helpers --
+
+private fun XmlReader.requireStart(name: String) {
+    if (eventType != EventType.START_ELEMENT || localName != name) {
+        throw KdbxParseException("Expected <$name>, got <$localName> (${eventType})")
+    }
+}
+
+private fun XmlReader.readElementText(): String {
+    val sb = StringBuilder()
+    while (true) {
+        when (next()) {
+            EventType.TEXT, EventType.CDSECT, EventType.ENTITY_REF -> sb.append(text)
+            EventType.END_ELEMENT -> return sb.toString()
+            EventType.START_ELEMENT -> throw KdbxParseException("Unexpected child element: $localName")
+            else -> {} // ignore processing instructions, comments, etc.
+        }
+    }
+}
+
+private fun XmlReader.skipElement() {
+    var depth = 1
+    while (depth > 0) {
+        when (next()) {
+            EventType.START_ELEMENT -> depth++
+            EventType.END_ELEMENT -> depth--
+            else -> {}
+        }
+    }
+}
+
+
+private fun String.toBooleanKdbx(): Boolean =
+    equals("True", ignoreCase = true) || equals("true")

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/DeletedObject.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/DeletedObject.kt
@@ -1,0 +1,8 @@
+package org.github.keepasscompose.core.model
+
+import kotlin.time.Instant
+
+data class DeletedObject(
+    val uuid: String,
+    val deletionTime: Instant? = null,
+)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxEntry.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxEntry.kt
@@ -1,6 +1,6 @@
 package org.github.keepasscompose.core.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class KdbxEntry(
     val uuid: String,

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlReaderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlReaderTest.kt
@@ -1,0 +1,715 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.time.Instant
+import org.github.keepasscompose.core.model.KdbxEntry
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalEncodingApi::class)
+class KdbxXmlReaderTest {
+
+    // -- Meta parsing tests --
+
+    @Test
+    fun parseMeta_databaseName() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <DatabaseName>Test Database</DatabaseName>
+                <DatabaseDescription>My test DB</DatabaseDescription>
+                <DefaultUserName>admin</DefaultUserName>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals("Test Database", result.meta.databaseName)
+        assertEquals("My test DB", result.meta.description)
+        assertEquals("admin", result.meta.defaultUserName)
+    }
+
+    @Test
+    fun parseMeta_recycleBin() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <RecycleBinEnabled>True</RecycleBinEnabled>
+                <RecycleBinUUID>AAAAAAAAAAAAAAAAAAAAAA==</RecycleBinUUID>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertTrue(result.meta.recycleBinEnabled)
+        assertEquals("AAAAAAAAAAAAAAAAAAAAAA==", result.meta.recycleBinUuid)
+    }
+
+    @Test
+    fun parseMeta_recycleBinDisabled() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <RecycleBinEnabled>False</RecycleBinEnabled>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertFalse(result.meta.recycleBinEnabled)
+        assertNull(result.meta.recycleBinUuid)
+    }
+
+    @Test
+    fun parseMeta_memoryProtection() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <MemoryProtection>
+                    <ProtectTitle>True</ProtectTitle>
+                    <ProtectUserName>True</ProtectUserName>
+                    <ProtectPassword>True</ProtectPassword>
+                    <ProtectURL>False</ProtectURL>
+                    <ProtectNotes>False</ProtectNotes>
+                </MemoryProtection>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertTrue(result.meta.protectTitle)
+        assertTrue(result.meta.protectUserName)
+        assertTrue(result.meta.protectPassword)
+        assertFalse(result.meta.protectUrl)
+        assertFalse(result.meta.protectNotes)
+    }
+
+    // -- Group parsing tests --
+
+    @Test
+    fun parseGroup_basic() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Notes>Root group notes</Notes>
+                    <IconID>48</IconID>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals("cm9vdA==", result.rootGroup.uuid)
+        assertEquals("Root", result.rootGroup.name)
+        assertEquals("Root group notes", result.rootGroup.notes)
+        assertEquals(48, result.rootGroup.icon.standardIndex)
+    }
+
+    @Test
+    fun parseGroup_nestedGroups() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Group>
+                        <UUID>Y2hpbGQ=</UUID>
+                        <Name>Internet</Name>
+                        <IconID>1</IconID>
+                        <Group>
+                            <UUID>Z3JhbmQ=</UUID>
+                            <Name>Social</Name>
+                            <IconID>2</IconID>
+                        </Group>
+                    </Group>
+                    <Group>
+                        <UUID>ZW1haWw=</UUID>
+                        <Name>Email</Name>
+                        <IconID>3</IconID>
+                    </Group>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals(2, result.rootGroup.groups.size)
+        assertEquals("Internet", result.rootGroup.groups[0].name)
+        assertEquals("Email", result.rootGroup.groups[1].name)
+
+        // Nested grandchild
+        assertEquals(1, result.rootGroup.groups[0].groups.size)
+        assertEquals("Social", result.rootGroup.groups[0].groups[0].name)
+    }
+
+    // -- Entry parsing tests --
+
+    @Test
+    fun parseEntry_standardFields() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <IconID>0</IconID>
+                        <String>
+                            <Key>Title</Key>
+                            <Value>My Website</Value>
+                        </String>
+                        <String>
+                            <Key>UserName</Key>
+                            <Value>user@example.com</Value>
+                        </String>
+                        <String>
+                            <Key>Password</Key>
+                            <Value>secret123</Value>
+                        </String>
+                        <String>
+                            <Key>URL</Key>
+                            <Value>https://example.com</Value>
+                        </String>
+                        <String>
+                            <Key>Notes</Key>
+                            <Value>Some notes here</Value>
+                        </String>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+        val entry = result.rootGroup.entries.first()
+
+        assertEquals("ZW50cnk=", entry.uuid)
+        assertEquals("My Website", entry.title)
+        assertEquals("user@example.com", entry.userName)
+        assertEquals("secret123", entry.password)
+        assertEquals("https://example.com", entry.url)
+        assertEquals("Some notes here", entry.notes)
+        assertEquals(5, entry.fields.size)
+    }
+
+    @Test
+    fun parseEntry_protectedField_withDecryptor() {
+        // "secret123" encoded as bytes, then base64'd as fake "ciphertext"
+        val plaintext = "secret123".encodeToByteArray()
+        val ciphertext = Base64.encode(plaintext)
+
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <String>
+                            <Key>Password</Key>
+                            <Value Protected="True">$ciphertext</Value>
+                        </String>
+                    </Entry>
+                </Group>
+            """,
+        )
+
+        // Identity decryptor: returns ciphertext as-is (since we used plaintext bytes as fake ciphertext)
+        val decryptor = InnerStreamDecryptor { it }
+        val result = KdbxXmlReader(isV4 = false, innerStreamDecryptor = decryptor).readXml(xml)
+        val entry = result.rootGroup.entries.first()
+        val field = entry.fields.first()
+
+        assertTrue(field.isProtected)
+        assertEquals("secret123", field.value)
+    }
+
+    @Test
+    fun parseEntry_protectedField_withoutDecryptor() {
+        val ciphertext = Base64.encode("encrypted".encodeToByteArray())
+
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <String>
+                            <Key>Password</Key>
+                            <Value Protected="True">$ciphertext</Value>
+                        </String>
+                    </Entry>
+                </Group>
+            """,
+        )
+
+        // No decryptor: value should remain as raw base64
+        val result = readerV3().readXml(xml)
+        val field = result.rootGroup.entries.first().fields.first()
+
+        assertTrue(field.isProtected)
+        assertEquals(ciphertext, field.value)
+    }
+
+    @Test
+    fun parseEntry_tags() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <Tags>banking;finance;important</Tags>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+        val entry = result.rootGroup.entries.first()
+
+        assertEquals(listOf("banking", "finance", "important"), entry.tags)
+    }
+
+    @Test
+    fun parseEntry_emptyTags() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <Tags></Tags>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertTrue(result.rootGroup.entries.first().tags.isEmpty())
+    }
+
+    @Test
+    fun parseEntry_times_v3() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <Times>
+                            <CreationTime>2024-06-15T10:30:00Z</CreationTime>
+                            <LastModificationTime>2024-06-16T12:00:00Z</LastModificationTime>
+                            <LastAccessTime>2024-06-17T08:00:00Z</LastAccessTime>
+                            <ExpiryTime>2025-06-15T10:30:00Z</ExpiryTime>
+                            <Expires>True</Expires>
+                        </Times>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+        val entry = result.rootGroup.entries.first()
+
+        assertEquals(Instant.parse("2024-06-15T10:30:00Z"), entry.creationTime)
+        assertEquals(Instant.parse("2024-06-16T12:00:00Z"), entry.lastModificationTime)
+        assertEquals(Instant.parse("2024-06-17T08:00:00Z"), entry.lastAccessTime)
+        assertEquals(Instant.parse("2025-06-15T10:30:00Z"), entry.expiryTime)
+        assertTrue(entry.expires)
+    }
+
+    @Test
+    fun parseEntry_times_v4_base64() {
+        // Encode a known Unix timestamp as KDBX 4.x base64 timestamp
+        // 2024-01-01T00:00:00Z = Unix 1704067200 + 62135596800 = 63839664000
+        val seconds = 1704067200L + 62135596800L
+        val encoded = encodeV4Timestamp(seconds)
+
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <Times>
+                            <CreationTime>$encoded</CreationTime>
+                            <Expires>False</Expires>
+                        </Times>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV4().readXml(xml)
+        val entry = result.rootGroup.entries.first()
+
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), entry.creationTime)
+        assertFalse(entry.expires)
+    }
+
+    @Test
+    fun parseEntry_history() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <String>
+                            <Key>Title</Key>
+                            <Value>Current Title</Value>
+                        </String>
+                        <History>
+                            <Entry>
+                                <UUID>ZW50cnk=</UUID>
+                                <String>
+                                    <Key>Title</Key>
+                                    <Value>Old Title</Value>
+                                </String>
+                            </Entry>
+                        </History>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+        val entry = result.rootGroup.entries.first()
+
+        assertEquals("Current Title", entry.title)
+        assertEquals(1, entry.history.size)
+        assertEquals("Old Title", entry.history[0].title)
+    }
+
+    @Test
+    fun parseEntry_customIcon() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <IconID>5</IconID>
+                        <CustomIconUUID>Y3VzdG9t</CustomIconUUID>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+        val entry = result.rootGroup.entries.first()
+
+        assertEquals(5, entry.icon.standardIndex)
+        assertEquals("Y3VzdG9t", entry.icon.customUuid)
+    }
+
+    // -- Binary/Attachment tests --
+
+    @Test
+    fun parseBinaries_andEntryReference() {
+        val binaryData = "Hello, World!".encodeToByteArray()
+        val base64Binary = Base64.encode(binaryData)
+
+        val xml = wrapKeePassFile(
+            meta = """
+                <Binaries>
+                    <Binary ID="0">$base64Binary</Binary>
+                </Binaries>
+            """,
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <Binary>
+                            <Key>readme.txt</Key>
+                            <Value Ref="0" />
+                        </Binary>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        // Check binaries pool
+        assertEquals(1, result.binaries.size)
+        assertTrue(binaryData.contentEquals(result.binaries[0]!!))
+
+        // Check entry attachment
+        val attachment = result.rootGroup.entries.first().attachments.first()
+        assertEquals("readme.txt", attachment.name)
+        assertEquals(0, attachment.id)
+        assertTrue(binaryData.contentEquals(attachment.data))
+    }
+
+    // -- DeletedObjects tests --
+
+    @Test
+    fun parseDeletedObjects() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                </Group>
+                <DeletedObjects>
+                    <DeletedObject>
+                        <UUID>ZGVsZXRlZA==</UUID>
+                        <DeletionTime>2024-03-15T14:00:00Z</DeletionTime>
+                    </DeletedObject>
+                    <DeletedObject>
+                        <UUID>ZGVsZXRlZDI=</UUID>
+                        <DeletionTime>2024-03-16T09:30:00Z</DeletionTime>
+                    </DeletedObject>
+                </DeletedObjects>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals(2, result.deletedObjects.size)
+        assertEquals("ZGVsZXRlZA==", result.deletedObjects[0].uuid)
+        assertEquals(Instant.parse("2024-03-15T14:00:00Z"), result.deletedObjects[0].deletionTime)
+        assertEquals("ZGVsZXRlZDI=", result.deletedObjects[1].uuid)
+        assertEquals(Instant.parse("2024-03-16T09:30:00Z"), result.deletedObjects[1].deletionTime)
+    }
+
+    @Test
+    fun parseDeletedObjects_empty() {
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                </Group>
+                <DeletedObjects>
+                </DeletedObjects>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertTrue(result.deletedObjects.isEmpty())
+    }
+
+    // -- Unknown elements are skipped --
+
+    @Test
+    fun unknownElements_skipped() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <Generator>KeePass</Generator>
+                <DatabaseName>Test</DatabaseName>
+                <UnknownElement>
+                    <Deeply><Nested>Content</Nested></Deeply>
+                </UnknownElement>
+            """,
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <UnknownGroupChild>foo</UnknownGroupChild>
+                    <Entry>
+                        <UUID>ZW50cnk=</UUID>
+                        <UnknownEntryChild>bar</UnknownEntryChild>
+                    </Entry>
+                </Group>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals("Test", result.meta.databaseName)
+        assertEquals("Root", result.rootGroup.name)
+        assertEquals(1, result.rootGroup.entries.size)
+    }
+
+    // -- Full integration test --
+
+    @Test
+    fun fullXml_integration() {
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <KeePassFile>
+                <Meta>
+                    <Generator>KeePass</Generator>
+                    <DatabaseName>My Passwords</DatabaseName>
+                    <DatabaseDescription>Personal password database</DatabaseDescription>
+                    <DefaultUserName>defaultuser</DefaultUserName>
+                    <RecycleBinEnabled>True</RecycleBinEnabled>
+                    <RecycleBinUUID>cmVjeWNsZQ==</RecycleBinUUID>
+                    <MemoryProtection>
+                        <ProtectTitle>False</ProtectTitle>
+                        <ProtectUserName>False</ProtectUserName>
+                        <ProtectPassword>True</ProtectPassword>
+                        <ProtectURL>False</ProtectURL>
+                        <ProtectNotes>False</ProtectNotes>
+                    </MemoryProtection>
+                </Meta>
+                <Root>
+                    <Group>
+                        <UUID>cm9vdA==</UUID>
+                        <Name>Root</Name>
+                        <IconID>48</IconID>
+                        <Group>
+                            <UUID>aW50ZXJuZXQ=</UUID>
+                            <Name>Internet</Name>
+                            <IconID>1</IconID>
+                            <Entry>
+                                <UUID>Z21haWw=</UUID>
+                                <IconID>0</IconID>
+                                <Tags>email;google</Tags>
+                                <Times>
+                                    <CreationTime>2024-01-15T10:00:00Z</CreationTime>
+                                    <LastModificationTime>2024-06-01T12:00:00Z</LastModificationTime>
+                                    <Expires>False</Expires>
+                                </Times>
+                                <String>
+                                    <Key>Title</Key>
+                                    <Value>Gmail</Value>
+                                </String>
+                                <String>
+                                    <Key>UserName</Key>
+                                    <Value>user@gmail.com</Value>
+                                </String>
+                                <String>
+                                    <Key>Password</Key>
+                                    <Value>mypassword</Value>
+                                </String>
+                                <String>
+                                    <Key>URL</Key>
+                                    <Value>https://mail.google.com</Value>
+                                </String>
+                            </Entry>
+                        </Group>
+                        <Group>
+                            <UUID>YmFua2luZw==</UUID>
+                            <Name>Banking</Name>
+                            <IconID>37</IconID>
+                        </Group>
+                    </Group>
+                    <DeletedObjects>
+                        <DeletedObject>
+                            <UUID>b2xkZW50cnk=</UUID>
+                            <DeletionTime>2024-05-20T08:00:00Z</DeletionTime>
+                        </DeletedObject>
+                    </DeletedObjects>
+                </Root>
+            </KeePassFile>
+        """.trimIndent()
+
+        val result = readerV3().readXml(xml)
+
+        // Meta
+        assertEquals("My Passwords", result.meta.databaseName)
+        assertEquals("Personal password database", result.meta.description)
+        assertEquals("defaultuser", result.meta.defaultUserName)
+        assertTrue(result.meta.recycleBinEnabled)
+        assertTrue(result.meta.protectPassword)
+        assertFalse(result.meta.protectTitle)
+
+        // Root group
+        assertEquals("Root", result.rootGroup.name)
+        assertEquals(48, result.rootGroup.icon.standardIndex)
+        assertEquals(2, result.rootGroup.groups.size)
+
+        // Internet subgroup
+        val internet = result.rootGroup.groups[0]
+        assertEquals("Internet", internet.name)
+        assertEquals(1, internet.entries.size)
+
+        // Gmail entry
+        val gmail = internet.entries[0]
+        assertEquals("Gmail", gmail.title)
+        assertEquals("user@gmail.com", gmail.userName)
+        assertEquals("mypassword", gmail.password)
+        assertEquals("https://mail.google.com", gmail.url)
+        assertEquals(listOf("email", "google"), gmail.tags)
+        assertNotNull(gmail.creationTime)
+        assertFalse(gmail.expires)
+
+        // Banking subgroup (empty)
+        val banking = result.rootGroup.groups[1]
+        assertEquals("Banking", banking.name)
+        assertTrue(banking.entries.isEmpty())
+
+        // Deleted objects
+        assertEquals(1, result.deletedObjects.size)
+        assertEquals("b2xkZW50cnk=", result.deletedObjects[0].uuid)
+    }
+
+    // -- Multiple entries with protected fields: decryptor called in order --
+
+    @Test
+    fun protectedFields_decryptedInOrder() {
+        val passwords = listOf("pass1", "pass2", "pass3")
+        val encoded = passwords.map { Base64.encode(it.encodeToByteArray()) }
+
+        val xml = wrapKeePassFile(
+            root = """
+                <Group>
+                    <UUID>cm9vdA==</UUID>
+                    <Name>Root</Name>
+                    <Entry>
+                        <UUID>ZTE=</UUID>
+                        <String><Key>Password</Key><Value Protected="True">${encoded[0]}</Value></String>
+                    </Entry>
+                    <Entry>
+                        <UUID>ZTI=</UUID>
+                        <String><Key>Password</Key><Value Protected="True">${encoded[1]}</Value></String>
+                    </Entry>
+                    <Entry>
+                        <UUID>ZTM=</UUID>
+                        <String><Key>Password</Key><Value Protected="True">${encoded[2]}</Value></String>
+                    </Entry>
+                </Group>
+            """,
+        )
+
+        // Track decryption order
+        val decryptionOrder = mutableListOf<String>()
+        val decryptor = InnerStreamDecryptor { ciphertext ->
+            val text = ciphertext.decodeToString()
+            decryptionOrder.add(text)
+            ciphertext // identity decryptor
+        }
+
+        val result = KdbxXmlReader(isV4 = false, innerStreamDecryptor = decryptor).readXml(xml)
+        val entries = result.rootGroup.entries
+
+        assertEquals(3, entries.size)
+        assertEquals("pass1", entries[0].password)
+        assertEquals("pass2", entries[1].password)
+        assertEquals("pass3", entries[2].password)
+
+        // Verify decryption was called in document order
+        assertEquals(listOf("pass1", "pass2", "pass3"), decryptionOrder)
+    }
+
+    // -- Helpers --
+
+    private fun readerV3() = KdbxXmlReader(isV4 = false)
+    private fun readerV4() = KdbxXmlReader(isV4 = true)
+
+    private fun wrapKeePassFile(
+        meta: String = "",
+        root: String = """
+            <Group>
+                <UUID>cm9vdA==</UUID>
+                <Name>Root</Name>
+            </Group>
+        """,
+    ): String = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <KeePassFile>
+            <Meta>$meta</Meta>
+            <Root>$root</Root>
+        </KeePassFile>
+    """.trimIndent()
+
+    private fun encodeV4Timestamp(secondsSinceDotNetEpoch: Long): String {
+        val bytes = ByteArray(8)
+        var value = secondsSinceDotNetEpoch
+        for (i in 0 until 8) {
+            bytes[i] = (value and 0xFF).toByte()
+            value = value shr 8
+        }
+        return Base64.encode(bytes)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ junit = "4.13.2"
 koin = "4.0.2"
 kotlin = "2.3.0"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.6.2"
+kotlinx-datetime = "0.7.1"
 kotlinx-io = "0.7.0"
 kotlinx-serialization = "1.8.1"
 material3 = "1.10.0-alpha05"
@@ -23,6 +23,7 @@ napier = "2.7.1"
 okio = "3.10.2"
 compose-material3-adaptive = "1.2.0"
 datastore = "1.1.2"
+xmlutil = "0.90.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -56,6 +57,7 @@ datastore-preferences-core = { module = "androidx.datastore:datastore-preference
 compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "compose-material3-adaptive" }
 compose-material3-adaptive-layout = { module = "org.jetbrains.compose.material3.adaptive:adaptive-layout", version.ref = "compose-material3-adaptive" }
 compose-material3-adaptive-navigation = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation", version.ref = "compose-material3-adaptive" }
+xmlutil-core = { module = "io.github.pdvrieze.xmlutil:core", version.ref = "xmlutil" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Add `KdbxXmlReader` that parses decrypted KDBX XML payloads into domain models, supporting both KDBX 3.1 (ISO timestamps) and 4.x (base64 binary timestamps) formats
- Parse full XML structure: `<Meta>` (database name, memory protection, binaries pool with GZip decompression), `<Root>` → recursive `<Group>` tree, `<Entry>` with all standard fields, protected values, tags, attachments, history, and `<DeletedObjects>`
- Add `InnerStreamDecryptor` interface for protected field decryption (Salsa20/ChaCha20 implementation deferred to Epic 3 — Cryptography Layer)
- Add `DeletedObject` model, `xmlutil-core` dependency for KMP XML parsing
- Migrate `Instant` from `kotlinx-datetime` to `kotlin.time` (Kotlin 2.3.0 stdlib), bump kotlinx-datetime to 0.7.1

Closes #12

## Test plan
- [x] Meta parsing: database name, description, recycle bin, memory protection flags
- [x] Group parsing: basic fields, nested groups (3 levels deep)
- [x] Entry parsing: standard fields (Title, UserName, Password, URL, Notes)
- [x] Protected fields: with decryptor (base64 decode + decrypt), without decryptor (raw base64)
- [x] Tags: semicolon-separated, empty tags
- [x] Timestamps: KDBX 3.1 ISO format, KDBX 4.x base64 binary format
- [x] Entry history, custom icons
- [x] Binary attachments: Meta pool parsing + entry reference resolution
- [x] DeletedObjects: multiple objects, empty section
- [x] Unknown elements gracefully skipped
- [x] Full integration test with realistic XML structure
- [x] Protected field decryption order verified (stream cipher ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)