### PR TITLE
[3.3] Implement ChaCha20 encryption/decryption

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/ChaCha20.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/ChaCha20.kt
@@ -1,0 +1,111 @@
+package org.github.keepasscompose.core.crypto
+
+/**
+ * Pure Kotlin implementation of ChaCha20 (IETF variant, RFC 8439).
+ * 256-bit key, 96-bit (12-byte) nonce, 32-bit block counter.
+ *
+ * Used on iOS where BouncyCastle is not available.
+ * JVM/Android use BouncyCastle's ChaCha7539Engine instead.
+ */
+@OptIn(ExperimentalUnsignedTypes::class)
+internal object ChaCha20 {
+
+    private const val STATE_SIZE = 16 // 16 x 32-bit words
+    private const val BLOCK_SIZE = 64 // 64 bytes per block
+
+    // "expand 32-byte k" as little-endian 32-bit words
+    private const val SIGMA0 = 0x61707865u
+    private const val SIGMA1 = 0x3320646eu
+    private const val SIGMA2 = 0x79622d32u
+    private const val SIGMA3 = 0x6b206574u
+
+    fun encrypt(data: ByteArray, key: ByteArray, nonce: ByteArray): ByteArray {
+        require(key.size == 32) { "ChaCha20 key must be 32 bytes, got ${key.size}" }
+        require(nonce.size == 12) { "ChaCha20 nonce must be 12 bytes, got ${nonce.size}" }
+
+        if (data.isEmpty()) return ByteArray(0)
+
+        val output = ByteArray(data.size)
+        val state = UIntArray(STATE_SIZE)
+        val workingState = UIntArray(STATE_SIZE)
+        val keyStream = ByteArray(BLOCK_SIZE)
+
+        // Initialize state
+        state[0] = SIGMA0
+        state[1] = SIGMA1
+        state[2] = SIGMA2
+        state[3] = SIGMA3
+        // Key words (little-endian)
+        for (i in 0 until 8) {
+            state[4 + i] = littleEndianToUInt(key, i * 4)
+        }
+        // Counter starts at 0 for IETF variant used by KeePass
+        state[12] = 0u
+        // Nonce words (little-endian)
+        for (i in 0 until 3) {
+            state[13 + i] = littleEndianToUInt(nonce, i * 4)
+        }
+
+        var offset = 0
+        while (offset < data.size) {
+            // Copy state to working state
+            state.copyInto(workingState)
+
+            // 20 rounds (10 double-rounds)
+            for (i in 0 until 10) {
+                // Column rounds
+                quarterRound(workingState, 0, 4, 8, 12)
+                quarterRound(workingState, 1, 5, 9, 13)
+                quarterRound(workingState, 2, 6, 10, 14)
+                quarterRound(workingState, 3, 7, 11, 15)
+                // Diagonal rounds
+                quarterRound(workingState, 0, 5, 10, 15)
+                quarterRound(workingState, 1, 6, 11, 12)
+                quarterRound(workingState, 2, 7, 8, 13)
+                quarterRound(workingState, 3, 4, 9, 14)
+            }
+
+            // Add original state
+            for (i in 0 until STATE_SIZE) {
+                workingState[i] += state[i]
+            }
+
+            // Serialize to key stream bytes (little-endian)
+            for (i in 0 until STATE_SIZE) {
+                uintToLittleEndian(workingState[i], keyStream, i * 4)
+            }
+
+            // XOR with data
+            val bytesToProcess = minOf(BLOCK_SIZE, data.size - offset)
+            for (i in 0 until bytesToProcess) {
+                output[offset + i] = (data[offset + i].toInt() xor keyStream[i].toInt()).toByte()
+            }
+
+            offset += BLOCK_SIZE
+            // Increment counter
+            state[12]++
+        }
+
+        return output
+    }
+
+    private fun quarterRound(state: UIntArray, a: Int, b: Int, c: Int, d: Int) {
+        state[a] += state[b]; state[d] = (state[d] xor state[a]).rotateLeft(16)
+        state[c] += state[d]; state[b] = (state[b] xor state[c]).rotateLeft(12)
+        state[a] += state[b]; state[d] = (state[d] xor state[a]).rotateLeft(8)
+        state[c] += state[d]; state[b] = (state[b] xor state[c]).rotateLeft(7)
+    }
+
+    private fun littleEndianToUInt(bytes: ByteArray, offset: Int): UInt =
+        (bytes[offset].toUByte().toUInt()) or
+            (bytes[offset + 1].toUByte().toUInt() shl 8) or
+            (bytes[offset + 2].toUByte().toUInt() shl 16) or
+            (bytes[offset + 3].toUByte().toUInt() shl 24)
+
+    private fun uintToLittleEndian(value: UInt, bytes: ByteArray, offset: Int) {
+        bytes[offset] = value.toByte()
+        bytes[offset + 1] = (value shr 8).toByte()
+        bytes[offset + 2] = (value shr 16).toByte()
+        bytes[offset + 3] = (value shr 24).toByte()
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProvider.ios.kt
@@ -135,7 +135,7 @@ actual class PlatformCryptoProvider actual constructor() : CryptoProvider {
     }
 
     override fun chaCha20(data: ByteArray, key: ByteArray, nonce: ByteArray): ByteArray {
-        TODO("iOS: Implement via libsodium crypto_stream_chacha20_ietf_xor")
+        return ChaCha20.encrypt(data, key, nonce)
     }
 
     override fun salsa20(data: ByteArray, key: ByteArray, nonce: ByteArray): ByteArray {

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProviderChaCha20Test.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProviderChaCha20Test.kt
@@ -1,0 +1,197 @@
+package org.github.keepasscompose.core.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+/**
+ * Tests for ChaCha20 (IETF variant, RFC 8439).
+ *
+ * Uses RFC 8439 Section 2.4.2 test vector plus round-trip and edge-case tests.
+ * Tests run on JVM (BouncyCastle) and validate the pure Kotlin implementation
+ * produces identical output.
+ */
+class PlatformCryptoProviderChaCha20Test {
+
+    private val crypto = PlatformCryptoProvider()
+
+    // RFC 8439 Section 2.4.2 test vector
+    private val rfc8439Key = byteArrayOf(
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    )
+    private val rfc8439Nonce = byteArrayOf(
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09.toByte(),
+        0x00, 0x00, 0x00, 0x4a, // 12-byte nonce
+    )
+    // "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."
+    private val rfc8439Plaintext =
+        "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."
+            .encodeToByteArray()
+
+    // Expected ciphertext from RFC 8439 Section 2.4.2
+    // Note: RFC 8439 uses initial counter = 1 for this test vector.
+    // KeePass uses initial counter = 0, so we test round-trip behavior
+    // and cross-validate the pure Kotlin impl against BouncyCastle.
+
+    @Test
+    fun chaCha20_outputLength_matchesInput() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+
+        for (len in listOf(0, 1, 15, 16, 63, 64, 65, 128, 256, 1000)) {
+            val data = ByteArray(len) { (it % 251).toByte() }
+            val result = crypto.chaCha20(data, key, nonce)
+            assertEquals(len, result.size, "Output length mismatch for input length $len")
+        }
+    }
+
+    @Test
+    fun chaCha20_emptyInput_returnsEmpty() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+        val result = crypto.chaCha20(ByteArray(0), key, nonce)
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun chaCha20_roundTrip_shortMessage() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+        val plaintext = "Hello, ChaCha20!".encodeToByteArray()
+
+        val encrypted = crypto.chaCha20(plaintext, key, nonce)
+        assertFalse(encrypted.contentEquals(plaintext), "Encrypted should differ from plaintext")
+
+        val decrypted = crypto.chaCha20(encrypted, key, nonce)
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun chaCha20_roundTrip_exactlyOneBlock() {
+        // 64 bytes = exactly one ChaCha20 block
+        val key = ByteArray(32) { (it * 3).toByte() }
+        val nonce = ByteArray(12) { (it * 7).toByte() }
+        val plaintext = ByteArray(64) { (it * 11).toByte() }
+
+        val encrypted = crypto.chaCha20(plaintext, key, nonce)
+        val decrypted = crypto.chaCha20(encrypted, key, nonce)
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun chaCha20_roundTrip_multiBlock() {
+        // 200 bytes spans multiple blocks
+        val key = ByteArray(32) { (it xor 0xAA).toByte() }
+        val nonce = ByteArray(12) { (it xor 0x55).toByte() }
+        val plaintext = ByteArray(200) { (it * 17 + 3).toByte() }
+
+        val encrypted = crypto.chaCha20(plaintext, key, nonce)
+        val decrypted = crypto.chaCha20(encrypted, key, nonce)
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun chaCha20_roundTrip_largeData() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+        val plaintext = ByteArray(10_000) { (it % 256).toByte() }
+
+        val encrypted = crypto.chaCha20(plaintext, key, nonce)
+        val decrypted = crypto.chaCha20(encrypted, key, nonce)
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun chaCha20_keySensitivity() {
+        val nonce = ByteArray(12) { it.toByte() }
+        val plaintext = ByteArray(64) { 0x42 }
+
+        val key1 = ByteArray(32) { it.toByte() }
+        val key2 = ByteArray(32) { it.toByte() }.also { it[0] = (it[0].toInt() xor 1).toByte() }
+
+        val enc1 = crypto.chaCha20(plaintext, key1, nonce)
+        val enc2 = crypto.chaCha20(plaintext, key2, nonce)
+        assertFalse(enc1.contentEquals(enc2), "Different keys must produce different ciphertext")
+    }
+
+    @Test
+    fun chaCha20_nonceSensitivity() {
+        val key = ByteArray(32) { it.toByte() }
+        val plaintext = ByteArray(64) { 0x42 }
+
+        val nonce1 = ByteArray(12) { it.toByte() }
+        val nonce2 = ByteArray(12) { it.toByte() }.also { it[0] = (it[0].toInt() xor 1).toByte() }
+
+        val enc1 = crypto.chaCha20(plaintext, key, nonce1)
+        val enc2 = crypto.chaCha20(plaintext, key, nonce2)
+        assertFalse(enc1.contentEquals(enc2), "Different nonces must produce different ciphertext")
+    }
+
+    @Test
+    fun chaCha20_deterministic() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+        val plaintext = "determinism test".encodeToByteArray()
+
+        val enc1 = crypto.chaCha20(plaintext, key, nonce)
+        val enc2 = crypto.chaCha20(plaintext, key, nonce)
+        assertContentEquals(enc1, enc2)
+    }
+
+    @Test
+    fun chaCha20_singleByte() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+        val plaintext = byteArrayOf(0x42)
+
+        val encrypted = crypto.chaCha20(plaintext, key, nonce)
+        assertEquals(1, encrypted.size)
+        val decrypted = crypto.chaCha20(encrypted, key, nonce)
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun chaCha20_pureKotlin_matchesBouncyCastle() {
+        // Cross-validate: pure Kotlin ChaCha20 must produce the same output as BouncyCastle
+        val key = rfc8439Key
+        val nonce = rfc8439Nonce
+        val plaintext = rfc8439Plaintext
+
+        val bouncyCastleResult = crypto.chaCha20(plaintext, key, nonce)
+        val pureKotlinResult = ChaCha20.encrypt(plaintext, key, nonce)
+
+        assertContentEquals(
+            bouncyCastleResult,
+            pureKotlinResult,
+            "Pure Kotlin ChaCha20 must match BouncyCastle output",
+        )
+    }
+
+    @Test
+    fun chaCha20_pureKotlin_matchesBouncyCastle_multiBlock() {
+        val key = ByteArray(32) { (it * 5 + 7).toByte() }
+        val nonce = ByteArray(12) { (it * 3 + 1).toByte() }
+        val plaintext = ByteArray(300) { (it * 13).toByte() }
+
+        val bouncyCastleResult = crypto.chaCha20(plaintext, key, nonce)
+        val pureKotlinResult = ChaCha20.encrypt(plaintext, key, nonce)
+
+        assertContentEquals(bouncyCastleResult, pureKotlinResult)
+    }
+
+    @Test
+    fun chaCha20_pureKotlin_roundTrip() {
+        val key = ByteArray(32) { it.toByte() }
+        val nonce = ByteArray(12) { it.toByte() }
+        val plaintext = "Pure Kotlin round-trip test".encodeToByteArray()
+
+        val encrypted = ChaCha20.encrypt(plaintext, key, nonce)
+        val decrypted = ChaCha20.encrypt(encrypted, key, nonce)
+        assertContentEquals(plaintext, decrypted)
+    }
+}


### PR DESCRIPTION
## Summary
- Pure Kotlin ChaCha20 (IETF variant, RFC 8439) implementation in commonMain for iOS platform
- iOS `PlatformCryptoProvider.chaCha20()` delegates to the pure Kotlin `ChaCha20` object
- 13 JVM tests: round-trips, key/nonce sensitivity, determinism, cross-validation against BouncyCastle

## Test plan
- [x] `./gradlew composeApp:jvmTest --tests PlatformCryptoProviderChaCha20Test` — all 13 tests pass
- [x] Pure Kotlin output matches BouncyCastle `ChaCha7539Engine` for identical inputs

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)