### PR TITLE
[4.6] Implement keyboard shortcuts (Desktop)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -50,6 +50,7 @@ import org.github.keepasscompose.ui.components.DatabaseTab
 import org.github.keepasscompose.ui.components.DatabaseTabBar
 import org.github.keepasscompose.ui.components.Toolbar
 import org.github.keepasscompose.ui.components.ToolbarCallbacks
+import org.github.keepasscompose.ui.shortcuts.keyboardShortcuts
 
 @Composable
 fun MainScreen(
@@ -104,6 +105,10 @@ private fun DesktopMainScreen(
     onTabClosed: (String) -> Unit,
 ) {
     Scaffold(
+        modifier = Modifier.keyboardShortcuts(
+            callbacks = toolbarCallbacks,
+            hasSelectedEntry = hasSelectedEntry,
+        ),
         topBar = {
             Column {
                 TopAppBar(

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/shortcuts/KeyboardShortcuts.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/shortcuts/KeyboardShortcuts.kt
@@ -1,0 +1,35 @@
+package org.github.keepasscompose.ui.shortcuts
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import org.github.keepasscompose.ui.components.ToolbarCallbacks
+
+fun Modifier.keyboardShortcuts(
+    callbacks: ToolbarCallbacks,
+    hasSelectedEntry: Boolean = false,
+): Modifier = onPreviewKeyEvent { event ->
+    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+
+    when {
+        event.isCtrlPressed -> when (event.key) {
+            Key.N -> { callbacks.onNewDatabase(); true }
+            Key.O -> { callbacks.onOpenDatabase(); true }
+            Key.S -> { callbacks.onSaveDatabase(); true }
+            Key.L -> { callbacks.onLockDatabase(); true }
+            Key.F -> { callbacks.onSearch(); true }
+            Key.B -> if (hasSelectedEntry) { callbacks.onCopyUsername(); true } else false
+            Key.C -> if (hasSelectedEntry) { callbacks.onCopyPassword(); true } else false
+            Key.E -> if (hasSelectedEntry) { callbacks.onEditEntry(); true } else false
+            else -> false
+        }
+        event.key == Key.Delete -> if (hasSelectedEntry) {
+            callbacks.onDeleteEntry(); true
+        } else false
+        else -> false
+    }
+}


### PR DESCRIPTION
## Summary
- Create `KeyboardShortcuts.kt` with `Modifier.keyboardShortcuts()` extension
- Shortcuts: Ctrl+N (new db), Ctrl+O (open), Ctrl+S (save), Ctrl+L (lock), Ctrl+F (search), Ctrl+B (copy username), Ctrl+C (copy password), Ctrl+E (edit entry), Delete (delete entry)
- Entry-specific shortcuts only fire when an entry is selected
- Applied to desktop `Scaffold` via `onPreviewKeyEvent`

Closes #38

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify Ctrl+N/O/S/L/F trigger database actions
- [ ] Verify Ctrl+B/C/E and Delete trigger entry actions only with selection
- [ ] Verify shortcuts don't interfere with text input fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)