### PR TITLE
[4.5] Build toolbar component

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/Toolbar.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/Toolbar.kt
@@ -1,0 +1,102 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+data class ToolbarCallbacks(
+    val onNewDatabase: () -> Unit = {},
+    val onOpenDatabase: () -> Unit = {},
+    val onSaveDatabase: () -> Unit = {},
+    val onLockDatabase: () -> Unit = {},
+    val onSearch: () -> Unit = {},
+    val onNewEntry: () -> Unit = {},
+    val onEditEntry: () -> Unit = {},
+    val onDeleteEntry: () -> Unit = {},
+    val onCopyUsername: () -> Unit = {},
+    val onCopyPassword: () -> Unit = {},
+)
+
+@Composable
+fun Toolbar(
+    callbacks: ToolbarCallbacks,
+    hasSelectedEntry: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        // Database actions
+        ToolbarButton(Icons.AutoMirrored.Filled.NoteAdd, "New Database", onClick = callbacks.onNewDatabase)
+        ToolbarButton(Icons.Filled.FolderOpen, "Open Database", onClick = callbacks.onOpenDatabase)
+        ToolbarButton(Icons.Filled.Save, "Save Database", onClick = callbacks.onSaveDatabase)
+        ToolbarButton(Icons.Filled.Lock, "Lock Database", onClick = callbacks.onLockDatabase)
+        ToolbarButton(Icons.Filled.Search, "Search", onClick = callbacks.onSearch)
+
+        VerticalDivider(modifier = Modifier.padding(horizontal = 4.dp))
+
+        // Entry actions (enabled when an entry is selected)
+        ToolbarButton(Icons.AutoMirrored.Filled.NoteAdd, "New Entry", onClick = callbacks.onNewEntry)
+        ToolbarButton(Icons.Filled.Edit, "Edit Entry", onClick = callbacks.onEditEntry, enabled = hasSelectedEntry)
+        ToolbarButton(Icons.Filled.Delete, "Delete Entry", onClick = callbacks.onDeleteEntry, enabled = hasSelectedEntry)
+
+        VerticalDivider(modifier = Modifier.padding(horizontal = 4.dp))
+
+        // Quick copy actions
+        ToolbarButton(Icons.Filled.Person, "Copy Username", onClick = callbacks.onCopyUsername, enabled = hasSelectedEntry)
+        ToolbarButton(Icons.Filled.Key, "Copy Password", onClick = callbacks.onCopyPassword, enabled = hasSelectedEntry)
+    }
+}
+
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ToolbarButton(
+    icon: ImageVector,
+    tooltip: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+        tooltip = { PlainTooltip { Text(tooltip) } },
+        state = rememberTooltipState(),
+    ) {
+        IconButton(onClick = onClick, enabled = enabled) {
+            Icon(
+                icon,
+                contentDescription = tooltip,
+                tint = if (enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -14,13 +14,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -52,6 +48,8 @@ import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.launch
 import org.github.keepasscompose.ui.components.DatabaseTab
 import org.github.keepasscompose.ui.components.DatabaseTabBar
+import org.github.keepasscompose.ui.components.Toolbar
+import org.github.keepasscompose.ui.components.ToolbarCallbacks
 
 @Composable
 fun MainScreen(
@@ -59,13 +57,10 @@ fun MainScreen(
     entryCount: Int = 0,
     tabs: List<DatabaseTab> = emptyList(),
     selectedTabId: String = "",
+    hasSelectedEntry: Boolean = false,
+    toolbarCallbacks: ToolbarCallbacks = ToolbarCallbacks(),
     onTabSelected: (String) -> Unit = {},
     onTabClosed: (String) -> Unit = {},
-    onNewEntry: () -> Unit = {},
-    onOpenDatabase: () -> Unit = {},
-    onSaveDatabase: () -> Unit = {},
-    onLockDatabase: () -> Unit = {},
-    onSearch: () -> Unit = {},
 ) {
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     val isCompact = !windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
@@ -73,10 +68,10 @@ fun MainScreen(
     if (isCompact) {
         MobileMainScreen(
             databaseName = databaseName,
-            onNewEntry = onNewEntry,
-            onOpenDatabase = onOpenDatabase,
-            onLockDatabase = onLockDatabase,
-            onSearch = onSearch,
+            onNewEntry = toolbarCallbacks.onNewEntry,
+            onOpenDatabase = toolbarCallbacks.onOpenDatabase,
+            onLockDatabase = toolbarCallbacks.onLockDatabase,
+            onSearch = toolbarCallbacks.onSearch,
         )
     } else {
         DesktopMainScreen(
@@ -84,13 +79,10 @@ fun MainScreen(
             entryCount = entryCount,
             tabs = tabs,
             selectedTabId = selectedTabId,
+            hasSelectedEntry = hasSelectedEntry,
+            toolbarCallbacks = toolbarCallbacks,
             onTabSelected = onTabSelected,
             onTabClosed = onTabClosed,
-            onNewEntry = onNewEntry,
-            onOpenDatabase = onOpenDatabase,
-            onSaveDatabase = onSaveDatabase,
-            onLockDatabase = onLockDatabase,
-            onSearch = onSearch,
         )
     }
 }
@@ -106,48 +98,34 @@ private fun DesktopMainScreen(
     entryCount: Int,
     tabs: List<DatabaseTab>,
     selectedTabId: String,
+    hasSelectedEntry: Boolean,
+    toolbarCallbacks: ToolbarCallbacks,
     onTabSelected: (String) -> Unit,
     onTabClosed: (String) -> Unit,
-    onNewEntry: () -> Unit,
-    onOpenDatabase: () -> Unit,
-    onSaveDatabase: () -> Unit,
-    onLockDatabase: () -> Unit,
-    onSearch: () -> Unit,
 ) {
     Scaffold(
         topBar = {
             Column {
                 TopAppBar(
                     title = { Text(databaseName.ifEmpty { "KeePass Compose" }) },
-                actions = {
-                    IconButton(onClick = onNewEntry) {
-                        Icon(Icons.AutoMirrored.Filled.NoteAdd, contentDescription = "New Entry")
-                    }
-                    IconButton(onClick = onOpenDatabase) {
-                        Icon(Icons.Filled.FolderOpen, contentDescription = "Open Database")
-                    }
-                    IconButton(onClick = onSaveDatabase) {
-                        Icon(Icons.Filled.Save, contentDescription = "Save Database")
-                    }
-                    IconButton(onClick = onLockDatabase) {
-                        Icon(Icons.Filled.Lock, contentDescription = "Lock Database")
-                    }
-                    IconButton(onClick = onSearch) {
-                        Icon(Icons.Filled.Search, contentDescription = "Search")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface,
-                ),
-            )
+                    actions = {
+                        Toolbar(
+                            callbacks = toolbarCallbacks,
+                            hasSelectedEntry = hasSelectedEntry,
+                        )
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                )
                 if (tabs.isNotEmpty()) {
                     DatabaseTabBar(
                         tabs = tabs,
                         selectedTabId = selectedTabId,
                         onTabSelected = onTabSelected,
                         onTabClosed = onTabClosed,
-                        onNewTab = onOpenDatabase,
+                        onNewTab = toolbarCallbacks.onOpenDatabase,
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- Create `Toolbar.kt` component with database actions (New, Open, Save, Lock, Search), entry actions (New, Edit, Delete), and quick copy buttons (Username, Password)
- Entry-specific actions are disabled when no entry is selected (`hasSelectedEntry` flag)
- Tooltips on hover via Material3 `TooltipBox`/`PlainTooltip`
- Extract `ToolbarCallbacks` data class to consolidate all action callbacks
- Integrate `Toolbar` into `DesktopMainScreen` top app bar, replacing inline icon buttons
- Refactor `MainScreen` to use `ToolbarCallbacks` instead of individual callback params

Closes #37

## Test plan
- [x] JVM target compiles with no warnings
- [ ] Verify all toolbar icons render in desktop layout
- [ ] Verify entry actions are disabled when no entry is selected
- [ ] Verify tooltips appear on hover (desktop)
- [ ] Verify mobile layout still uses simplified top bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)