### PR TITLE
[3.7] Implement SHA-256 and SHA-512 hashing

### DIFF
--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlWriterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlWriterTest.kt
@@ -406,8 +406,8 @@ class KdbxXmlWriterTest {
         val readResult = reader.readXml(writeResult.xml)
 
         // Check binaries pool round-trips
-        assertEquals(1, readResult.binaries.size)
-        assertTrue(binaryData.contentEquals(readResult.binaries[0]!!))
+        assertEquals(1, readResult.binaryPool.size)
+        assertTrue(binaryData.contentEquals(readResult.binaryPool[0]!!))
 
         // Check entry attachment
         val attachment = readResult.rootGroup.entries.first().attachments.first()
@@ -440,9 +440,9 @@ class KdbxXmlWriterTest {
         val reader = KdbxXmlReader(isV4 = false)
         val readResult = reader.readXml(writeResult.xml)
 
-        assertEquals(2, readResult.binaries.size)
-        assertTrue(data0.contentEquals(readResult.binaries[0]!!))
-        assertTrue(data1.contentEquals(readResult.binaries[1]!!))
+        assertEquals(2, readResult.binaryPool.size)
+        assertTrue(data0.contentEquals(readResult.binaryPool[0]!!))
+        assertTrue(data1.contentEquals(readResult.binaryPool[1]!!))
     }
 
     // -- DeletedObjects tests --

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProvider.ios.kt
@@ -1,19 +1,48 @@
 package org.github.keepasscompose.core.crypto
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.usePinned
 import org.github.keepasscompose.core.model.Argon2Variant
+import platform.CommonCrypto.CC_SHA256
+import platform.CommonCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.CommonCrypto.CC_SHA512
+import platform.CommonCrypto.CC_SHA512_DIGEST_LENGTH
 
 // iOS implementation will use a hybrid approach:
 // - Apple CommonCrypto (via CInterop) for AES-CBC, SHA-256/512, HMAC-SHA-256
 // - libsodium (via kotlin-libsodium or CInterop) for Argon2, ChaCha20, Salsa20
 // - Twofish requires a pure Kotlin or C library via CInterop
+@OptIn(ExperimentalForeignApi::class)
 actual class PlatformCryptoProvider actual constructor() : CryptoProvider {
 
     override fun sha256(data: ByteArray): ByteArray {
-        TODO("iOS: Implement via CommonCrypto CC_SHA256")
+        val digest = UByteArray(CC_SHA256_DIGEST_LENGTH)
+        digest.usePinned { digestPin ->
+            if (data.isEmpty()) {
+                CC_SHA256(null, 0u, digestPin.addressOf(0))
+            } else {
+                data.usePinned { dataPin ->
+                    CC_SHA256(dataPin.addressOf(0), data.size.convert(), digestPin.addressOf(0))
+                }
+            }
+        }
+        return digest.toByteArray()
     }
 
     override fun sha512(data: ByteArray): ByteArray {
-        TODO("iOS: Implement via CommonCrypto CC_SHA512")
+        val digest = UByteArray(CC_SHA512_DIGEST_LENGTH)
+        digest.usePinned { digestPin ->
+            if (data.isEmpty()) {
+                CC_SHA512(null, 0u, digestPin.addressOf(0))
+            } else {
+                data.usePinned { dataPin ->
+                    CC_SHA512(dataPin.addressOf(0), data.size.convert(), digestPin.addressOf(0))
+                }
+            }
+        }
+        return digest.toByteArray()
     }
 
     override fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProviderShaTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProviderShaTest.kt
@@ -1,0 +1,131 @@
+package org.github.keepasscompose.core.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for SHA-256 and SHA-512 implementations using known test vectors.
+ *
+ * Test vectors sourced from NIST FIPS 180-4 and RFC 6234.
+ */
+class PlatformCryptoProviderShaTest {
+
+    private val crypto = PlatformCryptoProvider()
+
+    // -- SHA-256 tests --
+
+    @Test
+    fun sha256_emptyInput() {
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        val expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        val result = crypto.sha256(ByteArray(0))
+        assertEquals(expected, result.toHex())
+    }
+
+    @Test
+    fun sha256_abc() {
+        // NIST FIPS 180-4 test vector: SHA-256("abc")
+        val expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        val result = crypto.sha256("abc".encodeToByteArray())
+        assertEquals(expected, result.toHex())
+    }
+
+    @Test
+    fun sha256_twoBlockMessage() {
+        // NIST test vector: SHA-256("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+        val input = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+        val expected = "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        val result = crypto.sha256(input.encodeToByteArray())
+        assertEquals(expected, result.toHex())
+    }
+
+    @Test
+    fun sha256_outputLength() {
+        val result = crypto.sha256("test".encodeToByteArray())
+        assertEquals(32, result.size)
+    }
+
+    @Test
+    fun sha256_deterministic() {
+        val data = "deterministic test".encodeToByteArray()
+        val result1 = crypto.sha256(data)
+        val result2 = crypto.sha256(data)
+        assertTrue(result1.contentEquals(result2))
+    }
+
+    @Test
+    fun sha256_differentInputsDifferentOutputs() {
+        val hash1 = crypto.sha256("input1".encodeToByteArray())
+        val hash2 = crypto.sha256("input2".encodeToByteArray())
+        assertFalse(hash1.contentEquals(hash2))
+    }
+
+    @Test
+    fun sha256_singleByte() {
+        // SHA-256 of single zero byte
+        val expected = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+        val result = crypto.sha256(byteArrayOf(0))
+        assertEquals(expected, result.toHex())
+    }
+
+    // -- SHA-512 tests --
+
+    @Test
+    fun sha512_emptyInput() {
+        // SHA-512("")
+        val expected = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce" +
+            "47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        val result = crypto.sha512(ByteArray(0))
+        assertEquals(expected, result.toHex())
+    }
+
+    @Test
+    fun sha512_abc() {
+        // NIST FIPS 180-4 test vector: SHA-512("abc")
+        val expected = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a" +
+            "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+        val result = crypto.sha512("abc".encodeToByteArray())
+        assertEquals(expected, result.toHex())
+    }
+
+    @Test
+    fun sha512_twoBlockMessage() {
+        // NIST test vector: SHA-512("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")
+        val input = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+        val expected = "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018" +
+            "501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909"
+        val result = crypto.sha512(input.encodeToByteArray())
+        assertEquals(expected, result.toHex())
+    }
+
+    @Test
+    fun sha512_outputLength() {
+        val result = crypto.sha512("test".encodeToByteArray())
+        assertEquals(64, result.size)
+    }
+
+    @Test
+    fun sha512_deterministic() {
+        val data = "deterministic test".encodeToByteArray()
+        val result1 = crypto.sha512(data)
+        val result2 = crypto.sha512(data)
+        assertTrue(result1.contentEquals(result2))
+    }
+
+    @Test
+    fun sha512_differentInputsDifferentOutputs() {
+        val hash1 = crypto.sha512("input1".encodeToByteArray())
+        val hash2 = crypto.sha512("input2".encodeToByteArray())
+        assertFalse(hash1.contentEquals(hash2))
+    }
+
+    // -- Helpers --
+
+    private fun ByteArray.toHex(): String =
+        joinToString("") { "%02x".format(it) }
+
+    private fun assertFalse(condition: Boolean) {
+        kotlin.test.assertFalse(condition)
+    }
+}


### PR DESCRIPTION
## Summary
- Implement iOS SHA-256/SHA-512 via Apple CommonCrypto (`CC_SHA256`, `CC_SHA512`) — completes platform coverage (JVM/Android already used BouncyCastle)
- Add JVM tests with NIST FIPS 180-4 test vectors for both algorithms (empty input, single-block, two-block messages, determinism, output length)
- Fix `KdbxXmlWriterTest` references to renamed `binaryPool` field (merge artifact from #162)

## Test plan
- [x] SHA-256: empty, "abc", two-block NIST vector, output length, determinism, collision resistance
- [x] SHA-512: empty, "abc", two-block NIST vector, output length, determinism, collision resistance
- [x] `./gradlew composeApp:jvmTest` passes

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)