### PR TITLE
[2.11] Write unit tests for KDBX engine

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxFixtureGenerator.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxFixtureGenerator.kt
@@ -1,0 +1,199 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.crypto.PlatformCryptoProvider
+import org.github.keepasscompose.core.model.Argon2Variant
+import org.github.keepasscompose.core.model.CipherId
+import org.github.keepasscompose.core.model.CompositeKey
+import org.github.keepasscompose.core.model.CompressionAlgorithm
+import org.github.keepasscompose.core.model.InnerStreamCipher
+import org.github.keepasscompose.core.model.KdbxAttachment
+import org.github.keepasscompose.core.model.KdbxDatabase
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.KdbxHeader
+import org.github.keepasscompose.core.model.KdbxIcon
+import org.github.keepasscompose.core.model.KdbxMeta
+import org.github.keepasscompose.core.model.KdbxVersion
+import org.github.keepasscompose.core.model.KdfParameters
+import kotlin.time.Instant
+
+/**
+ * Generates sample KDBX databases for use as test fixtures.
+ * All fixtures use deterministic seeds/IVs for reproducibility.
+ */
+object KdbxFixtureGenerator {
+
+    private val crypto = PlatformCryptoProvider()
+    private val writer = KdbxWriter(crypto)
+
+    /** Password used for all V4 fixtures. */
+    const val V4_PASSWORD = "fixture-v4-password"
+
+    /** Password used for all V3 fixtures. */
+    const val V3_PASSWORD = "fixture-v3-password"
+
+    /** Generates a KDBX 4.x file with AES-256 cipher and Argon2d KDF. */
+    fun generateV4AesArgon2d(): ByteArray = writer.writeDatabase(
+        buildV4Database(
+            databaseName = "V4 AES Argon2d Fixture",
+            cipher = CipherId.AES_256,
+            kdf = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2D,
+                salt = ByteArray(32) { (it + 1).toByte() },
+                parallelism = 2,
+                memory = 1024,
+                iterations = 1,
+            ),
+        ),
+        CompositeKey(password = V4_PASSWORD),
+    )
+
+    /** Generates a KDBX 4.x file with ChaCha20 cipher and AES-KDF. */
+    fun generateV4ChaCha20(): ByteArray = writer.writeDatabase(
+        buildV4Database(
+            databaseName = "V4 ChaCha20 Fixture",
+            cipher = CipherId.CHACHA20,
+            kdf = KdfParameters.AesKdf(
+                rounds = 2,
+                seed = ByteArray(32) { (it + 2).toByte() },
+            ),
+        ),
+        CompositeKey(password = V4_PASSWORD),
+    )
+
+    /** Generates a KDBX 4.x file with Twofish cipher. */
+    fun generateV4Twofish(): ByteArray = writer.writeDatabase(
+        buildV4Database(
+            databaseName = "V4 Twofish Fixture",
+            cipher = CipherId.TWOFISH,
+            kdf = KdfParameters.AesKdf(
+                rounds = 2,
+                seed = ByteArray(32) { (it + 3).toByte() },
+            ),
+        ),
+        CompositeKey(password = V4_PASSWORD),
+    )
+
+    /** Generates a KDBX 3.1 file with AES cipher and Salsa20 inner stream. */
+    fun generateV3Aes(): ByteArray = writer.writeDatabase(
+        buildV3Database(databaseName = "V3 AES Fixture"),
+        CompositeKey(password = V3_PASSWORD),
+    )
+
+    /** Generates a KDBX 3.1 file with Twofish cipher. */
+    fun generateV3Twofish(): ByteArray = writer.writeDatabase(
+        buildV3Database(
+            databaseName = "V3 Twofish Fixture",
+            cipher = CipherId.TWOFISH,
+        ),
+        CompositeKey(password = V3_PASSWORD),
+    )
+
+    private fun buildV4Database(
+        databaseName: String,
+        cipher: CipherId,
+        kdf: KdfParameters,
+    ): KdbxDatabase = KdbxDatabase(
+        meta = buildMeta(databaseName),
+        header = KdbxHeader(
+            version = KdbxVersion(4, 0),
+            cipher = cipher,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { (it + 0x10).toByte() },
+            encryptionIv = if (cipher == CipherId.CHACHA20) ByteArray(12) { (it + 0x20).toByte() }
+            else ByteArray(16) { (it + 0x20).toByte() },
+            kdfParameters = kdf,
+            innerRandomStreamId = InnerStreamCipher.CHACHA20,
+            innerRandomStreamKey = ByteArray(64) { (it + 0x30).toByte() },
+        ),
+        rootGroup = buildSampleRootGroup(),
+    )
+
+    private fun buildV3Database(
+        databaseName: String,
+        cipher: CipherId = CipherId.AES_256,
+    ): KdbxDatabase = KdbxDatabase(
+        meta = buildMeta(databaseName),
+        header = KdbxHeader(
+            version = KdbxVersion(3, 1),
+            cipher = cipher,
+            compression = CompressionAlgorithm.GZIP,
+            masterSeed = ByteArray(32) { (it + 0x10).toByte() },
+            encryptionIv = ByteArray(16) { (it + 0x20).toByte() },
+            kdfParameters = KdfParameters.AesKdf(
+                rounds = 2,
+                seed = ByteArray(32) { (it + 0x40).toByte() },
+            ),
+            innerRandomStreamId = InnerStreamCipher.SALSA20,
+            innerRandomStreamKey = ByteArray(32) { (it + 0x50).toByte() },
+            streamStartBytes = ByteArray(32) { (it + 0x60).toByte() },
+        ),
+        rootGroup = buildSampleRootGroup(),
+    )
+
+    private fun buildMeta(databaseName: String) = KdbxMeta(
+        databaseName = databaseName,
+        description = "Test fixture database",
+        defaultUserName = "testuser",
+        historyMaxItems = 10,
+        historyMaxSize = 6_291_456,
+        recycleBinEnabled = true,
+    )
+
+    /** Builds a sample root group with nested groups and multiple entries. */
+    private fun buildSampleRootGroup() = KdbxGroup(
+        uuid = "fixture-root",
+        name = "Root",
+        entries = listOf(
+            KdbxEntry(
+                uuid = "entry-email",
+                fields = listOf(
+                    KdbxEntryField("Title", "Email Account"),
+                    KdbxEntryField("UserName", "user@example.com"),
+                    KdbxEntryField("Password", "email-p@ssw0rd!", isProtected = true),
+                    KdbxEntryField("URL", "https://mail.example.com"),
+                    KdbxEntryField("Notes", "Primary email account"),
+                ),
+                tags = listOf("email", "personal"),
+                creationTime = Instant.parse("2024-01-15T10:00:00Z"),
+                lastModificationTime = Instant.parse("2024-06-01T12:00:00Z"),
+            ),
+        ),
+        groups = listOf(
+            KdbxGroup(
+                uuid = "group-banking",
+                name = "Banking",
+                icon = KdbxIcon(standardIndex = 37),
+                entries = listOf(
+                    KdbxEntry(
+                        uuid = "entry-bank",
+                        fields = listOf(
+                            KdbxEntryField("Title", "Bank Account"),
+                            KdbxEntryField("UserName", "bankuser"),
+                            KdbxEntryField("Password", "b@nk-s3cure!", isProtected = true),
+                            KdbxEntryField("URL", "https://bank.example.com"),
+                        ),
+                        creationTime = Instant.parse("2024-02-01T08:00:00Z"),
+                        lastModificationTime = Instant.parse("2024-05-15T09:00:00Z"),
+                    ),
+                ),
+            ),
+            KdbxGroup(
+                uuid = "group-work",
+                name = "Work",
+                icon = KdbxIcon(standardIndex = 38),
+                entries = listOf(
+                    KdbxEntry(
+                        uuid = "entry-vpn",
+                        fields = listOf(
+                            KdbxEntryField("Title", "VPN Access"),
+                            KdbxEntryField("UserName", "vpnuser"),
+                            KdbxEntryField("Password", "vpn-k3y!", isProtected = true),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+}

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxFixtureTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxFixtureTest.kt
@@ -1,0 +1,176 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.crypto.PlatformCryptoProvider
+import org.github.keepasscompose.core.model.CipherId
+import org.github.keepasscompose.core.model.CompositeKey
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests that use generated KDBX fixture files.
+ *
+ * These tests generate .kdbx files with known passwords and verify that
+ * the reader can correctly parse them. The fixtures can also be opened
+ * in KeePass/KeePassXC for manual compatibility verification.
+ */
+class KdbxFixtureTest {
+
+    private val crypto = PlatformCryptoProvider()
+    private val reader = KdbxReader(crypto)
+
+    // -- KDBX 4.x fixture tests --
+
+    @Test
+    fun readFixture_v4_aesArgon2d() {
+        val bytes = KdbxFixtureGenerator.generateV4AesArgon2d()
+        val key = CompositeKey(password = KdbxFixtureGenerator.V4_PASSWORD)
+
+        val result = reader.readDatabase(bytes, key)
+
+        assertFixtureContent(result, "V4 AES Argon2d Fixture")
+        assertEquals(CipherId.AES_256, result.header.cipher)
+        assertTrue(result.header.version.isV4)
+    }
+
+    @Test
+    fun readFixture_v4_chacha20() {
+        val bytes = KdbxFixtureGenerator.generateV4ChaCha20()
+        val key = CompositeKey(password = KdbxFixtureGenerator.V4_PASSWORD)
+
+        val result = reader.readDatabase(bytes, key)
+
+        assertFixtureContent(result, "V4 ChaCha20 Fixture")
+        assertEquals(CipherId.CHACHA20, result.header.cipher)
+    }
+
+    @Test
+    fun readFixture_v4_twofish() {
+        val bytes = KdbxFixtureGenerator.generateV4Twofish()
+        val key = CompositeKey(password = KdbxFixtureGenerator.V4_PASSWORD)
+
+        val result = reader.readDatabase(bytes, key)
+
+        assertFixtureContent(result, "V4 Twofish Fixture")
+        assertEquals(CipherId.TWOFISH, result.header.cipher)
+    }
+
+    // -- KDBX 3.1 fixture tests --
+
+    @Test
+    fun readFixture_v3_aes() {
+        val bytes = KdbxFixtureGenerator.generateV3Aes()
+        val key = CompositeKey(password = KdbxFixtureGenerator.V3_PASSWORD)
+
+        val result = reader.readDatabase(bytes, key)
+
+        assertFixtureContent(result, "V3 AES Fixture")
+        assertTrue(result.header.version.isV3)
+    }
+
+    @Test
+    fun readFixture_v3_twofish() {
+        val bytes = KdbxFixtureGenerator.generateV3Twofish()
+        val key = CompositeKey(password = KdbxFixtureGenerator.V3_PASSWORD)
+
+        val result = reader.readDatabase(bytes, key)
+
+        assertFixtureContent(result, "V3 Twofish Fixture")
+        assertEquals(CipherId.TWOFISH, result.header.cipher)
+    }
+
+    // -- Fixture wrong password tests --
+
+    @Test
+    fun readFixture_v4_wrongPassword_throws() {
+        val bytes = KdbxFixtureGenerator.generateV4AesArgon2d()
+        val wrongKey = CompositeKey(password = "wrong-password")
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(bytes, wrongKey)
+        }
+    }
+
+    @Test
+    fun readFixture_v3_wrongPassword_throws() {
+        val bytes = KdbxFixtureGenerator.generateV3Aes()
+        val wrongKey = CompositeKey(password = "wrong-password")
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(bytes, wrongKey)
+        }
+    }
+
+    // -- Save fixtures to disk (for manual verification with KeePass) --
+
+    @Test
+    fun saveFixtures_toDisk() {
+        val fixturesDir = File("build/test-fixtures")
+        fixturesDir.mkdirs()
+
+        File(fixturesDir, "v4_aes_argon2d.kdbx").writeBytes(
+            KdbxFixtureGenerator.generateV4AesArgon2d()
+        )
+        File(fixturesDir, "v4_chacha20.kdbx").writeBytes(
+            KdbxFixtureGenerator.generateV4ChaCha20()
+        )
+        File(fixturesDir, "v4_twofish.kdbx").writeBytes(
+            KdbxFixtureGenerator.generateV4Twofish()
+        )
+        File(fixturesDir, "v3_aes.kdbx").writeBytes(
+            KdbxFixtureGenerator.generateV3Aes()
+        )
+        File(fixturesDir, "v3_twofish.kdbx").writeBytes(
+            KdbxFixtureGenerator.generateV3Twofish()
+        )
+
+        // Verify all files were created
+        assertTrue(File(fixturesDir, "v4_aes_argon2d.kdbx").exists())
+        assertTrue(File(fixturesDir, "v4_chacha20.kdbx").exists())
+        assertTrue(File(fixturesDir, "v4_twofish.kdbx").exists())
+        assertTrue(File(fixturesDir, "v3_aes.kdbx").exists())
+        assertTrue(File(fixturesDir, "v3_twofish.kdbx").exists())
+    }
+
+    // -- Assertion helpers --
+
+    private fun assertFixtureContent(
+        result: org.github.keepasscompose.core.model.KdbxDatabase,
+        expectedName: String,
+    ) {
+        // Meta
+        assertEquals(expectedName, result.meta.databaseName)
+        assertEquals("Test fixture database", result.meta.description)
+        assertEquals("testuser", result.meta.defaultUserName)
+        assertEquals(10, result.meta.historyMaxItems)
+        assertTrue(result.meta.recycleBinEnabled)
+
+        // Root group structure
+        assertEquals("Root", result.rootGroup.name)
+        assertEquals(1, result.rootGroup.entries.size)
+        assertEquals(2, result.rootGroup.groups.size)
+
+        // Root entry
+        val email = result.rootGroup.entries[0]
+        assertEquals("Email Account", email.title)
+        assertEquals("user@example.com", email.userName)
+        assertEquals("email-p@ssw0rd!", email.password)
+        assertEquals("https://mail.example.com", email.url)
+
+        // Banking group
+        val banking = result.rootGroup.groups[0]
+        assertEquals("Banking", banking.name)
+        assertEquals(1, banking.entries.size)
+        assertEquals("Bank Account", banking.entries[0].title)
+        assertEquals("b@nk-s3cure!", banking.entries[0].password)
+
+        // Work group
+        val work = result.rootGroup.groups[1]
+        assertEquals("Work", work.name)
+        assertEquals(1, work.entries.size)
+        assertEquals("VPN Access", work.entries[0].title)
+        assertEquals("vpn-k3y!", work.entries[0].password)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxReaderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxReaderTest.kt
@@ -13,6 +13,7 @@ import org.github.keepasscompose.core.model.KdbxHeader
 import org.github.keepasscompose.core.model.KdbxMeta
 import org.github.keepasscompose.core.model.KdbxVersion
 import org.github.keepasscompose.core.model.KdfParameters
+import org.github.keepasscompose.core.model.Argon2Variant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -152,6 +153,114 @@ class KdbxReaderTest {
         assertEquals("Root", result.rootGroup.name)
         assertEquals("V3 Entry", result.rootGroup.entries[0].title)
         assertTrue(result.header.version.isV3)
+    }
+
+    @Test
+    fun readDatabase_v4_argon2d_roundTrip() {
+        val compositeKey = CompositeKey(password = "argon2dReader")
+        val meta = KdbxMeta(databaseName = "Argon2d DB")
+        val rootGroup = KdbxGroup(uuid = "cm9vdA==", name = "Root")
+
+        val fileBytes = buildKdbx4File(
+            compositeKey = compositeKey,
+            meta = meta,
+            rootGroup = rootGroup,
+            cipher = CipherId.AES_256,
+            ivSize = 16,
+            kdfParams = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2D,
+                salt = ByteArray(32) { (it + 5).toByte() },
+                parallelism = 2,
+                memory = 1024,
+                iterations = 1,
+            ),
+        )
+
+        val result = reader.readDatabase(fileBytes, compositeKey)
+
+        assertEquals("Argon2d DB", result.meta.databaseName)
+    }
+
+    @Test
+    fun readDatabase_v4_argon2id_roundTrip() {
+        val compositeKey = CompositeKey(password = "argon2idReader")
+        val meta = KdbxMeta(databaseName = "Argon2id DB")
+        val rootGroup = KdbxGroup(uuid = "cm9vdA==", name = "Root")
+
+        val fileBytes = buildKdbx4File(
+            compositeKey = compositeKey,
+            meta = meta,
+            rootGroup = rootGroup,
+            cipher = CipherId.CHACHA20,
+            ivSize = 12,
+            kdfParams = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2ID,
+                salt = ByteArray(32) { (it + 15).toByte() },
+                parallelism = 2,
+                memory = 1024,
+                iterations = 1,
+            ),
+        )
+
+        val result = reader.readDatabase(fileBytes, compositeKey)
+
+        assertEquals("Argon2id DB", result.meta.databaseName)
+    }
+
+    // -- Corrupted file handling tests --
+
+    @Test
+    fun readDatabase_invalidSignature_throwsDescriptiveError() {
+        val garbageBytes = ByteArray(200) { 0x42.toByte() }
+        val key = CompositeKey(password = "test")
+
+        val exception = assertFailsWith<KdbxParseException> {
+            reader.readDatabase(garbageBytes, key)
+        }
+        assertTrue(exception.message!!.contains("signature", ignoreCase = true))
+    }
+
+    @Test
+    fun readDatabase_truncatedHeader_throwsException() {
+        // Valid KDBX signature but truncated after 8 bytes
+        val truncated = byteArrayOf(
+            0x03.toByte(), 0xD9.toByte(), 0xA2.toByte(), 0x9A.toByte(), // sig1
+            0x67.toByte(), 0xFB.toByte(), 0x4B.toByte(), 0xB5.toByte(), // sig2
+            0x00, 0x04, // partial version
+        )
+        val key = CompositeKey(password = "test")
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(truncated, key)
+        }
+    }
+
+    @Test
+    fun readDatabase_v4_corruptedHmac_throwsInvalidCredentials() {
+        val compositeKey = CompositeKey(password = "hmac-test")
+        val meta = KdbxMeta(databaseName = "HMAC Test")
+        val rootGroup = KdbxGroup(uuid = "cm9vdA==", name = "Root")
+
+        val fileBytes = buildKdbx4File(
+            compositeKey = compositeKey,
+            meta = meta,
+            rootGroup = rootGroup,
+            cipher = CipherId.AES_256,
+            ivSize = 16,
+        )
+
+        // Corrupt the HMAC area (after header hash - find and corrupt)
+        val corrupted = fileBytes.copyOf()
+        // The header HMAC starts after the header + 32 bytes (SHA-256 hash)
+        // Flip some bytes in that area
+        val hmacStart = corrupted.size / 3 // approximate area
+        for (i in hmacStart until minOf(hmacStart + 10, corrupted.size)) {
+            corrupted[i] = (corrupted[i].toInt() xor 0xFF).toByte()
+        }
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(corrupted, compositeKey)
+        }
     }
 
     // -- Error handling tests --
@@ -295,13 +404,13 @@ class KdbxReaderTest {
         compression: CompressionAlgorithm = CompressionAlgorithm.GZIP,
         innerStreamKey: ByteArray = ByteArray(32) { (it + 0x20).toByte() },
         useInnerStreamEncryption: Boolean = false,
+        kdfParams: KdfParameters = KdfParameters.AesKdf(
+            rounds = 2,
+            seed = ByteArray(32) { (it + 0x30).toByte() },
+        ),
     ): ByteArray {
         val masterSeed = ByteArray(32) { (it + 1).toByte() }
         val encryptionIv = ByteArray(ivSize) { (it + 0x10).toByte() }
-        val kdfParams = KdfParameters.AesKdf(
-            rounds = 2,
-            seed = ByteArray(32) { (it + 0x30).toByte() },
-        )
 
         val header = KdbxHeader(
             version = KdbxVersion(4, 0),

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxWriterTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/database/KdbxWriterTest.kt
@@ -1,6 +1,7 @@
 package org.github.keepasscompose.core.database
 
 import org.github.keepasscompose.core.crypto.PlatformCryptoProvider
+import org.github.keepasscompose.core.model.Argon2Variant
 import org.github.keepasscompose.core.model.CipherId
 import org.github.keepasscompose.core.model.CompositeKey
 import org.github.keepasscompose.core.model.CompressionAlgorithm
@@ -11,12 +12,15 @@ import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.core.model.KdbxEntryField
 import org.github.keepasscompose.core.model.KdbxGroup
 import org.github.keepasscompose.core.model.KdbxHeader
+import org.github.keepasscompose.core.model.KdbxIcon
 import org.github.keepasscompose.core.model.KdbxMeta
 import org.github.keepasscompose.core.model.KdbxVersion
 import org.github.keepasscompose.core.model.KdfParameters
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 /**
  * Integration tests for KdbxWriter using real cryptographic operations.
@@ -338,6 +342,377 @@ class KdbxWriterTest {
         val result = reader.readDatabase(bytes, key)
 
         assertDatabaseEquals(database, result)
+    }
+
+    // -- KDBX 3.1 additional cipher tests --
+
+    @Test
+    fun roundTrip_v3_twofish_gzip() {
+        val database = buildDatabase(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.TWOFISH,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.SALSA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+            streamStartBytes = ByteArray(32) { 0x77.toByte() },
+            innerStreamKey = ByteArray(32) { 0x88.toByte() },
+        )
+        val key = CompositeKey(password = "v3-twofish")
+
+        val bytes = writer.writeDatabase(database, key)
+        val result = reader.readDatabase(bytes, key)
+
+        assertDatabaseEquals(database, result)
+    }
+
+    @Test
+    fun roundTrip_v3_twofish_noCompression() {
+        val database = buildDatabase(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.TWOFISH,
+            compression = CompressionAlgorithm.NONE,
+            innerStreamCipher = InnerStreamCipher.SALSA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { (it + 5).toByte() }),
+            streamStartBytes = ByteArray(32) { 0x99.toByte() },
+            innerStreamKey = ByteArray(32) { 0xAA.toByte() },
+        )
+        val key = CompositeKey(password = "v3-twofish-no-compress")
+
+        val bytes = writer.writeDatabase(database, key)
+        val result = reader.readDatabase(bytes, key)
+
+        assertDatabaseEquals(database, result)
+    }
+
+    // -- Argon2 KDF tests --
+
+    @Test
+    fun roundTrip_v4_argon2d_kdf() {
+        val database = buildDatabase(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.CHACHA20,
+            kdf = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2D,
+                salt = ByteArray(32) { it.toByte() },
+                parallelism = 2,
+                memory = 1024, // 1 MB - keep small for test speed
+                iterations = 1,
+            ),
+        )
+        val key = CompositeKey(password = "argon2d-test")
+
+        val bytes = writer.writeDatabase(database, key)
+        val result = reader.readDatabase(bytes, key)
+
+        assertDatabaseEquals(database, result)
+    }
+
+    @Test
+    fun roundTrip_v4_argon2id_kdf() {
+        val database = buildDatabase(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.CHACHA20,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.CHACHA20,
+            kdf = KdfParameters.Argon2(
+                variant = Argon2Variant.ARGON2ID,
+                salt = ByteArray(32) { (it + 10).toByte() },
+                parallelism = 2,
+                memory = 1024,
+                iterations = 1,
+            ),
+        )
+        val key = CompositeKey(password = "argon2id-test")
+
+        val bytes = writer.writeDatabase(database, key)
+        val result = reader.readDatabase(bytes, key)
+
+        assertDatabaseEquals(database, result)
+    }
+
+    // -- Read → Modify → Write → Re-read tests --
+
+    @Test
+    fun roundTrip_v4_readModifyWriteReread_addEntry() {
+        val database = buildDatabase(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.CHACHA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+        )
+        val key = CompositeKey(password = "modify-test")
+
+        // Write original
+        val bytes1 = writer.writeDatabase(database, key)
+        // Read back
+        val read1 = reader.readDatabase(bytes1, key)
+
+        // Modify: add new entry
+        val newEntry = KdbxEntry(
+            uuid = "new-entry-uuid",
+            fields = listOf(
+                KdbxEntryField("Title", "Added Entry"),
+                KdbxEntryField("Password", "newpass", isProtected = true),
+            ),
+        )
+        val modifiedDb = KdbxDatabase(
+            meta = read1.meta,
+            header = read1.header,
+            rootGroup = read1.rootGroup.copy(
+                entries = read1.rootGroup.entries + newEntry,
+            ),
+        )
+
+        // Write modified
+        val bytes2 = writer.writeDatabase(modifiedDb, key)
+        // Re-read
+        val read2 = reader.readDatabase(bytes2, key)
+
+        assertEquals(2, read2.rootGroup.entries.size)
+        assertEquals("Test Entry", read2.rootGroup.entries[0].title)
+        assertEquals("Added Entry", read2.rootGroup.entries[1].title)
+        assertEquals("newpass", read2.rootGroup.entries[1].password)
+    }
+
+    @Test
+    fun roundTrip_v4_readModifyWriteReread_changePassword() {
+        val database = buildDatabase(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.CHACHA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+        )
+        val originalKey = CompositeKey(password = "original-password")
+        val newKey = CompositeKey(password = "new-password")
+
+        // Write with original password
+        val bytes1 = writer.writeDatabase(database, originalKey)
+        val read1 = reader.readDatabase(bytes1, originalKey)
+
+        // Re-write with new password
+        val bytes2 = writer.writeDatabase(
+            KdbxDatabase(meta = read1.meta, header = read1.header, rootGroup = read1.rootGroup),
+            newKey,
+        )
+
+        // Can read with new password
+        val read2 = reader.readDatabase(bytes2, newKey)
+        assertDatabaseEquals(database, read2)
+
+        // Cannot read with old password
+        assertFailsWith<KdbxParseException> {
+            reader.readDatabase(bytes2, originalKey)
+        }
+    }
+
+    @Test
+    fun roundTrip_v3_readModifyWriteReread_addGroup() {
+        val database = buildDatabase(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.SALSA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+            streamStartBytes = ByteArray(32) { 0xDD.toByte() },
+            innerStreamKey = ByteArray(32) { 0xEE.toByte() },
+        )
+        val key = CompositeKey(password = "v3-modify")
+
+        val bytes1 = writer.writeDatabase(database, key)
+        val read1 = reader.readDatabase(bytes1, key)
+
+        // Modify: add subgroup with entry
+        val newGroup = KdbxGroup(
+            uuid = "new-group-uuid",
+            name = "New Group",
+            entries = listOf(
+                KdbxEntry(
+                    uuid = "nested-entry",
+                    fields = listOf(KdbxEntryField("Title", "Nested")),
+                ),
+            ),
+        )
+        val modifiedDb = KdbxDatabase(
+            meta = read1.meta,
+            header = read1.header,
+            rootGroup = read1.rootGroup.copy(
+                groups = read1.rootGroup.groups + newGroup,
+            ),
+        )
+
+        val bytes2 = writer.writeDatabase(modifiedDb, key)
+        val read2 = reader.readDatabase(bytes2, key)
+
+        assertEquals(1, read2.rootGroup.groups.size)
+        assertEquals("New Group", read2.rootGroup.groups[0].name)
+        assertEquals("Nested", read2.rootGroup.groups[0].entries[0].title)
+    }
+
+    // -- Entry history and metadata round-trip --
+
+    @Test
+    fun roundTrip_v4_entryWithHistory() {
+        val historyEntry = KdbxEntry(
+            uuid = "test-entry-uuid",
+            fields = listOf(
+                KdbxEntryField("Title", "Old Title"),
+                KdbxEntryField("Password", "old-pass", isProtected = true),
+            ),
+            lastModificationTime = Instant.parse("2024-01-01T00:00:00Z"),
+        )
+        val currentEntry = KdbxEntry(
+            uuid = "test-entry-uuid",
+            fields = listOf(
+                KdbxEntryField("Title", "New Title"),
+                KdbxEntryField("Password", "new-pass", isProtected = true),
+            ),
+            lastModificationTime = Instant.parse("2024-06-01T00:00:00Z"),
+            history = listOf(historyEntry),
+        )
+        val database = KdbxDatabase(
+            meta = KdbxMeta(
+                databaseName = "History Test",
+                historyMaxItems = 20,
+                historyMaxSize = 10_000_000,
+            ),
+            header = buildHeader(
+                version = KdbxVersion(4, 0),
+                cipher = CipherId.AES_256,
+                compression = CompressionAlgorithm.GZIP,
+                innerStreamCipher = InnerStreamCipher.CHACHA20,
+                kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+            ),
+            rootGroup = KdbxGroup(uuid = "root", name = "Root", entries = listOf(currentEntry)),
+        )
+        val key = CompositeKey(password = "history-test")
+
+        val bytes = writer.writeDatabase(database, key)
+        val result = reader.readDatabase(bytes, key)
+
+        assertEquals(20, result.meta.historyMaxItems)
+        assertEquals(10_000_000L, result.meta.historyMaxSize)
+        val entry = result.rootGroup.entries[0]
+        assertEquals("New Title", entry.title)
+        assertEquals("new-pass", entry.password)
+        assertEquals(1, entry.history.size)
+        assertEquals("Old Title", entry.history[0].title)
+        assertEquals("old-pass", entry.history[0].password)
+    }
+
+    // -- Multiple protected fields test --
+
+    @Test
+    fun roundTrip_v4_multipleProtectedFields_preserveOrder() {
+        val entry = KdbxEntry(
+            uuid = "multi-protected",
+            fields = listOf(
+                KdbxEntryField("Title", "Multi Protected"),
+                KdbxEntryField("Password", "pass1", isProtected = true),
+                KdbxEntryField("PIN", "1234", isProtected = true),
+                KdbxEntryField("SecretKey", "abc-def-ghi", isProtected = true),
+                KdbxEntryField("Notes", "visible notes"),
+            ),
+        )
+        val database = KdbxDatabase(
+            header = buildHeader(
+                version = KdbxVersion(4, 0),
+                cipher = CipherId.AES_256,
+                compression = CompressionAlgorithm.GZIP,
+                innerStreamCipher = InnerStreamCipher.CHACHA20,
+                kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+            ),
+            rootGroup = KdbxGroup(uuid = "root", name = "Root", entries = listOf(entry)),
+        )
+        val key = CompositeKey(password = "multi-protected")
+
+        val bytes = writer.writeDatabase(database, key)
+        val result = reader.readDatabase(bytes, key)
+
+        val restored = result.rootGroup.entries[0]
+        assertEquals("pass1", restored.password)
+        assertEquals("1234", restored.field("PIN"))
+        assertEquals("abc-def-ghi", restored.field("SecretKey"))
+        assertEquals("visible notes", restored.notes)
+    }
+
+    // -- Corrupted file handling tests --
+
+    @Test
+    fun read_truncatedFile_throwsException() {
+        val database = buildDatabase(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.CHACHA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+        )
+        val key = CompositeKey(password = "truncate-test")
+        val bytes = writer.writeDatabase(database, key)
+
+        // Truncate to just the header (first ~200 bytes)
+        val truncated = bytes.copyOfRange(0, minOf(200, bytes.size))
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(truncated, key)
+        }
+    }
+
+    @Test
+    fun read_invalidSignature_throwsException() {
+        val bytes = ByteArray(100) { 0xFF.toByte() }
+        val key = CompositeKey(password = "bad-sig")
+
+        assertFailsWith<KdbxParseException> {
+            reader.readDatabase(bytes, key)
+        }
+    }
+
+    @Test
+    fun read_corruptedPayload_throwsException() {
+        val database = buildDatabase(
+            version = KdbxVersion(4, 0),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.CHACHA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+        )
+        val key = CompositeKey(password = "corrupt-test")
+        val bytes = writer.writeDatabase(database, key)
+
+        // Corrupt bytes near the end (payload area)
+        val corrupted = bytes.copyOf()
+        for (i in (corrupted.size - 50) until corrupted.size) {
+            corrupted[i] = (corrupted[i].toInt() xor 0xFF).toByte()
+        }
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(corrupted, key)
+        }
+    }
+
+    @Test
+    fun read_v3_wrongPassword_throwsException() {
+        val database = buildDatabase(
+            version = KdbxVersion(3, 1),
+            cipher = CipherId.AES_256,
+            compression = CompressionAlgorithm.GZIP,
+            innerStreamCipher = InnerStreamCipher.SALSA20,
+            kdf = KdfParameters.AesKdf(rounds = 1, seed = ByteArray(32) { it.toByte() }),
+            streamStartBytes = ByteArray(32) { 0xBB.toByte() },
+            innerStreamKey = ByteArray(32) { 0xCC.toByte() },
+        )
+        val correctKey = CompositeKey(password = "correct")
+        val wrongKey = CompositeKey(password = "wrong")
+
+        val bytes = writer.writeDatabase(database, correctKey)
+
+        assertFailsWith<Exception> {
+            reader.readDatabase(bytes, wrongKey)
+        }
     }
 
     // -- Output format tests --


### PR DESCRIPTION
## Summary
- Add V3+Twofish cipher round-trip tests (reader and writer)
- Add Argon2d and Argon2id KDF round-trip tests (reader and writer)
- Add read → modify → write → re-read tests (add entry, change password, add group)
- Add entry history and metadata round-trip test
- Add multiple protected fields ordering test
- Add corrupted file handling tests (invalid signature, truncated header, corrupted HMAC, corrupted payload)
- Add `KdbxFixtureGenerator` for generating sample .kdbx files with known passwords (V4 AES/ChaCha20/Twofish + V3 AES/Twofish)
- Add `KdbxFixtureTest` that validates fixture content and saves files to disk for manual KeePass verification

## Test plan
- [x] 27 KdbxWriterTest tests pass (13 new)
- [x] 16 KdbxReaderTest tests pass (5 new)
- [x] 8 KdbxFixtureTest tests pass (all new)
- [x] Full jvmTest suite passes with no regressions

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)