### PR TITLE
[3.5] Implement Argon2 key derivation (KDBX 4.x)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/Argon2.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/Argon2.kt
@@ -1,0 +1,438 @@
+package org.github.keepasscompose.core.crypto
+
+import org.github.keepasscompose.core.model.Argon2Variant
+
+/**
+ * Pure Kotlin implementation of Argon2 (RFC 9106).
+ * Supports Argon2d (data-dependent) and Argon2id (hybrid) variants.
+ *
+ * Used on iOS where BouncyCastle is not available.
+ * JVM/Android use BouncyCastle's Argon2BytesGenerator instead.
+ *
+ * Key concepts:
+ * - Memory is organized as a matrix of 1024-byte blocks.
+ * - The matrix has [parallelism] lanes, each with [segmentLength] * 4 blocks.
+ * - Blocks are filled using a compression function G based on Blake2b.
+ */
+@OptIn(ExperimentalUnsignedTypes::class)
+internal object Argon2 {
+
+    private const val BLOCK_SIZE = 1024 // bytes per block
+    private const val QWORDS_PER_BLOCK = 128 // 1024 / 8
+    private const val SYNC_POINTS = 4
+    private const val ARGON2_PREHASH_DIGEST_LENGTH = 64
+    private const val ARGON2_HASH_LENGTH = 32
+
+    fun derive(
+        password: ByteArray,
+        salt: ByteArray,
+        variant: Argon2Variant,
+        version: Int,
+        memoryKB: Long,
+        iterations: Long,
+        parallelism: Int,
+    ): ByteArray {
+        val type = when (variant) {
+            Argon2Variant.ARGON2D -> 0
+            Argon2Variant.ARGON2ID -> 2
+        }
+        val tagLength = ARGON2_HASH_LENGTH
+
+        // Compute memory size: must be at least 8 * parallelism blocks
+        val memoryBlocks = maxOf(memoryKB.toInt(), 8 * parallelism)
+        // Round down to multiple of 4 * parallelism
+        val segmentLength = memoryBlocks / (SYNC_POINTS * parallelism)
+        val laneLength = segmentLength * SYNC_POINTS
+        val totalBlocks = laneLength * parallelism
+
+        // Allocate memory matrix as flat array of blocks
+        // Each block is 128 ULongs (1024 bytes)
+        val memory = Array(totalBlocks) { ULongArray(QWORDS_PER_BLOCK) }
+
+        // H0 = H(p, salt, ...) — initial hash
+        val h0 = initialHash(
+            password, salt, type, version, tagLength,
+            memoryKB.toInt(), iterations.toInt(), parallelism,
+        )
+
+        // Initialize first two blocks of each lane
+        for (lane in 0 until parallelism) {
+            // B[lane][0] = H'(H0 || 0 || lane)
+            val input0 = ByteArray(ARGON2_PREHASH_DIGEST_LENGTH + 8)
+            h0.copyInto(input0)
+            intToLittleEndian(0, input0, ARGON2_PREHASH_DIGEST_LENGTH)
+            intToLittleEndian(lane, input0, ARGON2_PREHASH_DIGEST_LENGTH + 4)
+            val block0 = variableLengthHash(input0, BLOCK_SIZE)
+            loadBlock(memory[lane * laneLength], block0)
+
+            // B[lane][1] = H'(H0 || 1 || lane)
+            val input1 = ByteArray(ARGON2_PREHASH_DIGEST_LENGTH + 8)
+            h0.copyInto(input1)
+            intToLittleEndian(1, input1, ARGON2_PREHASH_DIGEST_LENGTH)
+            intToLittleEndian(lane, input1, ARGON2_PREHASH_DIGEST_LENGTH + 4)
+            val block1 = variableLengthHash(input1, BLOCK_SIZE)
+            loadBlock(memory[lane * laneLength + 1], block1)
+        }
+
+        // Fill memory (main loop)
+        for (pass in 0 until iterations.toInt()) {
+            for (slice in 0 until SYNC_POINTS) {
+                for (lane in 0 until parallelism) {
+                    fillSegment(
+                        memory, pass, lane, slice,
+                        type, version, iterations.toInt(), parallelism,
+                        segmentLength, laneLength, totalBlocks,
+                    )
+                }
+            }
+        }
+
+        // Finalize: XOR last blocks of all lanes
+        val finalBlock = ULongArray(QWORDS_PER_BLOCK)
+        memory[(parallelism - 1) * laneLength + laneLength - 1].copyInto(finalBlock)
+        for (lane in 0 until parallelism - 1) {
+            val lastBlock = memory[lane * laneLength + laneLength - 1]
+            for (i in 0 until QWORDS_PER_BLOCK) {
+                finalBlock[i] = finalBlock[i] xor lastBlock[i]
+            }
+        }
+
+        val finalBytes = storeBlock(finalBlock)
+        return variableLengthHash(finalBytes, tagLength)
+    }
+
+    /**
+     * Compute the initial hash H0 per RFC 9106 Section 3.
+     */
+    private fun initialHash(
+        password: ByteArray,
+        salt: ByteArray,
+        type: Int,
+        version: Int,
+        tagLength: Int,
+        memoryKB: Int,
+        iterations: Int,
+        parallelism: Int,
+    ): ByteArray {
+        // H0 = Blake2b-512(LE32(p) || LE32(τ) || LE32(m) || LE32(t) ||
+        //                   LE32(v) || LE32(y) || LE32(|P|) || P ||
+        //                   LE32(|S|) || S || LE32(|K|) || K || LE32(|X|) || X)
+        // where K = empty, X = empty for our use case
+        val bufSize = 4 * 7 + // 7 LE32 fields before P
+            password.size + 4 + salt.size + 4 + 4 // |P|, P, |S|, S, |K|=0, |X|=0
+        val buf = ByteArray(bufSize + 4) // extra 4 for |X|
+        var off = 0
+
+        fun putInt(v: Int) { intToLittleEndian(v, buf, off); off += 4 }
+
+        putInt(parallelism)       // p (lanes)
+        putInt(tagLength)         // τ (tag length)
+        putInt(memoryKB)          // m (memory in KB)
+        putInt(iterations)        // t (iterations)
+        putInt(version)           // v (version)
+        putInt(type)              // y (type: 0=d, 2=id)
+        putInt(password.size)     // |P|
+        password.copyInto(buf, off); off += password.size
+        putInt(salt.size)         // |S|
+        salt.copyInto(buf, off); off += salt.size
+        putInt(0)                 // |K| = 0 (no secret)
+        putInt(0)                 // |X| = 0 (no associated data)
+
+        return Blake2b.hash(buf.copyOf(off), ARGON2_PREHASH_DIGEST_LENGTH)
+    }
+
+    /**
+     * Variable-length hash function H' per RFC 9106 Section 3.2.
+     *
+     * For T <= 64: return Blake2b(LE32(T) || X, T)
+     * For T > 64:
+     *   r = ceil(T/32) - 2
+     *   V_1 = Blake2b-64(LE32(T) || X), take first 32 bytes
+     *   V_i = Blake2b-64(V_{i-1}) for i = 2..r, take first 32 bytes each
+     *   V_{r+1} = Blake2b(V_r, T - 32*r), take all bytes
+     *   Output = V_1[0:32] || ... || V_r[0:32] || V_{r+1}
+     */
+    internal fun variableLengthHash(input: ByteArray, tagLength: Int): ByteArray {
+        if (tagLength <= 64) {
+            val lenPrefix = ByteArray(4)
+            intToLittleEndian(tagLength, lenPrefix, 0)
+            return Blake2b.hash(lenPrefix + input, tagLength)
+        }
+
+        val result = ByteArray(tagLength)
+        val lenPrefix = ByteArray(4)
+        intToLittleEndian(tagLength, lenPrefix, 0)
+
+        val r = (tagLength + 31) / 32 - 2 // ceil(T/32) - 2
+
+        // V_1 = Blake2b-64(LE32(T) || input)
+        var vi = Blake2b.hash(lenPrefix + input, 64)
+        vi.copyInto(result, 0, 0, 32)
+        var pos = 32
+
+        // V_2 through V_r: intermediate 64-byte digests, take first 32 bytes each
+        for (i in 2..r) {
+            vi = Blake2b.hash(vi, 64)
+            vi.copyInto(result, pos, 0, 32)
+            pos += 32
+        }
+
+        // V_{r+1}: final block with exactly the remaining bytes
+        val lastSize = tagLength - 32 * r
+        vi = Blake2b.hash(vi, lastSize)
+        vi.copyInto(result, pos, 0, lastSize)
+
+        return result
+    }
+
+    /**
+     * Fill one segment of memory (one slice of one lane).
+     */
+    private fun fillSegment(
+        memory: Array<ULongArray>,
+        pass: Int,
+        lane: Int,
+        slice: Int,
+        type: Int,
+        version: Int,
+        totalPasses: Int,
+        parallelism: Int,
+        segmentLength: Int,
+        laneLength: Int,
+        totalBlocks: Int,
+    ) {
+        val startIndex = if (pass == 0 && slice == 0) 2 else 0
+
+        // For Argon2i/Argon2id: generate pseudo-random values for addressing
+        // Argon2id uses data-independent addressing for first pass, first two slices
+        val useDataIndependent = type == 2 && pass == 0 && slice < 2 // Argon2id
+        var addressBlock = ULongArray(QWORDS_PER_BLOCK)
+        val inputBlock = ULongArray(QWORDS_PER_BLOCK)
+        val zeroBlock = ULongArray(QWORDS_PER_BLOCK)
+
+        if (useDataIndependent) {
+            inputBlock[0] = pass.toULong()
+            inputBlock[1] = lane.toULong()
+            inputBlock[2] = slice.toULong()
+            inputBlock[3] = totalBlocks.toULong()
+            inputBlock[4] = totalPasses.toULong()
+            inputBlock[5] = type.toULong()
+            // Generate first set of addresses (counter = 1)
+            inputBlock[6] = 1uL
+            addressBlock = compressG(zeroBlock, compressG(zeroBlock, inputBlock))
+        }
+
+        for (s in startIndex until segmentLength) {
+            val currentIndex = slice * segmentLength + s
+            val absoluteIndex = lane * laneLength + currentIndex
+
+            // Determine reference indices (j1, j2)
+            val j1: ULong
+            val j2: ULong
+
+            if (useDataIndependent) {
+                // Regenerate address block when positions 0-127 are exhausted
+                if (s != 0 && s % QWORDS_PER_BLOCK == 0) {
+                    inputBlock[6]++
+                    addressBlock = compressG(zeroBlock, compressG(zeroBlock, inputBlock))
+                }
+                // Use segment position as index (matching reference implementation)
+                val addrIdx = s % QWORDS_PER_BLOCK
+                j1 = addressBlock[addrIdx].toUInt().toULong()
+                j2 = (addressBlock[addrIdx] shr 32).toUInt().toULong()
+            } else {
+                // Argon2d: data-dependent
+                val prevIndex = if (currentIndex == 0) {
+                    lane * laneLength + laneLength - 1
+                } else {
+                    absoluteIndex - 1
+                }
+                j1 = memory[prevIndex][0].toUInt().toULong()
+                j2 = (memory[prevIndex][0] shr 32).toUInt().toULong()
+            }
+
+            // Compute reference lane and index
+            val refLane = if (pass == 0 && slice == 0) {
+                lane // Can only reference own lane in first slice of first pass
+            } else {
+                (j2 % parallelism.toULong()).toInt()
+            }
+
+            // Compute reference index within the reference lane
+            val referenceAreaSize: Int
+            if (pass == 0) {
+                if (refLane == lane) {
+                    referenceAreaSize = slice * segmentLength + s - 1
+                } else {
+                    referenceAreaSize = if (s == 0) {
+                        slice * segmentLength - 1
+                    } else {
+                        slice * segmentLength
+                    }
+                }
+            } else {
+                if (refLane == lane) {
+                    referenceAreaSize = laneLength - segmentLength + s - 1
+                } else {
+                    referenceAreaSize = if (s == 0) {
+                        laneLength - segmentLength - 1
+                    } else {
+                        laneLength - segmentLength
+                    }
+                }
+            }
+
+            // Map j1 to an index in the reference area
+            val x = j1 * j1 shr 32
+            val y = (referenceAreaSize.toULong() * x) shr 32
+            val relativePosition = (referenceAreaSize.toULong() - 1uL - y).toInt()
+
+            val startPosition = if (pass == 0) {
+                0
+            } else {
+                (slice + 1) * segmentLength
+            }
+            val refIndex = refLane * laneLength + ((startPosition + relativePosition) % laneLength)
+
+            // Previous block
+            val prevIndex = if (currentIndex == 0) {
+                lane * laneLength + laneLength - 1
+            } else {
+                absoluteIndex - 1
+            }
+
+            // Compute new block: G(prev, ref) XOR current (if not first pass and version 0x13)
+            val newBlock = compressG(memory[prevIndex], memory[refIndex])
+            if (pass > 0 && version == 0x13) {
+                for (i in 0 until QWORDS_PER_BLOCK) {
+                    memory[absoluteIndex][i] = memory[absoluteIndex][i] xor newBlock[i]
+                }
+            } else {
+                newBlock.copyInto(memory[absoluteIndex])
+            }
+        }
+    }
+
+    /**
+     * Compression function G. Takes two 1024-byte blocks and produces a 1024-byte block.
+     * G(X, Y) = X XOR Y XOR permute(X XOR Y)
+     */
+    private fun compressG(x: ULongArray, y: ULongArray): ULongArray {
+        val r = ULongArray(QWORDS_PER_BLOCK)
+        for (i in 0 until QWORDS_PER_BLOCK) {
+            r[i] = x[i] xor y[i]
+        }
+
+        // Save R for final XOR
+        val z = ULongArray(QWORDS_PER_BLOCK)
+        r.copyInto(z)
+
+        // Apply permutation P to rows and columns of 8x8 matrix of 16-byte values
+        // The 1024-byte block is viewed as an 8×8 matrix of 16-byte (128-bit) values,
+        // where each cell contains two ULong values (row-major order).
+
+        // Apply P to each row (8 rows, each with 8 cells = 16 ULongs)
+        for (row in 0 until 8) {
+            val base = row * 16
+            permutationP(
+                r, base, base + 1, base + 2, base + 3,
+                base + 4, base + 5, base + 6, base + 7,
+                base + 8, base + 9, base + 10, base + 11,
+                base + 12, base + 13, base + 14, base + 15,
+            )
+        }
+
+        // Apply P to each column
+        for (col in 0 until 8) {
+            val i0 = col * 2
+            permutationP(
+                r, i0, i0 + 1, i0 + 16, i0 + 17,
+                i0 + 32, i0 + 33, i0 + 48, i0 + 49,
+                i0 + 64, i0 + 65, i0 + 80, i0 + 81,
+                i0 + 96, i0 + 97, i0 + 112, i0 + 113,
+            )
+        }
+
+        // XOR with saved copy
+        for (i in 0 until QWORDS_PER_BLOCK) {
+            r[i] = r[i] xor z[i]
+        }
+
+        return r
+    }
+
+    /**
+     * Permutation P operating on 8 pairs of 64-bit words (v0..v15).
+     * Applies Blake2b-style G mixing function in a specific pattern.
+     */
+    private fun permutationP(
+        v: ULongArray,
+        i0: Int, i1: Int, i2: Int, i3: Int,
+        i4: Int, i5: Int, i6: Int, i7: Int,
+        i8: Int, i9: Int, i10: Int, i11: Int,
+        i12: Int, i13: Int, i14: Int, i15: Int,
+    ) {
+        gb(v, i0, i4, i8, i12)
+        gb(v, i1, i5, i9, i13)
+        gb(v, i2, i6, i10, i14)
+        gb(v, i3, i7, i11, i15)
+        gb(v, i0, i5, i10, i15)
+        gb(v, i1, i6, i11, i12)
+        gb(v, i2, i7, i8, i13)
+        gb(v, i3, i4, i9, i14)
+    }
+
+    /**
+     * Blake2b-based mixing function GB for Argon2.
+     * Different from standard Blake2b G: uses multiplication for diffusion.
+     */
+    private fun gb(v: ULongArray, a: Int, b: Int, c: Int, d: Int) {
+        v[a] = v[a] + v[b] + 2uL * (v[a].toUInt().toULong() * v[b].toUInt().toULong())
+        v[d] = (v[d] xor v[a]).ror64(32)
+        v[c] = v[c] + v[d] + 2uL * (v[c].toUInt().toULong() * v[d].toUInt().toULong())
+        v[b] = (v[b] xor v[c]).ror64(24)
+        v[a] = v[a] + v[b] + 2uL * (v[a].toUInt().toULong() * v[b].toUInt().toULong())
+        v[d] = (v[d] xor v[a]).ror64(16)
+        v[c] = v[c] + v[d] + 2uL * (v[c].toUInt().toULong() * v[d].toUInt().toULong())
+        v[b] = (v[b] xor v[c]).ror64(63)
+    }
+
+    private fun ULong.ror64(n: Int): ULong = (this shr n) or (this shl (64 - n))
+
+    // --- Helpers ---
+
+    private fun loadBlock(block: ULongArray, bytes: ByteArray) {
+        for (i in 0 until QWORDS_PER_BLOCK) {
+            block[i] = littleEndianToULong(bytes, i * 8)
+        }
+    }
+
+    private fun storeBlock(block: ULongArray): ByteArray {
+        val bytes = ByteArray(BLOCK_SIZE)
+        for (i in 0 until QWORDS_PER_BLOCK) {
+            ulongToLittleEndian(block[i], bytes, i * 8)
+        }
+        return bytes
+    }
+
+    private fun intToLittleEndian(value: Int, bytes: ByteArray, offset: Int) {
+        bytes[offset] = value.toByte()
+        bytes[offset + 1] = (value shr 8).toByte()
+        bytes[offset + 2] = (value shr 16).toByte()
+        bytes[offset + 3] = (value shr 24).toByte()
+    }
+
+    private fun littleEndianToULong(bytes: ByteArray, offset: Int): ULong {
+        var value = 0uL
+        for (i in 0 until 8) {
+            value = value or (bytes[offset + i].toUByte().toULong() shl (i * 8))
+        }
+        return value
+    }
+
+    private fun ulongToLittleEndian(value: ULong, bytes: ByteArray, offset: Int) {
+        for (i in 0 until 8) {
+            bytes[offset + i] = (value shr (i * 8)).toByte()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/Blake2b.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/Blake2b.kt
@@ -1,0 +1,157 @@
+package org.github.keepasscompose.core.crypto
+
+/**
+ * Pure Kotlin implementation of BLAKE2b (RFC 7693).
+ * Supports variable output length (1–64 bytes) and optional key (0–64 bytes).
+ *
+ * Used by [Argon2] for hashing within the key derivation algorithm.
+ */
+@OptIn(ExperimentalUnsignedTypes::class)
+internal object Blake2b {
+
+    private const val BLOCK_SIZE = 128 // bytes
+    private const val MAX_DIGEST_SIZE = 64 // bytes
+
+    // Initialization vector (same as SHA-512)
+    private val IV = ulongArrayOf(
+        0x6A09E667F3BCC908uL, 0xBB67AE8584CAA73BuL,
+        0x3C6EF372FE94F82BuL, 0xA54FF53A5F1D36F1uL,
+        0x510E527FADE682D1uL, 0x9B05688C2B3E6C1FuL,
+        0x1F83D9ABFB41BD6BuL, 0x5BE0CD19137E2179uL,
+    )
+
+    // Message schedule permutation (sigma)
+    private val SIGMA = arrayOf(
+        intArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+        intArrayOf(14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3),
+        intArrayOf(11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4),
+        intArrayOf(7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8),
+        intArrayOf(9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13),
+        intArrayOf(2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9),
+        intArrayOf(12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11),
+        intArrayOf(13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10),
+        intArrayOf(6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5),
+        intArrayOf(10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0),
+    )
+
+    /**
+     * Compute BLAKE2b hash of [data] with the specified [digestSize] (1–64).
+     */
+    fun hash(data: ByteArray, digestSize: Int): ByteArray {
+        require(digestSize in 1..MAX_DIGEST_SIZE) { "digestSize must be 1..64" }
+        return hash(data, digestSize, key = null)
+    }
+
+    /**
+     * Compute keyed BLAKE2b hash of [data] with [key] and [digestSize].
+     */
+    fun hash(data: ByteArray, digestSize: Int, key: ByteArray?): ByteArray {
+        require(digestSize in 1..MAX_DIGEST_SIZE) { "digestSize must be 1..64" }
+        val keyLen = key?.size ?: 0
+        require(keyLen <= MAX_DIGEST_SIZE) { "key must be 0..64 bytes" }
+
+        // Initialize state
+        val h = ULongArray(8)
+        IV.copyInto(h)
+        // Parameter block: fanout=1, depth=1, all others 0
+        h[0] = h[0] xor (digestSize.toULong() or (keyLen.toULong() shl 8) or (0x01uL shl 16) or (0x01uL shl 24))
+
+        var bytesCompressed = 0uL
+        val buffer = ByteArray(BLOCK_SIZE)
+        var bufferLen = 0
+
+        // If keyed, the first block is the padded key
+        if (key != null && keyLen > 0) {
+            key.copyInto(buffer)
+            // rest is already zero-filled
+            bufferLen = BLOCK_SIZE
+        }
+
+        // Process data
+        var offset = 0
+        val remaining = data.size
+
+        while (offset < remaining) {
+            // If buffer is full, compress it (it's not the last block because we still have data)
+            if (bufferLen == BLOCK_SIZE) {
+                bytesCompressed += BLOCK_SIZE.toULong()
+                compress(h, buffer, bytesCompressed, lastBlock = false)
+                bufferLen = 0
+            }
+            val toCopy = minOf(BLOCK_SIZE - bufferLen, remaining - offset)
+            data.copyInto(buffer, bufferLen, offset, offset + toCopy)
+            bufferLen += toCopy
+            offset += toCopy
+        }
+
+        // Final block
+        bytesCompressed += bufferLen.toULong()
+        // Pad with zeros
+        for (i in bufferLen until BLOCK_SIZE) {
+            buffer[i] = 0
+        }
+        compress(h, buffer, bytesCompressed, lastBlock = true)
+
+        // Produce output
+        val output = ByteArray(digestSize)
+        for (i in 0 until digestSize) {
+            output[i] = (h[i / 8] shr (8 * (i % 8))).toByte()
+        }
+        return output
+    }
+
+    private fun compress(h: ULongArray, block: ByteArray, t: ULong, lastBlock: Boolean) {
+        // Initialize working vector
+        val v = ULongArray(16)
+        h.copyInto(v, 0, 0, 8)
+        IV.copyInto(v, 8, 0, 8)
+
+        v[12] = v[12] xor t // low word of counter
+        // v[13] = v[13] xor 0 (high word of counter, not needed for < 2^64 bytes)
+        if (lastBlock) {
+            v[14] = v[14].inv()
+        }
+
+        // Parse block into 16 message words (little-endian)
+        val m = ULongArray(16)
+        for (i in 0 until 16) {
+            m[i] = littleEndianToULong(block, i * 8)
+        }
+
+        // 12 rounds of mixing
+        for (round in 0 until 12) {
+            val s = SIGMA[round % 10]
+            mix(v, 0, 4, 8, 12, m[s[0]], m[s[1]])
+            mix(v, 1, 5, 9, 13, m[s[2]], m[s[3]])
+            mix(v, 2, 6, 10, 14, m[s[4]], m[s[5]])
+            mix(v, 3, 7, 11, 15, m[s[6]], m[s[7]])
+            mix(v, 0, 5, 10, 15, m[s[8]], m[s[9]])
+            mix(v, 1, 6, 11, 12, m[s[10]], m[s[11]])
+            mix(v, 2, 7, 8, 13, m[s[12]], m[s[13]])
+            mix(v, 3, 4, 9, 14, m[s[14]], m[s[15]])
+        }
+
+        // Finalize
+        for (i in 0 until 8) {
+            h[i] = h[i] xor v[i] xor v[i + 8]
+        }
+    }
+
+    private fun mix(v: ULongArray, a: Int, b: Int, c: Int, d: Int, x: ULong, y: ULong) {
+        v[a] += v[b] + x; v[d] = (v[d] xor v[a]).rotateRight(32)
+        v[c] += v[d];      v[b] = (v[b] xor v[c]).rotateRight(24)
+        v[a] += v[b] + y;  v[d] = (v[d] xor v[a]).rotateRight(16)
+        v[c] += v[d];      v[b] = (v[b] xor v[c]).rotateRight(63)
+    }
+
+    private fun littleEndianToULong(bytes: ByteArray, offset: Int): ULong {
+        var value = 0uL
+        for (i in 0 until 8) {
+            value = value or (bytes[offset + i].toUByte().toULong() shl (i * 8))
+        }
+        return value
+    }
+
+    private fun ULong.rotateRight(n: Int): ULong =
+        (this shr n) or (this shl (64 - n))
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProvider.ios.kt
@@ -131,7 +131,7 @@ actual class PlatformCryptoProvider actual constructor() : CryptoProvider {
         iterations: Long,
         parallelism: Int,
     ): ByteArray {
-        TODO("iOS: Implement via libsodium crypto_pwhash")
+        return Argon2.derive(password, salt, variant, version, memory, iterations, parallelism)
     }
 
     override fun chaCha20(data: ByteArray, key: ByteArray, nonce: ByteArray): ByteArray {

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/Blake2bTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/Blake2bTest.kt
@@ -1,0 +1,88 @@
+package org.github.keepasscompose.core.crypto
+
+import org.bouncycastle.crypto.digests.Blake2bDigest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the pure Kotlin Blake2b implementation.
+ * Cross-validates against BouncyCastle's Blake2bDigest.
+ */
+class Blake2bTest {
+
+    private fun bouncyCastleBlake2b(data: ByteArray, digestSize: Int): ByteArray {
+        val digest = Blake2bDigest(digestSize * 8)
+        digest.update(data, 0, data.size)
+        val result = ByteArray(digestSize)
+        digest.doFinal(result, 0)
+        return result
+    }
+
+    @Test
+    fun blake2b_emptyInput_matchesBouncyCastle() {
+        val bc = bouncyCastleBlake2b(ByteArray(0), 64)
+        val pk = Blake2b.hash(ByteArray(0), 64)
+        assertContentEquals(bc, pk)
+    }
+
+    @Test
+    fun blake2b_abc_matchesBouncyCastle() {
+        val data = "abc".encodeToByteArray()
+        val bc = bouncyCastleBlake2b(data, 64)
+        val pk = Blake2b.hash(data, 64)
+        assertContentEquals(bc, pk, "BLAKE2b-512(\"abc\") must match BouncyCastle")
+    }
+
+    @Test
+    fun blake2b_shortInput_matchesBouncyCastle() {
+        for (len in listOf(1, 3, 15, 16, 31, 32, 63, 64, 127)) {
+            val data = ByteArray(len) { (it * 7 + 3).toByte() }
+            val bc = bouncyCastleBlake2b(data, 64)
+            val pk = Blake2b.hash(data, 64)
+            assertContentEquals(bc, pk, "BLAKE2b-512 mismatch for input length $len")
+        }
+    }
+
+    @Test
+    fun blake2b_exactlyOneBlock_matchesBouncyCastle() {
+        val data = ByteArray(128) { it.toByte() }
+        val bc = bouncyCastleBlake2b(data, 64)
+        val pk = Blake2b.hash(data, 64)
+        assertContentEquals(bc, pk)
+    }
+
+    @Test
+    fun blake2b_multiBlock_matchesBouncyCastle() {
+        val data = ByteArray(200) { (it % 251).toByte() }
+        val bc = bouncyCastleBlake2b(data, 64)
+        val pk = Blake2b.hash(data, 64)
+        assertContentEquals(bc, pk)
+    }
+
+    @Test
+    fun blake2b_variousDigestSizes_matchBouncyCastle() {
+        val data = "test data".encodeToByteArray()
+        for (digestSize in listOf(1, 16, 20, 32, 48, 64)) {
+            val bc = bouncyCastleBlake2b(data, digestSize)
+            val pk = Blake2b.hash(data, digestSize)
+            assertContentEquals(bc, pk, "Digest size $digestSize mismatch")
+        }
+    }
+
+    @Test
+    fun blake2b_outputLength() {
+        for (len in listOf(1, 16, 32, 48, 64)) {
+            val result = Blake2b.hash("test".encodeToByteArray(), len)
+            assertEquals(len, result.size, "Output length should be $len")
+        }
+    }
+
+    @Test
+    fun blake2b_deterministic() {
+        val data = "determinism".encodeToByteArray()
+        val r1 = Blake2b.hash(data, 64)
+        val r2 = Blake2b.hash(data, 64)
+        assertContentEquals(r1, r2)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProviderArgon2Test.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/PlatformCryptoProviderArgon2Test.kt
@@ -1,0 +1,154 @@
+package org.github.keepasscompose.core.crypto
+
+import org.github.keepasscompose.core.model.Argon2Variant
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Tests for Argon2 key derivation (KDBX 4.x).
+ *
+ * Cross-validates the pure Kotlin implementation against BouncyCastle.
+ * Tests cover both Argon2d and Argon2id variants.
+ */
+class PlatformCryptoProviderArgon2Test {
+
+    private val crypto = PlatformCryptoProvider()
+
+    // --- Cross-validation: pure Kotlin vs BouncyCastle ---
+
+    @Test
+    fun argon2d_pureKotlin_matchesBouncyCastle() {
+        val password = "testpassword".encodeToByteArray()
+        val salt = ByteArray(16) { (it * 3).toByte() }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2D, 0x13, 64, 2, 2)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2D, 0x13, 64, 2, 2)
+        assertContentEquals(
+            bcResult, pkResult,
+            "Pure Kotlin Argon2d must match BouncyCastle output",
+        )
+    }
+
+    @Test
+    fun argon2id_pureKotlin_matchesBouncyCastle() {
+        val password = "testpassword".encodeToByteArray()
+        val salt = ByteArray(16) { (it * 3).toByte() }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 64, 2, 2)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2ID, 0x13, 64, 2, 2)
+        assertContentEquals(
+            bcResult, pkResult,
+            "Pure Kotlin Argon2id must match BouncyCastle output",
+        )
+    }
+
+    @Test
+    fun argon2d_pureKotlin_matchesBouncyCastle_rfcParams() {
+        // RFC 9106 parameters (without key/AD, which our interface doesn't support)
+        val password = ByteArray(32) { 0x01 }
+        val salt = ByteArray(16) { 0x02 }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2D, 0x13, 32, 3, 4)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2D, 0x13, 32, 3, 4)
+        assertContentEquals(bcResult, pkResult)
+    }
+
+    @Test
+    fun argon2id_pureKotlin_matchesBouncyCastle_rfcParams() {
+        val password = ByteArray(32) { 0x01 }
+        val salt = ByteArray(16) { 0x02 }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 3, 4)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 3, 4)
+        assertContentEquals(bcResult, pkResult)
+    }
+
+    @Test
+    fun argon2_pureKotlin_matchesBouncyCastle_singleLane() {
+        val password = "singlelane".encodeToByteArray()
+        val salt = ByteArray(16) { 0xFF.toByte() }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 2, 1)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 2, 1)
+        assertContentEquals(bcResult, pkResult, "Single-lane Argon2id must match")
+    }
+
+    @Test
+    fun argon2_pureKotlin_matchesBouncyCastle_higherMemory() {
+        val password = "highmemory".encodeToByteArray()
+        val salt = ByteArray(16) { (it * 7).toByte() }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 256, 1, 2)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2ID, 0x13, 256, 1, 2)
+        assertContentEquals(bcResult, pkResult, "Higher memory Argon2id must match")
+    }
+
+    @Test
+    fun argon2d_pureKotlin_matchesBouncyCastle_singleIteration() {
+        val password = "quick".encodeToByteArray()
+        val salt = ByteArray(16) { it.toByte() }
+        val bcResult = crypto.argon2(password, salt, Argon2Variant.ARGON2D, 0x13, 32, 1, 1)
+        val pkResult = Argon2.derive(password, salt, Argon2Variant.ARGON2D, 0x13, 32, 1, 1)
+        assertContentEquals(bcResult, pkResult, "Single-iteration Argon2d must match")
+    }
+
+    // --- Behavioral tests ---
+
+    @Test
+    fun argon2_outputLength() {
+        val password = "password".encodeToByteArray()
+        val salt = ByteArray(16) { it.toByte() }
+        val result = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        assertEquals(32, result.size, "Output must be 32 bytes")
+    }
+
+    @Test
+    fun argon2_deterministic() {
+        val password = "password".encodeToByteArray()
+        val salt = ByteArray(16) { it.toByte() }
+        val result1 = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        val result2 = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        assertContentEquals(result1, result2)
+    }
+
+    @Test
+    fun argon2_passwordSensitivity() {
+        val salt = ByteArray(16) { it.toByte() }
+        val result1 = crypto.argon2("password1".encodeToByteArray(), salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        val result2 = crypto.argon2("password2".encodeToByteArray(), salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        assertFalse(result1.contentEquals(result2), "Different passwords must produce different output")
+    }
+
+    @Test
+    fun argon2_saltSensitivity() {
+        val password = "password".encodeToByteArray()
+        val salt1 = ByteArray(16) { it.toByte() }
+        val salt2 = ByteArray(16) { (it + 1).toByte() }
+        val result1 = crypto.argon2(password, salt1, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        val result2 = crypto.argon2(password, salt2, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        assertFalse(result1.contentEquals(result2), "Different salts must produce different output")
+    }
+
+    @Test
+    fun argon2_variantSensitivity() {
+        val password = "password".encodeToByteArray()
+        val salt = ByteArray(16) { it.toByte() }
+        val resultD = crypto.argon2(password, salt, Argon2Variant.ARGON2D, 0x13, 32, 1, 1)
+        val resultID = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        assertFalse(resultD.contentEquals(resultID), "Argon2d and Argon2id must produce different output")
+    }
+
+    @Test
+    fun argon2_iterationSensitivity() {
+        val password = "password".encodeToByteArray()
+        val salt = ByteArray(16) { it.toByte() }
+        val result1 = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        val result2 = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 2, 1)
+        assertFalse(result1.contentEquals(result2), "Different iterations must produce different output")
+    }
+
+    @Test
+    fun argon2_memorySensitivity() {
+        val password = "password".encodeToByteArray()
+        val salt = ByteArray(16) { it.toByte() }
+        val result1 = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        val result2 = crypto.argon2(password, salt, Argon2Variant.ARGON2ID, 0x13, 64, 1, 1)
+        assertFalse(result1.contentEquals(result2), "Different memory costs must produce different output")
+    }
+}


### PR DESCRIPTION
## Summary
- Add pure Kotlin Blake2b (RFC 7693) and Argon2 (RFC 9106) implementations in `commonMain`
- Support Argon2d and Argon2id variants with configurable memory, iterations, and parallelism
- Wire up iOS `PlatformCryptoProvider` to use the pure Kotlin Argon2 (JVM/Android continue using BouncyCastle)
- Add cross-validation tests ensuring pure Kotlin output matches BouncyCastle, plus behavioral tests for sensitivity and determinism

## Ticket
3.5

## Test plan
- [x] Blake2b cross-validated against BouncyCastle (empty, short, single-block, multi-block, various digest sizes)
- [x] Argon2d pure Kotlin matches BouncyCastle (multiple parameter combinations)
- [x] Argon2id pure Kotlin matches BouncyCastle (single lane, higher memory, RFC-like params)
- [x] Behavioral tests: determinism, password/salt/variant/iteration/memory sensitivity
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)