### PR TITLE
[4.7] Implement context menus

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/EntryContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/EntryContextMenu.kt
@@ -1,0 +1,73 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+data class EntryContextMenuCallbacks(
+    val onCopyUsername: () -> Unit = {},
+    val onCopyPassword: () -> Unit = {},
+    val onCopyUrl: () -> Unit = {},
+    val onEdit: () -> Unit = {},
+    val onDelete: () -> Unit = {},
+    val onOpenUrl: () -> Unit = {},
+)
+
+@Composable
+fun EntryContextMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    callbacks: EntryContextMenuCallbacks,
+    modifier: Modifier = Modifier,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        DropdownMenuItem(
+            text = { Text("Copy Username") },
+            onClick = { callbacks.onCopyUsername(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Person, contentDescription = null) },
+        )
+        DropdownMenuItem(
+            text = { Text("Copy Password") },
+            onClick = { callbacks.onCopyPassword(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Key, contentDescription = null) },
+        )
+        DropdownMenuItem(
+            text = { Text("Copy URL") },
+            onClick = { callbacks.onCopyUrl(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Link, contentDescription = null) },
+        )
+        HorizontalDivider()
+        DropdownMenuItem(
+            text = { Text("Edit Entry") },
+            onClick = { callbacks.onEdit(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Edit, contentDescription = null) },
+        )
+        DropdownMenuItem(
+            text = { Text("Delete Entry") },
+            onClick = { callbacks.onDelete(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Delete, contentDescription = null) },
+        )
+        HorizontalDivider()
+        DropdownMenuItem(
+            text = { Text("Open URL") },
+            onClick = { callbacks.onOpenUrl(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.OpenInBrowser, contentDescription = null) },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupContextMenu.kt
@@ -1,0 +1,68 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DeleteSweep
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+data class GroupContextMenuCallbacks(
+    val onNewEntry: () -> Unit = {},
+    val onNewSubGroup: () -> Unit = {},
+    val onEdit: () -> Unit = {},
+    val onDelete: () -> Unit = {},
+    val onEmptyRecycleBin: () -> Unit = {},
+)
+
+@Composable
+fun GroupContextMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    callbacks: GroupContextMenuCallbacks,
+    isRecycleBin: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        DropdownMenuItem(
+            text = { Text("New Entry") },
+            onClick = { callbacks.onNewEntry(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.AutoMirrored.Filled.NoteAdd, contentDescription = null) },
+        )
+        DropdownMenuItem(
+            text = { Text("New Sub-Group") },
+            onClick = { callbacks.onNewSubGroup(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.CreateNewFolder, contentDescription = null) },
+        )
+        HorizontalDivider()
+        DropdownMenuItem(
+            text = { Text("Edit Group") },
+            onClick = { callbacks.onEdit(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Edit, contentDescription = null) },
+        )
+        DropdownMenuItem(
+            text = { Text("Delete Group") },
+            onClick = { callbacks.onDelete(); onDismissRequest() },
+            leadingIcon = { Icon(Icons.Filled.Delete, contentDescription = null) },
+        )
+        if (isRecycleBin) {
+            HorizontalDivider()
+            DropdownMenuItem(
+                text = { Text("Empty Recycle Bin") },
+                onClick = { callbacks.onEmptyRecycleBin(); onDismissRequest() },
+                leadingIcon = { Icon(Icons.Filled.DeleteSweep, contentDescription = null) },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create `EntryContextMenu.kt` — right-click menu for entries: Copy Username, Copy Password, Copy URL, Edit, Delete, Open URL
- Create `GroupContextMenu.kt` — right-click menu for groups: New Entry, New Sub-Group, Edit, Delete, and Empty Recycle Bin (shown conditionally via `isRecycleBin` flag)
- Both components use Material3 `DropdownMenu` with `DropdownMenuItem`, icons, and dividers
- Callback data classes (`EntryContextMenuCallbacks`, `GroupContextMenuCallbacks`) for clean wiring

Closes #39

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify entry context menu shows all 6 actions
- [ ] Verify group context menu shows 4 actions (5 for recycle bin)
- [ ] Verify menus dismiss on item click and outside click

🤖 Generated with [Claude Code](https://claude.com/claude-code)