### PR TITLE
[2.9] Implement entry history management

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/EntryHistoryManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/EntryHistoryManager.kt
@@ -1,0 +1,114 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.time.Instant
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.KdbxMeta
+
+/**
+ * Manages entry history: capturing previous versions on modification and
+ * pruning history to stay within configured limits.
+ *
+ * KeePass stores previous versions of an entry inside the entry itself as
+ * a `history` list. Each history entry is a full snapshot (without its own
+ * nested history) taken at the moment before modification.
+ */
+class EntryHistoryManager(
+    private val historyMaxItems: Int = KdbxMeta.DEFAULT_HISTORY_MAX_ITEMS,
+    private val historyMaxSize: Long = KdbxMeta.DEFAULT_HISTORY_MAX_SIZE,
+) {
+    constructor(meta: KdbxMeta) : this(meta.historyMaxItems, meta.historyMaxSize)
+
+    /**
+     * Records the previous version of an entry into its history and returns
+     * the updated entry with the new history list (already pruned).
+     *
+     * The [previousVersion] is stored without its own history to avoid
+     * recursive nesting. The returned entry contains the merged and pruned
+     * history list.
+     *
+     * @param currentEntry The updated entry (after modification) whose history list will be extended.
+     * @param previousVersion The entry state before the modification.
+     * @return A copy of [currentEntry] with the previous version appended to history and pruned.
+     */
+    fun recordModification(currentEntry: KdbxEntry, previousVersion: KdbxEntry): KdbxEntry {
+        val snapshot = previousVersion.copy(history = emptyList())
+        val updatedHistory = currentEntry.history + snapshot
+        return currentEntry.copy(history = pruneHistory(updatedHistory))
+    }
+
+    /**
+     * Prunes a history list to respect both [historyMaxItems] and [historyMaxSize] limits.
+     *
+     * Entries are sorted by [KdbxEntry.lastModificationTime] (oldest first) and the oldest
+     * entries are removed until both limits are satisfied.
+     *
+     * A negative limit value means unlimited (no pruning for that dimension).
+     */
+    fun pruneHistory(history: List<KdbxEntry>): List<KdbxEntry> {
+        if (history.isEmpty()) return history
+
+        val sorted = history.sortedBy { it.lastModificationTime ?: Instant.DISTANT_PAST }
+
+        var result = sorted
+
+        // Prune by item count
+        if (historyMaxItems >= 0 && result.size > historyMaxItems) {
+            result = result.takeLast(historyMaxItems)
+        }
+
+        // Prune by total size
+        if (historyMaxSize >= 0) {
+            while (result.size > 0 && totalSize(result) > historyMaxSize) {
+                result = result.drop(1) // drop oldest
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Prunes history for all entries in a group tree. Used during save to enforce limits.
+     */
+    fun pruneGroupHistory(group: KdbxGroup): KdbxGroup {
+        return group.copy(
+            entries = group.entries.map { entry ->
+                if (entry.history.isEmpty()) entry
+                else entry.copy(history = pruneHistory(entry.history))
+            },
+            groups = group.groups.map { pruneGroupHistory(it) },
+        )
+    }
+
+    companion object {
+        /**
+         * Estimates the in-memory size of a single entry (excluding its history).
+         * This mirrors KeePass's approach of summing string and binary sizes.
+         */
+        fun estimateEntrySize(entry: KdbxEntry): Long {
+            var size = 128L // base overhead: UUID, icon, timestamps, booleans
+
+            for (field in entry.fields) {
+                size += field.key.length.toLong() * 2 // UTF-16 estimate
+                size += field.value.length.toLong() * 2
+            }
+
+            for (attachment in entry.attachments) {
+                size += attachment.name.length.toLong() * 2
+                size += attachment.data.size.toLong()
+            }
+
+            for (tag in entry.tags) {
+                size += tag.length.toLong() * 2
+            }
+
+            return size
+        }
+
+        /**
+         * Computes the total estimated size of all entries in a history list.
+         */
+        fun totalSize(history: List<KdbxEntry>): Long =
+            history.sumOf { estimateEntrySize(it) }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlReader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlReader.kt
@@ -94,6 +94,8 @@ class KdbxXmlReader(
         var databaseName = ""
         var description = ""
         var defaultUserName = ""
+        var historyMaxItems = KdbxMeta.DEFAULT_HISTORY_MAX_ITEMS
+        var historyMaxSize = KdbxMeta.DEFAULT_HISTORY_MAX_SIZE
         var recycleBinEnabled = true
         var recycleBinUuid: String? = null
         var protectTitle = false
@@ -107,6 +109,10 @@ class KdbxXmlReader(
                 "DatabaseName" -> databaseName = reader.readElementText()
                 "DatabaseDescription" -> description = reader.readElementText()
                 "DefaultUserName" -> defaultUserName = reader.readElementText()
+                "HistoryMaxItems" -> historyMaxItems = reader.readElementText().toIntOrNull()
+                    ?: KdbxMeta.DEFAULT_HISTORY_MAX_ITEMS
+                "HistoryMaxSize" -> historyMaxSize = reader.readElementText().toLongOrNull()
+                    ?: KdbxMeta.DEFAULT_HISTORY_MAX_SIZE
                 "RecycleBinEnabled" -> recycleBinEnabled = reader.readElementText().toBooleanKdbx()
                 "RecycleBinUUID" -> recycleBinUuid = reader.readElementText().ifBlank { null }
                 "MemoryProtection" -> {
@@ -126,6 +132,8 @@ class KdbxXmlReader(
             databaseName = databaseName,
             description = description,
             defaultUserName = defaultUserName,
+            historyMaxItems = historyMaxItems,
+            historyMaxSize = historyMaxSize,
             recycleBinEnabled = recycleBinEnabled,
             recycleBinUuid = recycleBinUuid,
             protectTitle = protectTitle,

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlWriter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxXmlWriter.kt
@@ -73,6 +73,8 @@ class KdbxXmlWriter(
         writer.writeElement("DatabaseName", meta.databaseName)
         writer.writeElement("DatabaseDescription", meta.description)
         writer.writeElement("DefaultUserName", meta.defaultUserName)
+        writer.writeElement("HistoryMaxItems", meta.historyMaxItems.toString())
+        writer.writeElement("HistoryMaxSize", meta.historyMaxSize.toString())
         writer.writeElement("RecycleBinEnabled", meta.recycleBinEnabled.toKdbxString())
         if (meta.recycleBinUuid != null) {
             writer.writeElement("RecycleBinUUID", meta.recycleBinUuid)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxMeta.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxMeta.kt
@@ -4,6 +4,8 @@ data class KdbxMeta(
     val databaseName: String = "",
     val description: String = "",
     val defaultUserName: String = "",
+    val historyMaxItems: Int = DEFAULT_HISTORY_MAX_ITEMS,
+    val historyMaxSize: Long = DEFAULT_HISTORY_MAX_SIZE,
     val recycleBinEnabled: Boolean = true,
     val recycleBinUuid: String? = null,
     val protectTitle: Boolean = false,
@@ -11,4 +13,9 @@ data class KdbxMeta(
     val protectPassword: Boolean = true,
     val protectUrl: Boolean = false,
     val protectNotes: Boolean = false,
-)
+) {
+    companion object {
+        const val DEFAULT_HISTORY_MAX_ITEMS = 12
+        const val DEFAULT_HISTORY_MAX_SIZE = 6_291_456L // 6 MB
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/EntryHistoryManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/EntryHistoryManagerTest.kt
@@ -1,0 +1,372 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import org.github.keepasscompose.core.model.KdbxAttachment
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.KdbxMeta
+
+class EntryHistoryManagerTest {
+
+    // -- recordModification --
+
+    @Test
+    fun recordModification_addsPreviousVersionToHistory() {
+        val manager = EntryHistoryManager(historyMaxItems = 10, historyMaxSize = -1)
+
+        val previous = entry("e1", "Old Title", modTime = time("2024-01-01T00:00:00Z"))
+        val current = entry("e1", "New Title", modTime = time("2024-02-01T00:00:00Z"))
+
+        val result = manager.recordModification(current, previous)
+
+        assertEquals(1, result.history.size)
+        assertEquals("Old Title", result.history[0].title)
+        assertEquals("New Title", result.title)
+    }
+
+    @Test
+    fun recordModification_appendsToExistingHistory() {
+        val manager = EntryHistoryManager(historyMaxItems = 10, historyMaxSize = -1)
+
+        val v1 = entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z"))
+        val v2 = entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z"), history = listOf(v1))
+        val v3 = entry("e1", "V3", modTime = time("2024-03-01T00:00:00Z"), history = v2.history)
+
+        val result = manager.recordModification(v3, v2)
+
+        assertEquals(2, result.history.size)
+        assertEquals("V1", result.history[0].title)
+        assertEquals("V2", result.history[1].title)
+    }
+
+    @Test
+    fun recordModification_previousVersionHistoryIsStripped() {
+        val manager = EntryHistoryManager(historyMaxItems = 10, historyMaxSize = -1)
+
+        val v1 = entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z"))
+        val previousWithHistory = entry(
+            "e1", "V2",
+            modTime = time("2024-02-01T00:00:00Z"),
+            history = listOf(v1),
+        )
+        val current = entry("e1", "V3", modTime = time("2024-03-01T00:00:00Z"))
+
+        val result = manager.recordModification(current, previousWithHistory)
+
+        // The snapshot of previousWithHistory in history should have empty history
+        assertEquals(1, result.history.size)
+        assertTrue(result.history[0].history.isEmpty())
+    }
+
+    // -- pruneHistory: by item count --
+
+    @Test
+    fun pruneHistory_withinLimits_unchanged() {
+        val manager = EntryHistoryManager(historyMaxItems = 5, historyMaxSize = -1)
+
+        val history = listOf(
+            entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z")),
+            entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z")),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun pruneHistory_exceedsMaxItems_removesOldest() {
+        val manager = EntryHistoryManager(historyMaxItems = 2, historyMaxSize = -1)
+
+        val history = listOf(
+            entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z")),
+            entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z")),
+            entry("e1", "V3", modTime = time("2024-03-01T00:00:00Z")),
+            entry("e1", "V4", modTime = time("2024-04-01T00:00:00Z")),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals(2, result.size)
+        assertEquals("V3", result[0].title)
+        assertEquals("V4", result[1].title)
+    }
+
+    @Test
+    fun pruneHistory_maxItemsZero_removesAll() {
+        val manager = EntryHistoryManager(historyMaxItems = 0, historyMaxSize = -1)
+
+        val history = listOf(
+            entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z")),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun pruneHistory_maxItemsNegative_unlimited() {
+        val manager = EntryHistoryManager(historyMaxItems = -1, historyMaxSize = -1)
+
+        val history = (1..50).map {
+            entry("e1", "V$it", modTime = Instant.fromEpochSeconds(1704067200L + it * 86400L))
+        }
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals(50, result.size)
+    }
+
+    // -- pruneHistory: by size --
+
+    @Test
+    fun pruneHistory_exceedsMaxSize_removesOldest() {
+        // Each entry with a large attachment will be sizable
+        val largeData = ByteArray(1000)
+        val manager = EntryHistoryManager(historyMaxItems = -1, historyMaxSize = 1500)
+
+        val history = listOf(
+            entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z"),
+                attachments = listOf(KdbxAttachment(0, "file.bin", largeData))),
+            entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z"),
+                attachments = listOf(KdbxAttachment(1, "file.bin", largeData))),
+            entry("e1", "V3", modTime = time("2024-03-01T00:00:00Z"),
+                attachments = listOf(KdbxAttachment(2, "file.bin", largeData))),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        // Each entry is ~1000+ bytes, so only 1 should fit within 1500 limit
+        assertEquals(1, result.size)
+        assertEquals("V3", result[0].title)
+    }
+
+    @Test
+    fun pruneHistory_maxSizeNegative_unlimited() {
+        val largeData = ByteArray(10_000)
+        val manager = EntryHistoryManager(historyMaxItems = -1, historyMaxSize = -1)
+
+        val history = listOf(
+            entry("e1", "V1", attachments = listOf(KdbxAttachment(0, "f", largeData))),
+            entry("e1", "V2", attachments = listOf(KdbxAttachment(1, "f", largeData))),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals(2, result.size)
+    }
+
+    // -- pruneHistory: combined limits --
+
+    @Test
+    fun pruneHistory_bothLimits_mostRestrictiveWins() {
+        val largeData = ByteArray(2000)
+        // Max 5 items, but max size only fits ~2 entries
+        val manager = EntryHistoryManager(historyMaxItems = 5, historyMaxSize = 5000)
+
+        val history = (1..5).map {
+            entry("e1", "V$it",
+                modTime = time("2024-0${it}-01T00:00:00Z"),
+                attachments = listOf(KdbxAttachment(it, "file.bin", largeData)))
+        }
+
+        val result = manager.pruneHistory(history)
+
+        // Size limit should be more restrictive than item count
+        assertTrue(result.size < 5)
+        // Newest entries should be kept
+        assertEquals("V5", result.last().title)
+    }
+
+    // -- pruneHistory: sorting --
+
+    @Test
+    fun pruneHistory_unsortedInput_sortedByModificationTime() {
+        val manager = EntryHistoryManager(historyMaxItems = -1, historyMaxSize = -1)
+
+        val history = listOf(
+            entry("e1", "V3", modTime = time("2024-03-01T00:00:00Z")),
+            entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z")),
+            entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z")),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals("V1", result[0].title)
+        assertEquals("V2", result[1].title)
+        assertEquals("V3", result[2].title)
+    }
+
+    @Test
+    fun pruneHistory_nullModificationTime_treatedAsOldest() {
+        val manager = EntryHistoryManager(historyMaxItems = 2, historyMaxSize = -1)
+
+        val history = listOf(
+            entry("e1", "V1", modTime = null),
+            entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z")),
+            entry("e1", "V3", modTime = time("2024-03-01T00:00:00Z")),
+        )
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals(2, result.size)
+        assertEquals("V2", result[0].title)
+        assertEquals("V3", result[1].title)
+    }
+
+    @Test
+    fun pruneHistory_emptyList_returnsEmpty() {
+        val manager = EntryHistoryManager(historyMaxItems = 5, historyMaxSize = -1)
+
+        val result = manager.pruneHistory(emptyList())
+
+        assertTrue(result.isEmpty())
+    }
+
+    // -- pruneGroupHistory --
+
+    @Test
+    fun pruneGroupHistory_prunesAllEntriesInTree() {
+        val manager = EntryHistoryManager(historyMaxItems = 1, historyMaxSize = -1)
+
+        val entryWithHistory = entry("e1", "Current",
+            modTime = time("2024-03-01T00:00:00Z"),
+            history = listOf(
+                entry("e1", "V1", modTime = time("2024-01-01T00:00:00Z")),
+                entry("e1", "V2", modTime = time("2024-02-01T00:00:00Z")),
+            ))
+
+        val nestedEntryWithHistory = entry("e2", "Nested",
+            modTime = time("2024-03-01T00:00:00Z"),
+            history = listOf(
+                entry("e2", "N1", modTime = time("2024-01-01T00:00:00Z")),
+                entry("e2", "N2", modTime = time("2024-02-01T00:00:00Z")),
+                entry("e2", "N3", modTime = time("2024-02-15T00:00:00Z")),
+            ))
+
+        val group = KdbxGroup(
+            uuid = "root",
+            name = "Root",
+            entries = listOf(entryWithHistory),
+            groups = listOf(
+                KdbxGroup(
+                    uuid = "sub",
+                    name = "Sub",
+                    entries = listOf(nestedEntryWithHistory),
+                )
+            ),
+        )
+
+        val result = manager.pruneGroupHistory(group)
+
+        assertEquals(1, result.entries[0].history.size)
+        assertEquals("V2", result.entries[0].history[0].title)
+
+        assertEquals(1, result.groups[0].entries[0].history.size)
+        assertEquals("N3", result.groups[0].entries[0].history[0].title)
+    }
+
+    @Test
+    fun pruneGroupHistory_entriesWithoutHistory_unchanged() {
+        val manager = EntryHistoryManager(historyMaxItems = 1, historyMaxSize = -1)
+
+        val entryNoHistory = entry("e1", "No History")
+        val group = KdbxGroup(uuid = "root", name = "Root", entries = listOf(entryNoHistory))
+
+        val result = manager.pruneGroupHistory(group)
+
+        assertTrue(result.entries[0].history.isEmpty())
+    }
+
+    // -- estimateEntrySize --
+
+    @Test
+    fun estimateEntrySize_emptyEntry() {
+        val e = KdbxEntry(uuid = "test")
+        val size = EntryHistoryManager.estimateEntrySize(e)
+
+        // Should be base overhead only
+        assertEquals(128L, size)
+    }
+
+    @Test
+    fun estimateEntrySize_withFields() {
+        val e = KdbxEntry(
+            uuid = "test",
+            fields = listOf(
+                KdbxEntryField("Title", "My Entry"),
+                KdbxEntryField("Password", "secret123", isProtected = true),
+            ),
+        )
+        val size = EntryHistoryManager.estimateEntrySize(e)
+
+        // Base + field strings (key + value) * 2 for UTF-16
+        val expectedFieldSize = ("Title".length + "My Entry".length +
+            "Password".length + "secret123".length) * 2L
+        assertEquals(128L + expectedFieldSize, size)
+    }
+
+    @Test
+    fun estimateEntrySize_withAttachments() {
+        val data = ByteArray(5000)
+        val e = KdbxEntry(
+            uuid = "test",
+            attachments = listOf(KdbxAttachment(0, "photo.jpg", data)),
+        )
+        val size = EntryHistoryManager.estimateEntrySize(e)
+
+        val expectedAttachmentSize = "photo.jpg".length * 2L + 5000L
+        assertEquals(128L + expectedAttachmentSize, size)
+    }
+
+    @Test
+    fun estimateEntrySize_withTags() {
+        val e = KdbxEntry(
+            uuid = "test",
+            tags = listOf("work", "important"),
+        )
+        val size = EntryHistoryManager.estimateEntrySize(e)
+
+        val expectedTagSize = ("work".length + "important".length) * 2L
+        assertEquals(128L + expectedTagSize, size)
+    }
+
+    // -- Constructor from KdbxMeta --
+
+    @Test
+    fun constructorFromMeta_usesMetaValues() {
+        val meta = KdbxMeta(historyMaxItems = 5, historyMaxSize = 1024)
+        val manager = EntryHistoryManager(meta)
+
+        val history = (1..10).map {
+            entry("e1", "V$it", modTime = time("2024-01-${it.toString().padStart(2, '0')}T00:00:00Z"))
+        }
+
+        val result = manager.pruneHistory(history)
+
+        assertEquals(5, result.size)
+    }
+
+    // -- Helpers --
+
+    private fun entry(
+        uuid: String,
+        title: String,
+        modTime: Instant? = null,
+        history: List<KdbxEntry> = emptyList(),
+        attachments: List<KdbxAttachment> = emptyList(),
+    ) = KdbxEntry(
+        uuid = uuid,
+        fields = listOf(KdbxEntryField(KdbxEntry.FIELD_TITLE, title)),
+        lastModificationTime = modTime,
+        history = history,
+        attachments = attachments,
+    )
+
+    private fun time(iso: String): Instant = Instant.parse(iso)
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlReaderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlReaderTest.kt
@@ -81,6 +81,43 @@ class KdbxXmlReaderTest {
         assertFalse(result.meta.protectNotes)
     }
 
+    @Test
+    fun parseMeta_historyMaxItems() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <HistoryMaxItems>20</HistoryMaxItems>
+                <HistoryMaxSize>10485760</HistoryMaxSize>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals(20, result.meta.historyMaxItems)
+        assertEquals(10485760L, result.meta.historyMaxSize)
+    }
+
+    @Test
+    fun parseMeta_historyMaxItems_defaults() {
+        val xml = wrapKeePassFile(meta = "")
+        val result = readerV3().readXml(xml)
+
+        assertEquals(12, result.meta.historyMaxItems)
+        assertEquals(6291456L, result.meta.historyMaxSize)
+    }
+
+    @Test
+    fun parseMeta_historyMaxItems_negativeUnlimited() {
+        val xml = wrapKeePassFile(
+            meta = """
+                <HistoryMaxItems>-1</HistoryMaxItems>
+                <HistoryMaxSize>-1</HistoryMaxSize>
+            """,
+        )
+        val result = readerV3().readXml(xml)
+
+        assertEquals(-1, result.meta.historyMaxItems)
+        assertEquals(-1L, result.meta.historyMaxSize)
+    }
+
     // -- Group parsing tests --
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlWriterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/KdbxXmlWriterTest.kt
@@ -74,6 +74,33 @@ class KdbxXmlWriterTest {
     }
 
     @Test
+    fun writeMeta_historyMaxItems() {
+        val meta = KdbxMeta(historyMaxItems = 25, historyMaxSize = 10485760)
+        val result = writeAndReadBack(meta = meta)
+
+        assertEquals(25, result.meta.historyMaxItems)
+        assertEquals(10485760L, result.meta.historyMaxSize)
+    }
+
+    @Test
+    fun writeMeta_historyMaxItems_defaults() {
+        val meta = KdbxMeta()
+        val result = writeAndReadBack(meta = meta)
+
+        assertEquals(12, result.meta.historyMaxItems)
+        assertEquals(6291456L, result.meta.historyMaxSize)
+    }
+
+    @Test
+    fun writeMeta_historyMaxItems_negativeUnlimited() {
+        val meta = KdbxMeta(historyMaxItems = -1, historyMaxSize = -1)
+        val result = writeAndReadBack(meta = meta)
+
+        assertEquals(-1, result.meta.historyMaxItems)
+        assertEquals(-1L, result.meta.historyMaxSize)
+    }
+
+    @Test
     fun writeMeta_memoryProtection_allFalse() {
         val meta = KdbxMeta(
             protectTitle = false,


### PR DESCRIPTION
## Summary
- Add `historyMaxItems` and `historyMaxSize` fields to `KdbxMeta` with KeePass defaults (12 items, 6 MB)
- Parse and write `HistoryMaxItems`/`HistoryMaxSize` in XML reader/writer
- Create `EntryHistoryManager` with support for recording modifications, pruning by item count and total size, and recursive group-tree pruning on save

## Test plan
- [x] EntryHistoryManager: record modification appends previous version to history
- [x] EntryHistoryManager: previous version's own history is stripped (no recursive nesting)
- [x] EntryHistoryManager: prune by max items removes oldest entries
- [x] EntryHistoryManager: prune by max size removes oldest entries
- [x] EntryHistoryManager: combined limits (most restrictive wins)
- [x] EntryHistoryManager: negative limits mean unlimited
- [x] EntryHistoryManager: null modification time treated as oldest
- [x] EntryHistoryManager: pruneGroupHistory recurses through nested groups
- [x] EntryHistoryManager: entry size estimation (fields, attachments, tags)
- [x] XML reader/writer: round-trip HistoryMaxItems and HistoryMaxSize
- [x] XML reader/writer: defaults when elements are missing
- [x] XML reader/writer: negative values for unlimited

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)