### PR TITLE
[2.6] Implement binary attachment handling

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxBinaryPool.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxBinaryPool.kt
@@ -1,0 +1,101 @@
+package org.github.keepasscompose.core.database
+
+import okio.Buffer
+import okio.GzipSink
+import okio.GzipSource
+import okio.buffer
+
+/**
+ * Manages a pool of binary attachments for a KDBX database.
+ *
+ * In KDBX 3.1, binaries are stored in the XML `<Meta><Binaries>` section.
+ * In KDBX 4.x, binaries are stored in the inner header as separate fields.
+ *
+ * This pool provides a unified interface for both formats, supporting:
+ * - ID-based storage and retrieval
+ * - GZip compression and decompression
+ * - Deduplication (finding existing binaries by content)
+ */
+class KdbxBinaryPool(
+    entries: Map<Int, ByteArray> = emptyMap(),
+) {
+    private val pool = mutableMapOf<Int, ByteArray>()
+
+    init {
+        pool.putAll(entries)
+    }
+
+    /** Returns the number of binaries in the pool. */
+    val size: Int get() = pool.size
+
+    /** Returns true if the pool contains no binaries. */
+    fun isEmpty(): Boolean = pool.isEmpty()
+
+    /** Returns the binary data for the given [id], or null if not found. */
+    operator fun get(id: Int): ByteArray? = pool[id]
+
+    /** Returns true if the pool contains a binary with the given [id]. */
+    fun contains(id: Int): Boolean = pool.containsKey(id)
+
+    /** Returns all entries as an immutable map. */
+    fun entries(): Map<Int, ByteArray> = pool.toMap()
+
+    /**
+     * Adds binary [data] to the pool with the given [id].
+     * Overwrites any existing binary with the same ID.
+     */
+    fun put(id: Int, data: ByteArray) {
+        pool[id] = data
+    }
+
+    /**
+     * Adds binary [data] to the pool, automatically assigning the next available ID.
+     *
+     * @return The assigned ID.
+     */
+    fun add(data: ByteArray): Int {
+        val id = nextId()
+        pool[id] = data
+        return id
+    }
+
+    /** Removes the binary with the given [id]. Returns the removed data, or null. */
+    fun remove(id: Int): ByteArray? = pool.remove(id)
+
+    /** Removes all binaries from the pool. */
+    fun clear() = pool.clear()
+
+    /**
+     * Finds an existing binary by content, returning its ID if found.
+     * Useful for deduplication when adding attachments.
+     */
+    fun findByContent(data: ByteArray): Int? =
+        pool.entries.firstOrNull { it.value.contentEquals(data) }?.key
+
+    /**
+     * Adds binary [data] to the pool, reusing an existing ID if identical content
+     * already exists. Returns the ID (existing or newly assigned).
+     */
+    fun addOrReuse(data: ByteArray): Int =
+        findByContent(data) ?: add(data)
+
+    private fun nextId(): Int =
+        if (pool.isEmpty()) 0 else pool.keys.max() + 1
+
+    companion object {
+        /** Compresses [data] using GZip. */
+        fun compressGzip(data: ByteArray): ByteArray {
+            val buffer = Buffer()
+            GzipSink(buffer).buffer().use { sink ->
+                sink.write(data)
+            }
+            return buffer.readByteArray()
+        }
+
+        /** Decompresses GZip-compressed [data]. */
+        fun decompressGzip(data: ByteArray): ByteArray {
+            val source = Buffer().apply { write(data) }
+            return GzipSource(source).buffer().readByteArray()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxInnerHeaderReader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxInnerHeaderReader.kt
@@ -1,0 +1,117 @@
+package org.github.keepasscompose.core.database
+
+import okio.BufferedSource
+
+/**
+ * Result of reading the KDBX 4.x inner header.
+ *
+ * The inner header appears after decryption and (optional) decompression,
+ * immediately before the XML payload. It contains:
+ * - The inner random stream cipher ID and key (for protected field encryption)
+ * - Binary attachments (stored outside XML in KDBX 4.x)
+ *
+ * @param innerRandomStreamId The inner random stream cipher identifier.
+ * @param innerRandomStreamKey The key for the inner random stream cipher.
+ * @param binaries The binary attachment pool parsed from inner header fields.
+ */
+data class KdbxInnerHeaderReadResult(
+    val innerRandomStreamId: Int,
+    val innerRandomStreamKey: ByteArray,
+    val binaries: KdbxBinaryPool,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KdbxInnerHeaderReadResult) return false
+        return innerRandomStreamId == other.innerRandomStreamId &&
+            innerRandomStreamKey.contentEquals(other.innerRandomStreamKey)
+    }
+
+    override fun hashCode(): Int {
+        var result = innerRandomStreamId
+        result = 31 * result + innerRandomStreamKey.contentHashCode()
+        return result
+    }
+}
+
+/**
+ * Reads the KDBX 4.x inner header from a decrypted stream.
+ *
+ * The inner header format is a sequence of fields:
+ * - 1 byte: field ID
+ * - 4 bytes (LE): field data length
+ * - N bytes: field data
+ *
+ * Field IDs:
+ * - 0x00: End of inner header
+ * - 0x01: Inner random stream ID (4 bytes, LE uint32)
+ * - 0x02: Inner random stream key (variable length)
+ * - 0x03: Binary attachment (first byte = flags, rest = data)
+ *
+ * Binary flags byte:
+ * - Bit 0 (0x01): Memory protection flag (data should be protected in memory)
+ */
+class KdbxInnerHeaderReader {
+
+    fun readInnerHeader(source: BufferedSource): KdbxInnerHeaderReadResult {
+        var innerStreamId = 0
+        var innerStreamKey = ByteArray(0)
+        val binaries = KdbxBinaryPool()
+        var binaryIndex = 0
+
+        while (true) {
+            val fieldId = source.readByte().toInt() and 0xFF
+            val fieldSize = source.readIntLe()
+
+            if (fieldId == FIELD_END_OF_INNER_HEADER) {
+                if (fieldSize > 0) {
+                    source.skip(fieldSize.toLong())
+                }
+                break
+            }
+
+            when (fieldId) {
+                FIELD_INNER_RANDOM_STREAM_ID -> {
+                    val data = source.readByteArray(fieldSize.toLong())
+                    innerStreamId = data.toLittleEndianInt()
+                }
+                FIELD_INNER_RANDOM_STREAM_KEY -> {
+                    innerStreamKey = source.readByteArray(fieldSize.toLong())
+                }
+                FIELD_BINARY -> {
+                    val data = source.readByteArray(fieldSize.toLong())
+                    if (data.isNotEmpty()) {
+                        // First byte is flags, rest is the actual binary data
+                        val binaryData = data.copyOfRange(1, data.size)
+                        binaries.put(binaryIndex, binaryData)
+                    }
+                    binaryIndex++
+                }
+                else -> {
+                    // Skip unknown fields
+                    source.skip(fieldSize.toLong())
+                }
+            }
+        }
+
+        return KdbxInnerHeaderReadResult(
+            innerRandomStreamId = innerStreamId,
+            innerRandomStreamKey = innerStreamKey,
+            binaries = binaries,
+        )
+    }
+
+    companion object {
+        private const val FIELD_END_OF_INNER_HEADER = 0x00
+        private const val FIELD_INNER_RANDOM_STREAM_ID = 0x01
+        private const val FIELD_INNER_RANDOM_STREAM_KEY = 0x02
+        private const val FIELD_BINARY = 0x03
+
+        private fun ByteArray.toLittleEndianInt(): Int {
+            var result = 0
+            for (i in indices.take(4)) {
+                result = result or ((this[i].toInt() and 0xFF) shl (i * 8))
+            }
+            return result
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxInnerHeaderWriter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxInnerHeaderWriter.kt
@@ -1,0 +1,69 @@
+package org.github.keepasscompose.core.database
+
+import okio.Buffer
+import okio.BufferedSink
+
+/**
+ * Writes the KDBX 4.x inner header to a sink.
+ *
+ * The inner header is written after encryption/decryption boundaries and before the XML payload.
+ * It contains the inner random stream parameters and binary attachments.
+ *
+ * Field format: 1 byte ID + 4 bytes LE length + N bytes data.
+ *
+ * @see KdbxInnerHeaderReader
+ */
+class KdbxInnerHeaderWriter {
+
+    /**
+     * Writes the inner header fields to [sink].
+     *
+     * @param sink The output sink.
+     * @param innerRandomStreamId The inner random stream cipher ID.
+     * @param innerRandomStreamKey The inner random stream cipher key.
+     * @param binaries The binary attachment pool to serialize.
+     */
+    fun writeInnerHeader(
+        sink: BufferedSink,
+        innerRandomStreamId: Int,
+        innerRandomStreamKey: ByteArray,
+        binaries: KdbxBinaryPool,
+    ) {
+        // 1. Write inner random stream ID
+        writeField(sink, FIELD_INNER_RANDOM_STREAM_ID, intToLittleEndianBytes(innerRandomStreamId))
+
+        // 2. Write inner random stream key
+        writeField(sink, FIELD_INNER_RANDOM_STREAM_KEY, innerRandomStreamKey)
+
+        // 3. Write binary attachments in order of their IDs
+        val sortedEntries = binaries.entries().entries.sortedBy { it.key }
+        for ((_, data) in sortedEntries) {
+            // Prepend the flags byte (0x01 = memory protection)
+            val fieldData = ByteArray(1 + data.size)
+            fieldData[0] = BINARY_FLAG_MEMORY_PROTECTION
+            data.copyInto(fieldData, 1)
+            writeField(sink, FIELD_BINARY, fieldData)
+        }
+
+        // 4. Write end-of-inner-header
+        writeField(sink, FIELD_END_OF_INNER_HEADER, ByteArray(0))
+    }
+
+    private fun writeField(sink: BufferedSink, fieldId: Int, data: ByteArray) {
+        sink.writeByte(fieldId)
+        sink.writeIntLe(data.size)
+        sink.write(data)
+    }
+
+    companion object {
+        private const val FIELD_END_OF_INNER_HEADER = 0x00
+        private const val FIELD_INNER_RANDOM_STREAM_ID = 0x01
+        private const val FIELD_INNER_RANDOM_STREAM_KEY = 0x02
+        private const val FIELD_BINARY = 0x03
+
+        private const val BINARY_FLAG_MEMORY_PROTECTION: Byte = 0x01
+
+        private fun intToLittleEndianBytes(value: Int): ByteArray =
+            Buffer().apply { writeIntLe(value) }.readByteArray()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlReader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlReader.kt
@@ -5,8 +5,6 @@ import nl.adaptivity.xmlutil.EventType
 import nl.adaptivity.xmlutil.XmlReader
 import nl.adaptivity.xmlutil.xmlStreaming
 import okio.Buffer
-import okio.GzipSource
-import okio.buffer
 import org.github.keepasscompose.core.model.DeletedObject
 import org.github.keepasscompose.core.model.KdbxAttachment
 import org.github.keepasscompose.core.model.KdbxEntry
@@ -23,13 +21,14 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * @param meta The parsed database metadata.
  * @param rootGroup The root group containing all groups and entries.
  * @param deletedObjects Objects that were deleted from the database.
- * @param binaries Binary attachment pool (ID to data) parsed from Meta/Binaries (KDBX 3.1).
+ * @param binaryPool The binary attachment pool, populated from either
+ *   XML Meta/Binaries (KDBX 3.1) or the inner header (KDBX 4.x).
  */
 data class KdbxXmlReadResult(
     val meta: KdbxMeta,
     val rootGroup: KdbxGroup,
     val deletedObjects: List<DeletedObject> = emptyList(),
-    val binaries: Map<Int, ByteArray> = emptyMap(),
+    val binaryPool: KdbxBinaryPool = KdbxBinaryPool(),
 )
 
 /**
@@ -42,14 +41,18 @@ data class KdbxXmlReadResult(
  * @param isV4 Whether the source file is KDBX 4.x (affects timestamp format).
  * @param innerStreamDecryptor Optional decryptor for protected field values.
  *   If null, protected values are left as raw base64 strings.
+ * @param externalBinaryPool Optional pre-populated binary pool from the KDBX 4.x inner header.
+ *   When provided, entry attachment references resolve against this pool instead of
+ *   parsing binaries from XML Meta/Binaries.
  */
 @OptIn(ExperimentalEncodingApi::class)
 class KdbxXmlReader(
     private val isV4: Boolean = true,
     private val innerStreamDecryptor: InnerStreamDecryptor? = null,
+    private val externalBinaryPool: KdbxBinaryPool? = null,
 ) {
 
-    private var binariesPool: Map<Int, ByteArray> = emptyMap()
+    private var binariesPool: KdbxBinaryPool = externalBinaryPool ?: KdbxBinaryPool()
 
     fun readXml(xml: String): KdbxXmlReadResult {
         val reader = xmlStreaming.newReader(xml)
@@ -79,7 +82,7 @@ class KdbxXmlReader(
             meta = meta,
             rootGroup = rootGroup ?: throw KdbxParseException("Missing Root/Group element"),
             deletedObjects = deletedObjects,
-            binaries = binariesPool,
+            binaryPool = binariesPool,
         )
     }
 
@@ -114,7 +117,7 @@ class KdbxXmlReader(
                     protectUrl = mp.protectUrl
                     protectNotes = mp.protectNotes
                 }
-                "Binaries" -> binariesPool = parseBinaries(reader)
+                "Binaries" -> parseBinariesIntoPool(reader)
                 else -> reader.skipElement()
             }
         }
@@ -164,9 +167,8 @@ class KdbxXmlReader(
         return MemoryProtection(protectTitle, protectUserName, protectPassword, protectUrl, protectNotes)
     }
 
-    private fun parseBinaries(reader: XmlReader): Map<Int, ByteArray> {
+    private fun parseBinariesIntoPool(reader: XmlReader) {
         reader.requireStart("Binaries")
-        val pool = mutableMapOf<Int, ByteArray>()
 
         while (reader.nextTag() == EventType.START_ELEMENT) {
             if (reader.localName == "Binary") {
@@ -177,16 +179,14 @@ class KdbxXmlReader(
                 if (id != null && base64Text.isNotBlank()) {
                     var data = Base64.decode(base64Text)
                     if (compressed) {
-                        data = decompressGzip(data)
+                        data = KdbxBinaryPool.decompressGzip(data)
                     }
-                    pool[id] = data
+                    binariesPool.put(id, data)
                 }
             } else {
                 reader.skipElement()
             }
         }
-
-        return pool
     }
 
     // -- Root parsing --
@@ -396,7 +396,7 @@ class KdbxXmlReader(
         return KdbxAttachment(
             id = refId,
             name = name,
-            data = binariesPool[refId] ?: ByteArray(0),
+            data = binariesPool[refId] ?: byteArrayOf(),
         )
     }
 
@@ -459,13 +459,6 @@ class KdbxXmlReader(
         Instant.fromEpochSeconds(seconds - DOTNET_EPOCH_OFFSET)
     } catch (_: Exception) {
         null
-    }
-
-    // -- Utilities --
-
-    private fun decompressGzip(data: ByteArray): ByteArray {
-        val source = Buffer().apply { write(data) }
-        return GzipSource(source).buffer().readByteArray()
     }
 
     companion object {

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxBinaryPoolTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxBinaryPoolTest.kt
@@ -1,0 +1,186 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KdbxBinaryPoolTest {
+
+    @Test
+    fun emptyPool() {
+        val pool = KdbxBinaryPool()
+        assertEquals(0, pool.size)
+        assertTrue(pool.isEmpty())
+        assertNull(pool[0])
+        assertFalse(pool.contains(0))
+    }
+
+    @Test
+    fun putAndGet() {
+        val pool = KdbxBinaryPool()
+        val data = "hello".encodeToByteArray()
+
+        pool.put(0, data)
+
+        assertEquals(1, pool.size)
+        assertTrue(pool.contains(0))
+        assertTrue(data.contentEquals(pool[0]!!))
+    }
+
+    @Test
+    fun constructFromMap() {
+        val data0 = "file1".encodeToByteArray()
+        val data1 = "file2".encodeToByteArray()
+        val pool = KdbxBinaryPool(mapOf(0 to data0, 1 to data1))
+
+        assertEquals(2, pool.size)
+        assertTrue(data0.contentEquals(pool[0]!!))
+        assertTrue(data1.contentEquals(pool[1]!!))
+    }
+
+    @Test
+    fun add_assignsSequentialIds() {
+        val pool = KdbxBinaryPool()
+
+        val id0 = pool.add("first".encodeToByteArray())
+        val id1 = pool.add("second".encodeToByteArray())
+
+        assertEquals(0, id0)
+        assertEquals(1, id1)
+        assertEquals(2, pool.size)
+    }
+
+    @Test
+    fun add_continuesAfterExistingMaxId() {
+        val pool = KdbxBinaryPool(mapOf(5 to "data".encodeToByteArray()))
+
+        val newId = pool.add("new".encodeToByteArray())
+
+        assertEquals(6, newId)
+    }
+
+    @Test
+    fun remove() {
+        val data = "removeme".encodeToByteArray()
+        val pool = KdbxBinaryPool(mapOf(0 to data))
+
+        val removed = pool.remove(0)
+
+        assertNotNull(removed)
+        assertTrue(data.contentEquals(removed))
+        assertEquals(0, pool.size)
+        assertNull(pool[0])
+    }
+
+    @Test
+    fun remove_nonExistent() {
+        val pool = KdbxBinaryPool()
+        assertNull(pool.remove(99))
+    }
+
+    @Test
+    fun clear() {
+        val pool = KdbxBinaryPool(mapOf(
+            0 to "a".encodeToByteArray(),
+            1 to "b".encodeToByteArray(),
+        ))
+
+        pool.clear()
+
+        assertEquals(0, pool.size)
+        assertTrue(pool.isEmpty())
+    }
+
+    @Test
+    fun entries_returnsImmutableCopy() {
+        val pool = KdbxBinaryPool(mapOf(0 to "data".encodeToByteArray()))
+
+        val entries = pool.entries()
+
+        assertEquals(1, entries.size)
+        assertTrue(entries.containsKey(0))
+    }
+
+    @Test
+    fun findByContent_found() {
+        val data = "findme".encodeToByteArray()
+        val pool = KdbxBinaryPool(mapOf(3 to data))
+
+        val id = pool.findByContent("findme".encodeToByteArray())
+
+        assertEquals(3, id)
+    }
+
+    @Test
+    fun findByContent_notFound() {
+        val pool = KdbxBinaryPool(mapOf(0 to "other".encodeToByteArray()))
+
+        assertNull(pool.findByContent("missing".encodeToByteArray()))
+    }
+
+    @Test
+    fun addOrReuse_reusesExisting() {
+        val data = "shared".encodeToByteArray()
+        val pool = KdbxBinaryPool(mapOf(2 to data))
+
+        val id = pool.addOrReuse("shared".encodeToByteArray())
+
+        assertEquals(2, id)
+        assertEquals(1, pool.size) // No new entry added
+    }
+
+    @Test
+    fun addOrReuse_addsNew() {
+        val pool = KdbxBinaryPool(mapOf(0 to "existing".encodeToByteArray()))
+
+        val id = pool.addOrReuse("new".encodeToByteArray())
+
+        assertEquals(1, id)
+        assertEquals(2, pool.size)
+    }
+
+    @Test
+    fun gzipRoundTrip() {
+        val original = "This is some test data for GZip compression testing!".encodeToByteArray()
+
+        val compressed = KdbxBinaryPool.compressGzip(original)
+        val decompressed = KdbxBinaryPool.decompressGzip(compressed)
+
+        assertTrue(original.contentEquals(decompressed))
+        // Compressed data should differ from original
+        assertFalse(original.contentEquals(compressed))
+    }
+
+    @Test
+    fun gzipRoundTrip_emptyData() {
+        val original = ByteArray(0)
+
+        val compressed = KdbxBinaryPool.compressGzip(original)
+        val decompressed = KdbxBinaryPool.decompressGzip(compressed)
+
+        assertTrue(original.contentEquals(decompressed))
+    }
+
+    @Test
+    fun gzipRoundTrip_binaryData() {
+        val original = ByteArray(256) { it.toByte() }
+
+        val compressed = KdbxBinaryPool.compressGzip(original)
+        val decompressed = KdbxBinaryPool.decompressGzip(compressed)
+
+        assertTrue(original.contentEquals(decompressed))
+    }
+
+    @Test
+    fun put_overwritesExisting() {
+        val pool = KdbxBinaryPool()
+        pool.put(0, "old".encodeToByteArray())
+        pool.put(0, "new".encodeToByteArray())
+
+        assertEquals(1, pool.size)
+        assertEquals("new", pool[0]!!.decodeToString())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxInnerHeaderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxInnerHeaderTest.kt
@@ -1,0 +1,291 @@
+package org.github.keepasscompose.core.database
+
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KdbxInnerHeaderTest {
+
+    // -- Reader tests --
+
+    @Test
+    fun readInnerHeader_streamIdAndKey() {
+        val buf = Buffer()
+
+        // Inner stream ID = 3 (ChaCha20)
+        buf.writeByte(0x01) // field ID
+        buf.writeIntLe(4)   // length
+        buf.writeIntLe(3)   // ChaCha20
+
+        // Inner stream key (32 bytes)
+        val key = ByteArray(32) { (it + 1).toByte() }
+        buf.writeByte(0x02) // field ID
+        buf.writeIntLe(32)  // length
+        buf.write(key)
+
+        // End of inner header
+        buf.writeByte(0x00)
+        buf.writeIntLe(0)
+
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        assertEquals(3, result.innerRandomStreamId)
+        assertTrue(key.contentEquals(result.innerRandomStreamKey))
+        assertTrue(result.binaries.isEmpty())
+    }
+
+    @Test
+    fun readInnerHeader_withBinaries() {
+        val buf = Buffer()
+
+        // Inner stream ID
+        buf.writeByte(0x01)
+        buf.writeIntLe(4)
+        buf.writeIntLe(3)
+
+        // Inner stream key
+        buf.writeByte(0x02)
+        buf.writeIntLe(4)
+        buf.write(ByteArray(4))
+
+        // Binary 0: flags(1 byte) + data "hello"
+        val binary0Data = "hello".encodeToByteArray()
+        buf.writeByte(0x03)
+        buf.writeIntLe(1 + binary0Data.size) // flags + data
+        buf.writeByte(0x01) // flags: memory protection
+        buf.write(binary0Data)
+
+        // Binary 1: flags(1 byte) + data "world"
+        val binary1Data = "world".encodeToByteArray()
+        buf.writeByte(0x03)
+        buf.writeIntLe(1 + binary1Data.size)
+        buf.writeByte(0x00) // flags: none
+        buf.write(binary1Data)
+
+        // End of inner header
+        buf.writeByte(0x00)
+        buf.writeIntLe(0)
+
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        assertEquals(2, result.binaries.size)
+        assertTrue(binary0Data.contentEquals(result.binaries[0]!!))
+        assertTrue(binary1Data.contentEquals(result.binaries[1]!!))
+    }
+
+    @Test
+    fun readInnerHeader_skipsUnknownFields() {
+        val buf = Buffer()
+
+        // Unknown field ID 0x05
+        buf.writeByte(0x05)
+        buf.writeIntLe(3)
+        buf.write("abc".encodeToByteArray())
+
+        // Inner stream ID
+        buf.writeByte(0x01)
+        buf.writeIntLe(4)
+        buf.writeIntLe(2) // Salsa20
+
+        // Inner stream key
+        buf.writeByte(0x02)
+        buf.writeIntLe(4)
+        buf.write(ByteArray(4))
+
+        // End
+        buf.writeByte(0x00)
+        buf.writeIntLe(0)
+
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        assertEquals(2, result.innerRandomStreamId)
+    }
+
+    @Test
+    fun readInnerHeader_endWithData() {
+        val buf = Buffer()
+
+        // Inner stream ID
+        buf.writeByte(0x01)
+        buf.writeIntLe(4)
+        buf.writeIntLe(3)
+
+        // Inner stream key
+        buf.writeByte(0x02)
+        buf.writeIntLe(4)
+        buf.write(ByteArray(4))
+
+        // End of inner header with extra data (should be skipped)
+        buf.writeByte(0x00)
+        buf.writeIntLe(4)
+        buf.write("junk".encodeToByteArray())
+
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        assertEquals(3, result.innerRandomStreamId)
+    }
+
+    // -- Writer tests --
+
+    @Test
+    fun writeInnerHeader_streamIdAndKey() {
+        val buf = Buffer()
+        val key = ByteArray(32) { (it + 1).toByte() }
+
+        KdbxInnerHeaderWriter().writeInnerHeader(
+            sink = buf,
+            innerRandomStreamId = 3,
+            innerRandomStreamKey = key,
+            binaries = KdbxBinaryPool(),
+        )
+
+        // Read it back
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        assertEquals(3, result.innerRandomStreamId)
+        assertTrue(key.contentEquals(result.innerRandomStreamKey))
+        assertTrue(result.binaries.isEmpty())
+    }
+
+    @Test
+    fun writeAndReadInnerHeader_withBinaries() {
+        val binary0 = "attachment1".encodeToByteArray()
+        val binary1 = "attachment2".encodeToByteArray()
+        val key = ByteArray(32) { 0xAA.toByte() }
+
+        val pool = KdbxBinaryPool()
+        pool.put(0, binary0)
+        pool.put(1, binary1)
+
+        val buf = Buffer()
+        KdbxInnerHeaderWriter().writeInnerHeader(
+            sink = buf,
+            innerRandomStreamId = 3,
+            innerRandomStreamKey = key,
+            binaries = pool,
+        )
+
+        // Read it back
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        assertEquals(3, result.innerRandomStreamId)
+        assertTrue(key.contentEquals(result.innerRandomStreamKey))
+        assertEquals(2, result.binaries.size)
+        assertTrue(binary0.contentEquals(result.binaries[0]!!))
+        assertTrue(binary1.contentEquals(result.binaries[1]!!))
+    }
+
+    @Test
+    fun writeAndRead_roundTrip_preservesBinaryOrder() {
+        val pool = KdbxBinaryPool()
+        // Add in non-sequential order
+        pool.put(2, "c".encodeToByteArray())
+        pool.put(0, "a".encodeToByteArray())
+        pool.put(1, "b".encodeToByteArray())
+
+        val buf = Buffer()
+        KdbxInnerHeaderWriter().writeInnerHeader(
+            sink = buf,
+            innerRandomStreamId = 2,
+            innerRandomStreamKey = ByteArray(16),
+            binaries = pool,
+        )
+
+        val result = KdbxInnerHeaderReader().readInnerHeader(buf)
+
+        // Writer sorts by ID, reader assigns sequential IDs 0, 1, 2
+        assertEquals(3, result.binaries.size)
+        assertEquals("a", result.binaries[0]!!.decodeToString())
+        assertEquals("b", result.binaries[1]!!.decodeToString())
+        assertEquals("c", result.binaries[2]!!.decodeToString())
+    }
+
+    // -- XmlReader external pool integration --
+
+    @Test
+    fun xmlReader_usesExternalPool() {
+        val binaryData = "external binary data".encodeToByteArray()
+        val pool = KdbxBinaryPool()
+        pool.put(0, binaryData)
+
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <KeePassFile>
+                <Meta></Meta>
+                <Root>
+                    <Group>
+                        <UUID>cm9vdA==</UUID>
+                        <Name>Root</Name>
+                        <Entry>
+                            <UUID>ZW50cnk=</UUID>
+                            <Binary>
+                                <Key>document.pdf</Key>
+                                <Value Ref="0" />
+                            </Binary>
+                        </Entry>
+                    </Group>
+                </Root>
+            </KeePassFile>
+        """.trimIndent()
+
+        val result = KdbxXmlReader(
+            isV4 = true,
+            externalBinaryPool = pool,
+        ).readXml(xml)
+
+        val attachment = result.rootGroup.entries.first().attachments.first()
+        assertEquals("document.pdf", attachment.name)
+        assertEquals(0, attachment.id)
+        assertTrue(binaryData.contentEquals(attachment.data))
+
+        // Pool should be the same one we provided
+        assertEquals(1, result.binaryPool.size)
+        assertTrue(binaryData.contentEquals(result.binaryPool[0]!!))
+    }
+
+    @Test
+    fun xmlReader_externalPoolIgnoresXmlBinaries() {
+        val externalData = "from inner header".encodeToByteArray()
+        val pool = KdbxBinaryPool()
+        pool.put(0, externalData)
+
+        // XML also has a Binaries section — but since external pool is provided,
+        // the XML binaries should be ADDED to the same pool
+        val xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <KeePassFile>
+                <Meta>
+                    <Binaries>
+                        <Binary ID="1">${kotlin.io.encoding.Base64.encode("from xml".encodeToByteArray())}</Binary>
+                    </Binaries>
+                </Meta>
+                <Root>
+                    <Group>
+                        <UUID>cm9vdA==</UUID>
+                        <Name>Root</Name>
+                        <Entry>
+                            <UUID>ZW50cnk=</UUID>
+                            <Binary>
+                                <Key>file.txt</Key>
+                                <Value Ref="0" />
+                            </Binary>
+                        </Entry>
+                    </Group>
+                </Root>
+            </KeePassFile>
+        """.trimIndent()
+
+        val result = KdbxXmlReader(
+            isV4 = true,
+            externalBinaryPool = pool,
+        ).readXml(xml)
+
+        // Entry references pool ID 0 which has the external data
+        val attachment = result.rootGroup.entries.first().attachments.first()
+        assertTrue(externalData.contentEquals(attachment.data))
+
+        // Pool should have both entries (external + XML)
+        assertEquals(2, result.binaryPool.size)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlReaderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlReaderTest.kt
@@ -431,8 +431,8 @@ class KdbxXmlReaderTest {
         val result = readerV3().readXml(xml)
 
         // Check binaries pool
-        assertEquals(1, result.binaries.size)
-        assertTrue(binaryData.contentEquals(result.binaries[0]!!))
+        assertEquals(1, result.binaryPool.size)
+        assertTrue(binaryData.contentEquals(result.binaryPool[0]!!))
 
         // Check entry attachment
         val attachment = result.rootGroup.entries.first().attachments.first()


### PR DESCRIPTION
## Summary
- Add `KdbxBinaryPool` for centralized binary attachment management with GZip compress/decompress, ID-based storage, and content-based deduplication
- Add `KdbxInnerHeaderReader`/`KdbxInnerHeaderWriter` for KDBX 4.x inner header parsing (binary attachments, inner stream cipher ID & key)
- Update `KdbxXmlReader` to accept an external `KdbxBinaryPool` so KDBX 4.x entry attachments resolve against inner header binaries instead of XML

## Test plan
- [x] `KdbxBinaryPoolTest`: add/get/remove, deduplication, GZip round-trip (text, empty, binary data), overwrite behavior
- [x] `KdbxInnerHeaderTest`: read/write stream ID & key, binary attachments with flags, unknown field skipping, round-trip preservation
- [x] `KdbxInnerHeaderTest`: XmlReader external pool integration, XML+external pool coexistence
- [x] Existing `KdbxXmlReaderTest` updated and passing (field rename `binaries` → `binaryPool`)
- [x] `./gradlew composeApp:jvmTest` passes

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)