### PR TITLE
[2.10] Implement Recycle Bin support

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/RecycleBinManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/RecycleBinManager.kt
@@ -1,0 +1,287 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import org.github.keepasscompose.core.model.DeletedObject
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.KdbxIcon
+import org.github.keepasscompose.core.model.KdbxMeta
+
+/**
+ * Manages the KeePass Recycle Bin: moving deleted entries and groups to a
+ * special recycle bin group instead of permanently deleting them.
+ *
+ * When `recycleBinEnabled` is false, delete operations remove items permanently
+ * and record [DeletedObject] tombstones.
+ */
+@OptIn(ExperimentalEncodingApi::class, ExperimentalUuidApi::class)
+class RecycleBinManager(private val meta: KdbxMeta) {
+
+    /**
+     * Result of a delete operation. Contains the updated group tree,
+     * updated metadata (may include a new recycle bin UUID), and any
+     * deleted-object tombstones (only for permanent deletions).
+     */
+    data class DeleteResult(
+        val rootGroup: KdbxGroup,
+        val meta: KdbxMeta,
+        val deletedObjects: List<DeletedObject> = emptyList(),
+    )
+
+    /**
+     * Result of emptying the recycle bin. Contains the updated group tree
+     * and tombstones for all permanently deleted items.
+     */
+    data class EmptyResult(
+        val rootGroup: KdbxGroup,
+        val deletedObjects: List<DeletedObject>,
+    )
+
+    /**
+     * Deletes an entry by moving it to the recycle bin, or permanently
+     * if the recycle bin is disabled.
+     *
+     * @param rootGroup The current root group tree.
+     * @param entryUuid UUID of the entry to delete.
+     * @param now Current timestamp for tombstones and recycle bin creation.
+     * @return Updated state after the deletion.
+     */
+    fun deleteEntry(rootGroup: KdbxGroup, entryUuid: String, now: Instant): DeleteResult {
+        if (!meta.recycleBinEnabled) {
+            val updated = removeEntry(rootGroup, entryUuid) ?: return noChange(rootGroup)
+            return DeleteResult(
+                rootGroup = updated,
+                meta = meta,
+                deletedObjects = listOf(DeletedObject(uuid = entryUuid, deletionTime = now)),
+            )
+        }
+
+        val entry = findEntry(rootGroup, entryUuid) ?: return noChange(rootGroup)
+        val withoutEntry = removeEntry(rootGroup, entryUuid) ?: return noChange(rootGroup)
+
+        val (groupWithBin, updatedMeta) = ensureRecycleBin(withoutEntry, now)
+        val recycleBinUuid = updatedMeta.recycleBinUuid!!
+
+        val result = addEntryToGroup(groupWithBin, recycleBinUuid, entry)
+        return DeleteResult(rootGroup = result, meta = updatedMeta)
+    }
+
+    /**
+     * Deletes a group by moving it to the recycle bin, or permanently
+     * if the recycle bin is disabled.
+     *
+     * The recycle bin group itself cannot be moved to the recycle bin.
+     *
+     * @param rootGroup The current root group tree.
+     * @param groupUuid UUID of the group to delete.
+     * @param now Current timestamp for tombstones and recycle bin creation.
+     * @return Updated state after the deletion.
+     */
+    fun deleteGroup(rootGroup: KdbxGroup, groupUuid: String, now: Instant): DeleteResult {
+        // Cannot delete the recycle bin group itself via this method
+        if (groupUuid == meta.recycleBinUuid) return noChange(rootGroup)
+
+        if (!meta.recycleBinEnabled) {
+            val group = findGroup(rootGroup, groupUuid) ?: return noChange(rootGroup)
+            val updated = removeGroup(rootGroup, groupUuid) ?: return noChange(rootGroup)
+            return DeleteResult(
+                rootGroup = updated,
+                meta = meta,
+                deletedObjects = collectUuids(group, now),
+            )
+        }
+
+        val group = findGroup(rootGroup, groupUuid) ?: return noChange(rootGroup)
+        val withoutGroup = removeGroup(rootGroup, groupUuid) ?: return noChange(rootGroup)
+
+        val (groupWithBin, updatedMeta) = ensureRecycleBin(withoutGroup, now)
+        val recycleBinUuid = updatedMeta.recycleBinUuid!!
+
+        val result = addGroupToGroup(groupWithBin, recycleBinUuid, group)
+        return DeleteResult(rootGroup = result, meta = updatedMeta)
+    }
+
+    /**
+     * Empties the recycle bin, permanently deleting all its contents
+     * and recording tombstones for each deleted item.
+     *
+     * @param rootGroup The current root group tree.
+     * @param now Current timestamp for tombstones.
+     * @return Updated state with empty recycle bin and tombstones.
+     */
+    fun emptyRecycleBin(rootGroup: KdbxGroup, now: Instant): EmptyResult {
+        val recycleBinUuid = meta.recycleBinUuid
+            ?: return EmptyResult(rootGroup = rootGroup, deletedObjects = emptyList())
+
+        val recycleBin = findGroup(rootGroup, recycleBinUuid)
+            ?: return EmptyResult(rootGroup = rootGroup, deletedObjects = emptyList())
+
+        val tombstones = collectContentsUuids(recycleBin, now)
+
+        val cleared = replaceGroup(rootGroup, recycleBinUuid) { bin ->
+            bin.copy(entries = emptyList(), groups = emptyList())
+        }
+
+        return EmptyResult(rootGroup = cleared, deletedObjects = tombstones)
+    }
+
+    /**
+     * Finds the recycle bin group in the tree, if it exists.
+     */
+    fun findRecycleBin(rootGroup: KdbxGroup): KdbxGroup? {
+        val uuid = meta.recycleBinUuid ?: return null
+        return findGroup(rootGroup, uuid)
+    }
+
+    // -- Internal helpers --
+
+    private fun noChange(rootGroup: KdbxGroup) =
+        DeleteResult(rootGroup = rootGroup, meta = meta)
+
+    /**
+     * Ensures a recycle bin group exists. Creates one if needed.
+     * Returns the updated root group and meta.
+     */
+    private fun ensureRecycleBin(rootGroup: KdbxGroup, now: Instant): Pair<KdbxGroup, KdbxMeta> {
+        val existingUuid = meta.recycleBinUuid
+        if (existingUuid != null && findGroup(rootGroup, existingUuid) != null) {
+            return rootGroup to meta
+        }
+
+        val newUuid = generateUuid()
+        val recycleBin = KdbxGroup(
+            uuid = newUuid,
+            name = RECYCLE_BIN_NAME,
+            icon = KdbxIcon(standardIndex = RECYCLE_BIN_ICON),
+        )
+
+        val updatedRoot = rootGroup.copy(groups = rootGroup.groups + recycleBin)
+        val updatedMeta = meta.copy(recycleBinUuid = newUuid)
+        return updatedRoot to updatedMeta
+    }
+
+    companion object {
+        const val RECYCLE_BIN_NAME = "Recycle Bin"
+        const val RECYCLE_BIN_ICON = 43
+
+        internal fun generateUuid(): String =
+            Base64.encode(Uuid.random().toByteArray())
+
+        /** Find an entry by UUID anywhere in the group tree. */
+        fun findEntry(group: KdbxGroup, entryUuid: String): KdbxEntry? {
+            group.entries.firstOrNull { it.uuid == entryUuid }?.let { return it }
+            for (sub in group.groups) {
+                findEntry(sub, entryUuid)?.let { return it }
+            }
+            return null
+        }
+
+        /** Find a group by UUID anywhere in the group tree (not including root itself). */
+        fun findGroup(root: KdbxGroup, groupUuid: String): KdbxGroup? {
+            if (root.uuid == groupUuid) return root
+            for (sub in root.groups) {
+                findGroup(sub, groupUuid)?.let { return it }
+            }
+            return null
+        }
+
+        /** Remove an entry by UUID from the tree. Returns null if not found. */
+        fun removeEntry(group: KdbxGroup, entryUuid: String): KdbxGroup? {
+            val hasEntry = group.entries.any { it.uuid == entryUuid }
+            if (hasEntry) {
+                return group.copy(entries = group.entries.filter { it.uuid != entryUuid })
+            }
+            var found = false
+            val updatedGroups = group.groups.map { sub ->
+                val result = removeEntry(sub, entryUuid)
+                if (result != null) {
+                    found = true
+                    result
+                } else {
+                    sub
+                }
+            }
+            return if (found) group.copy(groups = updatedGroups) else null
+        }
+
+        /** Remove a group by UUID from the tree. Returns null if not found. */
+        fun removeGroup(group: KdbxGroup, groupUuid: String): KdbxGroup? {
+            val hasGroup = group.groups.any { it.uuid == groupUuid }
+            if (hasGroup) {
+                return group.copy(groups = group.groups.filter { it.uuid != groupUuid })
+            }
+            var found = false
+            val updatedGroups = group.groups.map { sub ->
+                val result = removeGroup(sub, groupUuid)
+                if (result != null) {
+                    found = true
+                    result
+                } else {
+                    sub
+                }
+            }
+            return if (found) group.copy(groups = updatedGroups) else null
+        }
+
+        /** Add an entry to a specific group by UUID. */
+        fun addEntryToGroup(root: KdbxGroup, targetUuid: String, entry: KdbxEntry): KdbxGroup {
+            if (root.uuid == targetUuid) {
+                return root.copy(entries = root.entries + entry)
+            }
+            return root.copy(groups = root.groups.map { sub ->
+                addEntryToGroup(sub, targetUuid, entry)
+            })
+        }
+
+        /** Add a child group to a specific group by UUID. */
+        fun addGroupToGroup(root: KdbxGroup, targetUuid: String, group: KdbxGroup): KdbxGroup {
+            if (root.uuid == targetUuid) {
+                return root.copy(groups = root.groups + group)
+            }
+            return root.copy(groups = root.groups.map { sub ->
+                addGroupToGroup(sub, targetUuid, group)
+            })
+        }
+
+        /** Replace a group in the tree using a transform function. */
+        fun replaceGroup(root: KdbxGroup, targetUuid: String, transform: (KdbxGroup) -> KdbxGroup): KdbxGroup {
+            if (root.uuid == targetUuid) return transform(root)
+            return root.copy(groups = root.groups.map { sub ->
+                replaceGroup(sub, targetUuid, transform)
+            })
+        }
+
+        /** Collect tombstones for a group and all its contents (entries + subgroups). */
+        fun collectUuids(group: KdbxGroup, now: Instant): List<DeletedObject> {
+            val result = mutableListOf<DeletedObject>()
+            result.add(DeletedObject(uuid = group.uuid, deletionTime = now))
+            collectContentsUuidsInto(group, now, result)
+            return result
+        }
+
+        /** Collect tombstones for a group's contents only (not the group itself). */
+        fun collectContentsUuids(group: KdbxGroup, now: Instant): List<DeletedObject> {
+            val result = mutableListOf<DeletedObject>()
+            collectContentsUuidsInto(group, now, result)
+            return result
+        }
+
+        private fun collectContentsUuidsInto(
+            group: KdbxGroup,
+            now: Instant,
+            result: MutableList<DeletedObject>,
+        ) {
+            for (entry in group.entries) {
+                result.add(DeletedObject(uuid = entry.uuid, deletionTime = now))
+            }
+            for (sub in group.groups) {
+                result.add(DeletedObject(uuid = sub.uuid, deletionTime = now))
+                collectContentsUuidsInto(sub, now, result)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/RecycleBinManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/RecycleBinManagerTest.kt
@@ -1,0 +1,368 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.KdbxMeta
+
+class RecycleBinManagerTest {
+
+    private val now = Instant.parse("2024-06-15T12:00:00Z")
+
+    // -- deleteEntry: recycle bin enabled --
+
+    @Test
+    fun deleteEntry_movesToRecycleBin() {
+        val entry = entry("e1", "Gmail")
+        val root = rootWith(entries = listOf(entry))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.deleteEntry(root, "e1", now)
+
+        // Entry removed from root
+        assertTrue(result.rootGroup.entries.isEmpty())
+        // Entry in recycle bin
+        val bin = manager(result).findRecycleBin(result.rootGroup)
+        assertNotNull(bin)
+        assertEquals(1, bin.entries.size)
+        assertEquals("Gmail", bin.entries[0].title)
+        // No tombstones (soft delete)
+        assertTrue(result.deletedObjects.isEmpty())
+    }
+
+    @Test
+    fun deleteEntry_createsRecycleBinOnFirstDelete() {
+        val entry = entry("e1", "Gmail")
+        val root = rootWith(entries = listOf(entry))
+        val meta = KdbxMeta(recycleBinEnabled = true, recycleBinUuid = null)
+        val manager = RecycleBinManager(meta)
+
+        val result = manager.deleteEntry(root, "e1", now)
+
+        // Meta now has recycle bin UUID
+        assertNotNull(result.meta.recycleBinUuid)
+        // Recycle bin group created
+        val bin = RecycleBinManager(result.meta).findRecycleBin(result.rootGroup)
+        assertNotNull(bin)
+        assertEquals(RecycleBinManager.RECYCLE_BIN_NAME, bin.name)
+        assertEquals(RecycleBinManager.RECYCLE_BIN_ICON, bin.icon.standardIndex)
+        assertEquals(1, bin.entries.size)
+    }
+
+    @Test
+    fun deleteEntry_fromNestedGroup() {
+        val entry = entry("e1", "Nested Entry")
+        val subGroup = KdbxGroup(uuid = "sub", name = "Sub", entries = listOf(entry))
+        val root = rootWith(groups = listOf(subGroup))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.deleteEntry(root, "e1", now)
+
+        // Removed from nested group
+        assertTrue(result.rootGroup.groups[0].entries.isEmpty())
+        // Added to recycle bin
+        val bin = manager(result).findRecycleBin(result.rootGroup)
+        assertNotNull(bin)
+        assertEquals(1, bin.entries.size)
+    }
+
+    @Test
+    fun deleteEntry_nonExistent_noChange() {
+        val root = rootWith()
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.deleteEntry(root, "nonexistent", now)
+
+        assertEquals(root, result.rootGroup)
+        assertTrue(result.deletedObjects.isEmpty())
+    }
+
+    // -- deleteEntry: recycle bin disabled --
+
+    @Test
+    fun deleteEntry_recycleBinDisabled_permanentDelete() {
+        val entry = entry("e1", "Gmail")
+        val root = rootWith(entries = listOf(entry))
+        val manager = RecycleBinManager(KdbxMeta(recycleBinEnabled = false))
+
+        val result = manager.deleteEntry(root, "e1", now)
+
+        assertTrue(result.rootGroup.entries.isEmpty())
+        assertEquals(1, result.deletedObjects.size)
+        assertEquals("e1", result.deletedObjects[0].uuid)
+        assertEquals(now, result.deletedObjects[0].deletionTime)
+    }
+
+    // -- deleteGroup: recycle bin enabled --
+
+    @Test
+    fun deleteGroup_movesToRecycleBin() {
+        val subGroup = KdbxGroup(
+            uuid = "sub1",
+            name = "Work",
+            entries = listOf(entry("e1", "Work Email")),
+        )
+        val root = rootWith(groups = listOf(subGroup, recycleBinGroup()))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.deleteGroup(root, "sub1", now)
+
+        // Group removed from root (only recycle bin remains)
+        val nonBinGroups = result.rootGroup.groups.filter { it.uuid != RECYCLE_BIN_UUID }
+        assertTrue(nonBinGroups.isEmpty())
+        // Group in recycle bin with its entries intact
+        val bin = manager(result).findRecycleBin(result.rootGroup)
+        assertNotNull(bin)
+        assertEquals(1, bin.groups.size)
+        assertEquals("Work", bin.groups[0].name)
+        assertEquals(1, bin.groups[0].entries.size)
+        // No tombstones
+        assertTrue(result.deletedObjects.isEmpty())
+    }
+
+    @Test
+    fun deleteGroup_cannotDeleteRecycleBinItself() {
+        val root = rootWith(groups = listOf(recycleBinGroup()))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.deleteGroup(root, RECYCLE_BIN_UUID, now)
+
+        // No change
+        assertEquals(1, result.rootGroup.groups.size)
+        assertEquals(RECYCLE_BIN_UUID, result.rootGroup.groups[0].uuid)
+    }
+
+    @Test
+    fun deleteGroup_createsRecycleBinOnFirstDelete() {
+        val subGroup = KdbxGroup(uuid = "sub1", name = "Work")
+        val root = rootWith(groups = listOf(subGroup))
+        val meta = KdbxMeta(recycleBinEnabled = true, recycleBinUuid = null)
+        val manager = RecycleBinManager(meta)
+
+        val result = manager.deleteGroup(root, "sub1", now)
+
+        assertNotNull(result.meta.recycleBinUuid)
+        val bin = RecycleBinManager(result.meta).findRecycleBin(result.rootGroup)
+        assertNotNull(bin)
+        assertEquals(1, bin.groups.size)
+        assertEquals("Work", bin.groups[0].name)
+    }
+
+    // -- deleteGroup: recycle bin disabled --
+
+    @Test
+    fun deleteGroup_recycleBinDisabled_permanentDelete() {
+        val subGroup = KdbxGroup(
+            uuid = "sub1",
+            name = "Work",
+            entries = listOf(entry("e1", "Entry1")),
+            groups = listOf(
+                KdbxGroup(uuid = "sub2", name = "Nested", entries = listOf(entry("e2", "Entry2")))
+            ),
+        )
+        val root = rootWith(groups = listOf(subGroup))
+        val manager = RecycleBinManager(KdbxMeta(recycleBinEnabled = false))
+
+        val result = manager.deleteGroup(root, "sub1", now)
+
+        assertTrue(result.rootGroup.groups.isEmpty())
+        // Tombstones for group + all contents
+        val uuids = result.deletedObjects.map { it.uuid }.toSet()
+        assertEquals(setOf("sub1", "e1", "sub2", "e2"), uuids)
+        assertTrue(result.deletedObjects.all { it.deletionTime == now })
+    }
+
+    @Test
+    fun deleteGroup_nonExistent_noChange() {
+        val root = rootWith()
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.deleteGroup(root, "nonexistent", now)
+
+        assertEquals(root, result.rootGroup)
+    }
+
+    // -- emptyRecycleBin --
+
+    @Test
+    fun emptyRecycleBin_removesAllContents() {
+        val bin = recycleBinGroup(
+            entries = listOf(entry("e1", "Deleted1"), entry("e2", "Deleted2")),
+            groups = listOf(KdbxGroup(uuid = "dg1", name = "Deleted Group")),
+        )
+        val root = rootWith(groups = listOf(bin))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.emptyRecycleBin(root, now)
+
+        // Recycle bin still exists but is empty
+        val emptyBin = RecycleBinManager(metaWithRecycleBin()).findRecycleBin(result.rootGroup)
+        assertNotNull(emptyBin)
+        assertTrue(emptyBin.entries.isEmpty())
+        assertTrue(emptyBin.groups.isEmpty())
+        // Tombstones for all contents
+        val uuids = result.deletedObjects.map { it.uuid }.toSet()
+        assertEquals(setOf("e1", "e2", "dg1"), uuids)
+    }
+
+    @Test
+    fun emptyRecycleBin_nestedContents() {
+        val nestedGroup = KdbxGroup(
+            uuid = "ng1",
+            name = "Nested",
+            entries = listOf(entry("ne1", "Nested Entry")),
+        )
+        val bin = recycleBinGroup(
+            groups = listOf(nestedGroup),
+        )
+        val root = rootWith(groups = listOf(bin))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.emptyRecycleBin(root, now)
+
+        val uuids = result.deletedObjects.map { it.uuid }.toSet()
+        assertEquals(setOf("ng1", "ne1"), uuids)
+    }
+
+    @Test
+    fun emptyRecycleBin_alreadyEmpty() {
+        val bin = recycleBinGroup()
+        val root = rootWith(groups = listOf(bin))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val result = manager.emptyRecycleBin(root, now)
+
+        assertTrue(result.deletedObjects.isEmpty())
+    }
+
+    @Test
+    fun emptyRecycleBin_noRecycleBinExists() {
+        val root = rootWith()
+        val manager = RecycleBinManager(KdbxMeta(recycleBinEnabled = true, recycleBinUuid = null))
+
+        val result = manager.emptyRecycleBin(root, now)
+
+        assertTrue(result.deletedObjects.isEmpty())
+        assertEquals(root, result.rootGroup)
+    }
+
+    // -- findRecycleBin --
+
+    @Test
+    fun findRecycleBin_exists() {
+        val bin = recycleBinGroup()
+        val root = rootWith(groups = listOf(bin))
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        val found = manager.findRecycleBin(root)
+
+        assertNotNull(found)
+        assertEquals(RECYCLE_BIN_UUID, found.uuid)
+    }
+
+    @Test
+    fun findRecycleBin_noUuidInMeta() {
+        val root = rootWith()
+        val manager = RecycleBinManager(KdbxMeta(recycleBinUuid = null))
+
+        assertNull(manager.findRecycleBin(root))
+    }
+
+    @Test
+    fun findRecycleBin_uuidInMetaButGroupMissing() {
+        val root = rootWith()
+        val manager = RecycleBinManager(metaWithRecycleBin())
+
+        assertNull(manager.findRecycleBin(root))
+    }
+
+    // -- Tree operation helpers --
+
+    @Test
+    fun findEntry_inNestedGroup() {
+        val entry = entry("e1", "Deep Entry")
+        val sub2 = KdbxGroup(uuid = "sub2", name = "Sub2", entries = listOf(entry))
+        val sub1 = KdbxGroup(uuid = "sub1", name = "Sub1", groups = listOf(sub2))
+        val root = rootWith(groups = listOf(sub1))
+
+        val found = RecycleBinManager.findEntry(root, "e1")
+
+        assertNotNull(found)
+        assertEquals("Deep Entry", found.title)
+    }
+
+    @Test
+    fun removeEntry_fromNestedGroup() {
+        val entry = entry("e1", "Entry")
+        val sub = KdbxGroup(uuid = "sub", name = "Sub", entries = listOf(entry))
+        val root = rootWith(groups = listOf(sub))
+
+        val result = RecycleBinManager.removeEntry(root, "e1")
+
+        assertNotNull(result)
+        assertTrue(result.groups[0].entries.isEmpty())
+    }
+
+    @Test
+    fun removeGroup_fromRoot() {
+        val sub = KdbxGroup(uuid = "sub", name = "Sub")
+        val root = rootWith(groups = listOf(sub))
+
+        val result = RecycleBinManager.removeGroup(root, "sub")
+
+        assertNotNull(result)
+        assertTrue(result.groups.isEmpty())
+    }
+
+    @Test
+    fun addEntryToGroup_nestedTarget() {
+        val sub = KdbxGroup(uuid = "sub", name = "Sub")
+        val root = rootWith(groups = listOf(sub))
+
+        val result = RecycleBinManager.addEntryToGroup(root, "sub", entry("e1", "New"))
+
+        assertEquals(1, result.groups[0].entries.size)
+        assertEquals("New", result.groups[0].entries[0].title)
+    }
+
+    // -- Helpers --
+
+    private fun entry(uuid: String, title: String) = KdbxEntry(
+        uuid = uuid,
+        fields = listOf(KdbxEntryField(KdbxEntry.FIELD_TITLE, title)),
+    )
+
+    private fun rootWith(
+        entries: List<KdbxEntry> = emptyList(),
+        groups: List<KdbxGroup> = emptyList(),
+    ) = KdbxGroup(uuid = "root", name = "Root", entries = entries, groups = groups)
+
+    private fun recycleBinGroup(
+        entries: List<KdbxEntry> = emptyList(),
+        groups: List<KdbxGroup> = emptyList(),
+    ) = KdbxGroup(
+        uuid = RECYCLE_BIN_UUID,
+        name = RecycleBinManager.RECYCLE_BIN_NAME,
+        entries = entries,
+        groups = groups,
+    )
+
+    private fun metaWithRecycleBin() = KdbxMeta(
+        recycleBinEnabled = true,
+        recycleBinUuid = RECYCLE_BIN_UUID,
+    )
+
+    /** Create a new manager from a result's meta, for chaining assertions. */
+    private fun manager(result: RecycleBinManager.DeleteResult) =
+        RecycleBinManager(result.meta)
+
+    companion object {
+        private const val RECYCLE_BIN_UUID = "cmVjeWNsZWJpbg=="
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RecycleBinManager` for soft-deleting entries and groups by moving them to a recycle bin group
- Create recycle bin group automatically on first delete (with standard KeePass icon 43)
- Permanent deletion with `DeletedObject` tombstones when recycle bin is disabled
- Support emptying the recycle bin (clears contents, records tombstones)
- Tree manipulation helpers (`findEntry`, `removeEntry`, `addEntryToGroup`, etc.) for immutable group structures

## Test plan
- [x] Delete entry moves to recycle bin
- [x] Delete entry creates recycle bin on first delete
- [x] Delete entry from nested group
- [x] Delete entry with recycle bin disabled (permanent delete with tombstone)
- [x] Delete non-existent entry is a no-op
- [x] Delete group moves to recycle bin with contents intact
- [x] Cannot delete the recycle bin group itself
- [x] Delete group creates recycle bin on first delete
- [x] Delete group with recycle bin disabled (permanent delete with tombstones for all contents)
- [x] Empty recycle bin removes all contents and creates tombstones
- [x] Empty recycle bin with nested contents
- [x] Empty already-empty recycle bin is a no-op
- [x] Find recycle bin (exists, no UUID, UUID but group missing)
- [x] Tree operation helpers (find/remove/add in nested groups)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)