### PR TITLE
[3.10] Implement composite key derivation

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/CompositeKeyDerivation.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/crypto/CompositeKeyDerivation.kt
@@ -1,0 +1,117 @@
+package org.github.keepasscompose.core.crypto
+
+import org.github.keepasscompose.core.model.CompositeKey
+import org.github.keepasscompose.core.model.KdfParameters
+
+/**
+ * Implements KeePass composite key derivation.
+ *
+ * The derivation combines password, key file, and optional hardware key into a
+ * single master key suitable for encrypting/decrypting a KDBX database.
+ *
+ * Flow:
+ * 1. **Composite key hash**: SHA-256 of concatenated per-credential hashes
+ * 2. **Transformed key**: Apply KDF (AES-KDF or Argon2) to the composite key hash
+ * 3. **Master key**: SHA-256(masterSeed || transformedKey)
+ *
+ * For KDBX 4.x HMAC verification, the base key is derived separately:
+ *   SHA-512(masterSeed || transformedKey || 0x01)
+ */
+class CompositeKeyDerivation(private val crypto: CryptoProvider) {
+
+    /**
+     * Result of the full key derivation, containing both the master key
+     * (used for payload encryption) and the transformed key (used for HMAC).
+     */
+    data class DerivedKeys(
+        val masterKey: ByteArray,
+        val transformedKey: ByteArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is DerivedKeys) return false
+            return masterKey.contentEquals(other.masterKey) &&
+                transformedKey.contentEquals(other.transformedKey)
+        }
+
+        override fun hashCode(): Int {
+            var result = masterKey.contentHashCode()
+            result = 31 * result + transformedKey.contentHashCode()
+            return result
+        }
+    }
+
+    /**
+     * Derive the master key and transformed key from a composite key and header parameters.
+     *
+     * @param compositeKey The user's credentials (password, key file, hardware key).
+     * @param masterSeed The 32-byte random seed from the KDBX header.
+     * @param kdfParameters The KDF algorithm and its parameters from the header.
+     * @return [DerivedKeys] containing the master key and transformed key.
+     * @throws IllegalArgumentException if the composite key has no credentials.
+     */
+    fun deriveKeys(
+        compositeKey: CompositeKey,
+        masterSeed: ByteArray,
+        kdfParameters: KdfParameters,
+    ): DerivedKeys {
+        val compositeKeyHash = deriveCompositeKeyHash(compositeKey)
+        val transformedKey = deriveTransformedKey(compositeKeyHash, kdfParameters)
+        val masterKey = crypto.sha256(masterSeed + transformedKey)
+        return DerivedKeys(masterKey, transformedKey)
+    }
+
+    /**
+     * Build the composite key hash: SHA-256 of the concatenation of each credential's
+     * individual hash. Password: SHA-256(utf8Bytes). Key file: SHA-256(data).
+     * Hardware key challenge is included as-is.
+     */
+    fun deriveCompositeKeyHash(compositeKey: CompositeKey): ByteArray {
+        val parts = mutableListOf<ByteArray>()
+
+        compositeKey.password?.let { password ->
+            parts.add(crypto.sha256(password.encodeToByteArray()))
+        }
+        compositeKey.keyFileData?.let { keyData ->
+            parts.add(crypto.sha256(keyData))
+        }
+        compositeKey.hardwareKeyChallenge?.let { challenge ->
+            parts.add(challenge)
+        }
+
+        require(parts.isNotEmpty()) { "Composite key must contain at least one credential" }
+
+        val concatenated = parts.fold(ByteArray(0)) { acc, part -> acc + part }
+        return crypto.sha256(concatenated)
+    }
+
+    /**
+     * Apply the KDF to the composite key hash to produce the transformed key.
+     */
+    fun deriveTransformedKey(
+        compositeKeyHash: ByteArray,
+        kdfParameters: KdfParameters,
+    ): ByteArray = when (kdfParameters) {
+        is KdfParameters.AesKdf -> {
+            val transformed = crypto.aesKdf(compositeKeyHash, kdfParameters.seed, kdfParameters.rounds)
+            crypto.sha256(transformed)
+        }
+        is KdfParameters.Argon2 -> {
+            crypto.argon2(
+                password = compositeKeyHash,
+                salt = kdfParameters.salt,
+                variant = kdfParameters.variant,
+                version = kdfParameters.version,
+                memory = kdfParameters.memory,
+                iterations = kdfParameters.iterations,
+                parallelism = kdfParameters.parallelism,
+            )
+        }
+    }
+
+    /**
+     * Compute the HMAC base key for KDBX 4.x header and block verification.
+     */
+    fun computeHmacBaseKey(masterSeed: ByteArray, transformedKey: ByteArray): ByteArray =
+        crypto.sha512(masterSeed + transformedKey + byteArrayOf(0x01))
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxReader.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxReader.kt
@@ -2,13 +2,13 @@ package org.github.keepasscompose.core.database
 
 import okio.Buffer
 import okio.BufferedSource
+import org.github.keepasscompose.core.crypto.CompositeKeyDerivation
 import org.github.keepasscompose.core.crypto.CryptoProvider
 import org.github.keepasscompose.core.model.CipherId
 import org.github.keepasscompose.core.model.CompositeKey
 import org.github.keepasscompose.core.model.CompressionAlgorithm
 import org.github.keepasscompose.core.model.InnerStreamCipher
 import org.github.keepasscompose.core.model.KdbxDatabase
-import org.github.keepasscompose.core.model.KdfParameters
 
 /**
  * Orchestrates reading a KDBX file by combining header parsing, key derivation,
@@ -19,6 +19,8 @@ import org.github.keepasscompose.core.model.KdfParameters
  * @param crypto Platform-specific cryptographic provider.
  */
 class KdbxReader(private val crypto: CryptoProvider) {
+
+    private val keyDerivation = CompositeKeyDerivation(crypto)
 
     /**
      * Reads and decrypts a KDBX database from a byte array.
@@ -47,9 +49,9 @@ class KdbxReader(private val crypto: CryptoProvider) {
         val header = headerResult.header
 
         // 2. Derive keys
-        val compositeKeyHash = deriveCompositeKeyHash(compositeKey)
-        val transformedKey = deriveTransformedKey(compositeKeyHash, header.kdfParameters)
-        val masterKey = crypto.sha256(header.masterSeed + transformedKey)
+        val keys = keyDerivation.deriveKeys(compositeKey, header.masterSeed, header.kdfParameters)
+        val masterKey = keys.masterKey
+        val transformedKey = keys.transformedKey
 
         // 3. Verify and read encrypted payload
         val encryptedPayload: ByteArray
@@ -112,56 +114,6 @@ class KdbxReader(private val crypto: CryptoProvider) {
         )
     }
 
-    // -- Composite key derivation --
-
-    /**
-     * Builds the composite key hash: SHA-256 of the concatenation of each credential's
-     * individual hash. For password: SHA-256(SHA-256(utf8Bytes)). For key file: SHA-256(data).
-     */
-    private fun deriveCompositeKeyHash(compositeKey: CompositeKey): ByteArray {
-        val parts = mutableListOf<ByteArray>()
-
-        compositeKey.password?.let { password ->
-            parts.add(crypto.sha256(password.encodeToByteArray()))
-        }
-        compositeKey.keyFileData?.let { keyData ->
-            parts.add(crypto.sha256(keyData))
-        }
-        compositeKey.hardwareKeyChallenge?.let { challenge ->
-            parts.add(challenge)
-        }
-
-        if (parts.isEmpty()) {
-            throw KdbxParseException("Composite key must contain at least one credential")
-        }
-
-        val concatenated = parts.fold(ByteArray(0)) { acc, part -> acc + part }
-        return crypto.sha256(concatenated)
-    }
-
-    // -- KDF --
-
-    private fun deriveTransformedKey(
-        compositeKeyHash: ByteArray,
-        kdfParameters: KdfParameters,
-    ): ByteArray = when (kdfParameters) {
-        is KdfParameters.AesKdf -> {
-            val transformed = crypto.aesKdf(compositeKeyHash, kdfParameters.seed, kdfParameters.rounds)
-            crypto.sha256(transformed)
-        }
-        is KdfParameters.Argon2 -> {
-            crypto.argon2(
-                password = compositeKeyHash,
-                salt = kdfParameters.salt,
-                variant = kdfParameters.variant,
-                version = kdfParameters.version,
-                memory = kdfParameters.memory,
-                iterations = kdfParameters.iterations,
-                parallelism = kdfParameters.parallelism,
-            )
-        }
-    }
-
     // -- Header verification (KDBX 4.x) --
 
     private fun verifyHeaderHash(headerResult: KdbxHeaderReadResult) {
@@ -181,7 +133,7 @@ class KdbxReader(private val crypto: CryptoProvider) {
         val expected = headerResult.headerHmac
             ?: throw KdbxParseException("KDBX 4.x file missing header HMAC")
 
-        val hmacBaseKey = computeHmacBaseKey(masterSeed, transformedKey)
+        val hmacBaseKey = keyDerivation.computeHmacBaseKey(masterSeed, transformedKey)
         val blockKey = computeHmacBlockKey(hmacBaseKey, HEADER_HMAC_BLOCK_INDEX)
         val actual = crypto.hmacSha256(blockKey, headerResult.rawHeaderBytes)
 
@@ -205,7 +157,7 @@ class KdbxReader(private val crypto: CryptoProvider) {
         masterSeed: ByteArray,
         transformedKey: ByteArray,
     ): ByteArray {
-        val hmacBaseKey = computeHmacBaseKey(masterSeed, transformedKey)
+        val hmacBaseKey = keyDerivation.computeHmacBaseKey(masterSeed, transformedKey)
         val output = Buffer()
         var blockIndex = 0L
 
@@ -342,9 +294,6 @@ class KdbxReader(private val crypto: CryptoProvider) {
     }
 
     // -- HMAC helpers --
-
-    private fun computeHmacBaseKey(masterSeed: ByteArray, transformedKey: ByteArray): ByteArray =
-        crypto.sha512(masterSeed + transformedKey + byteArrayOf(0x01))
 
     private fun computeHmacBlockKey(hmacBaseKey: ByteArray, blockIndex: Long): ByteArray {
         val indexBytes = Buffer().apply { writeLongLe(blockIndex) }.readByteArray()

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxWriter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/KdbxWriter.kt
@@ -2,6 +2,7 @@ package org.github.keepasscompose.core.database
 
 import okio.Buffer
 import okio.BufferedSink
+import org.github.keepasscompose.core.crypto.CompositeKeyDerivation
 import org.github.keepasscompose.core.crypto.CryptoProvider
 import org.github.keepasscompose.core.model.CipherId
 import org.github.keepasscompose.core.model.CompositeKey
@@ -10,7 +11,6 @@ import org.github.keepasscompose.core.model.InnerStreamCipher
 import org.github.keepasscompose.core.model.KdbxDatabase
 import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.core.model.KdbxGroup
-import org.github.keepasscompose.core.model.KdfParameters
 
 /**
  * Orchestrates writing a KDBX database by combining XML serialization, compression,
@@ -24,6 +24,8 @@ import org.github.keepasscompose.core.model.KdfParameters
  * @param crypto Platform-specific cryptographic provider.
  */
 class KdbxWriter(private val crypto: CryptoProvider) {
+
+    private val keyDerivation = CompositeKeyDerivation(crypto)
 
     /**
      * Serializes and encrypts a KDBX database to a byte array.
@@ -49,9 +51,9 @@ class KdbxWriter(private val crypto: CryptoProvider) {
         val header = database.header
 
         // 1. Derive keys
-        val compositeKeyHash = deriveCompositeKeyHash(compositeKey)
-        val transformedKey = deriveTransformedKey(compositeKeyHash, header.kdfParameters)
-        val masterKey = crypto.sha256(header.masterSeed + transformedKey)
+        val keys = keyDerivation.deriveKeys(compositeKey, header.masterSeed, header.kdfParameters)
+        val masterKey = keys.masterKey
+        val transformedKey = keys.transformedKey
 
         // 2. Create inner stream encryptor for protected field values
         val innerStreamCipher = header.innerRandomStreamId
@@ -112,7 +114,7 @@ class KdbxWriter(private val crypto: CryptoProvider) {
 
         // 9. Write V4 header authentication: SHA-256 hash + HMAC-SHA-256
         if (header.version.isV4) {
-            val hmacBaseKey = computeHmacBaseKey(header.masterSeed, transformedKey)
+            val hmacBaseKey = keyDerivation.computeHmacBaseKey(header.masterSeed, transformedKey)
             sink.write(crypto.sha256(headerResult.rawHeaderBytes))
             val headerBlockKey = computeHmacBlockKey(hmacBaseKey, HEADER_HMAC_BLOCK_INDEX)
             sink.write(crypto.hmacSha256(headerBlockKey, headerResult.rawHeaderBytes))
@@ -120,56 +122,10 @@ class KdbxWriter(private val crypto: CryptoProvider) {
 
         // 10. Write encrypted payload
         if (header.version.isV4) {
-            val hmacBaseKey = computeHmacBaseKey(header.masterSeed, transformedKey)
+            val hmacBaseKey = keyDerivation.computeHmacBaseKey(header.masterSeed, transformedKey)
             writeHmacBlocks(sink, encryptedPayload, hmacBaseKey)
         } else {
             sink.write(encryptedPayload)
-        }
-    }
-
-    // -- Composite key derivation --
-
-    private fun deriveCompositeKeyHash(compositeKey: CompositeKey): ByteArray {
-        val parts = mutableListOf<ByteArray>()
-
-        compositeKey.password?.let { password ->
-            parts.add(crypto.sha256(password.encodeToByteArray()))
-        }
-        compositeKey.keyFileData?.let { keyData ->
-            parts.add(crypto.sha256(keyData))
-        }
-        compositeKey.hardwareKeyChallenge?.let { challenge ->
-            parts.add(challenge)
-        }
-
-        if (parts.isEmpty()) {
-            throw KdbxParseException("Composite key must contain at least one credential")
-        }
-
-        val concatenated = parts.fold(ByteArray(0)) { acc, part -> acc + part }
-        return crypto.sha256(concatenated)
-    }
-
-    // -- KDF --
-
-    private fun deriveTransformedKey(
-        compositeKeyHash: ByteArray,
-        kdfParameters: KdfParameters,
-    ): ByteArray = when (kdfParameters) {
-        is KdfParameters.AesKdf -> {
-            val transformed = crypto.aesKdf(compositeKeyHash, kdfParameters.seed, kdfParameters.rounds)
-            crypto.sha256(transformed)
-        }
-        is KdfParameters.Argon2 -> {
-            crypto.argon2(
-                password = compositeKeyHash,
-                salt = kdfParameters.salt,
-                variant = kdfParameters.variant,
-                version = kdfParameters.version,
-                memory = kdfParameters.memory,
-                iterations = kdfParameters.iterations,
-                parallelism = kdfParameters.parallelism,
-            )
         }
     }
 
@@ -308,9 +264,6 @@ class KdbxWriter(private val crypto: CryptoProvider) {
     }
 
     // -- HMAC helpers --
-
-    private fun computeHmacBaseKey(masterSeed: ByteArray, transformedKey: ByteArray): ByteArray =
-        crypto.sha512(masterSeed + transformedKey + byteArrayOf(0x01))
 
     private fun computeHmacBlockKey(hmacBaseKey: ByteArray, blockIndex: Long): ByteArray {
         val indexBytes = Buffer().apply { writeLongLe(blockIndex) }.readByteArray()

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/CompositeKeyDerivationTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/crypto/CompositeKeyDerivationTest.kt
@@ -1,0 +1,170 @@
+package org.github.keepasscompose.core.crypto
+
+import org.github.keepasscompose.core.model.Argon2Variant
+import org.github.keepasscompose.core.model.CompositeKey
+import org.github.keepasscompose.core.model.KdfParameters
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+/**
+ * Tests for [CompositeKeyDerivation].
+ *
+ * Verifies composite key hashing, KDF application, and the full key derivation
+ * pipeline used by KdbxReader/KdbxWriter.
+ */
+class CompositeKeyDerivationTest {
+
+    private val crypto = PlatformCryptoProvider()
+    private val kd = CompositeKeyDerivation(crypto)
+
+    // --- Composite key hash ---
+
+    @Test
+    fun compositeKeyHash_passwordOnly() {
+        val key = CompositeKey(password = "test")
+        val hash = kd.deriveCompositeKeyHash(key)
+        assertEquals(32, hash.size)
+        // SHA-256(SHA-256("test"))
+        val expected = crypto.sha256(crypto.sha256("test".encodeToByteArray()))
+        assertContentEquals(expected, hash)
+    }
+
+    @Test
+    fun compositeKeyHash_keyFileOnly() {
+        val keyData = "keyfile-data".encodeToByteArray()
+        val key = CompositeKey(keyFileData = keyData)
+        val hash = kd.deriveCompositeKeyHash(key)
+        assertEquals(32, hash.size)
+        val expected = crypto.sha256(crypto.sha256(keyData))
+        assertContentEquals(expected, hash)
+    }
+
+    @Test
+    fun compositeKeyHash_passwordAndKeyFile() {
+        val keyData = "keyfile-data".encodeToByteArray()
+        val key = CompositeKey(password = "test", keyFileData = keyData)
+        val hash = kd.deriveCompositeKeyHash(key)
+        assertEquals(32, hash.size)
+        // SHA-256(SHA-256("test") || SHA-256(keyData))
+        val passwordHash = crypto.sha256("test".encodeToByteArray())
+        val keyFileHash = crypto.sha256(keyData)
+        val expected = crypto.sha256(passwordHash + keyFileHash)
+        assertContentEquals(expected, hash)
+    }
+
+    @Test
+    fun compositeKeyHash_emptyKey_throws() {
+        val key = CompositeKey()
+        assertFailsWith<IllegalArgumentException> {
+            kd.deriveCompositeKeyHash(key)
+        }
+    }
+
+    @Test
+    fun compositeKeyHash_deterministic() {
+        val key = CompositeKey(password = "password")
+        val h1 = kd.deriveCompositeKeyHash(key)
+        val h2 = kd.deriveCompositeKeyHash(key)
+        assertContentEquals(h1, h2)
+    }
+
+    @Test
+    fun compositeKeyHash_differentPasswords_differentHashes() {
+        val h1 = kd.deriveCompositeKeyHash(CompositeKey(password = "pass1"))
+        val h2 = kd.deriveCompositeKeyHash(CompositeKey(password = "pass2"))
+        assertFalse(h1.contentEquals(h2))
+    }
+
+    // --- Transformed key (KDF) ---
+
+    @Test
+    fun transformedKey_aesKdf() {
+        val compositeKeyHash = ByteArray(32) { it.toByte() }
+        val seed = ByteArray(32) { (it + 32).toByte() }
+        val kdfParams = KdfParameters.AesKdf(rounds = 10, seed = seed)
+        val transformed = kd.deriveTransformedKey(compositeKeyHash, kdfParams)
+        assertEquals(32, transformed.size)
+        // AES-KDF result should be SHA-256 of the transformed key
+        val expected = crypto.sha256(crypto.aesKdf(compositeKeyHash, seed, 10))
+        assertContentEquals(expected, transformed)
+    }
+
+    @Test
+    fun transformedKey_argon2() {
+        val compositeKeyHash = ByteArray(32) { it.toByte() }
+        val salt = ByteArray(16) { it.toByte() }
+        val kdfParams = KdfParameters.Argon2(
+            variant = Argon2Variant.ARGON2ID,
+            version = 0x13,
+            salt = salt,
+            parallelism = 1,
+            memory = 32,
+            iterations = 1,
+        )
+        val transformed = kd.deriveTransformedKey(compositeKeyHash, kdfParams)
+        assertEquals(32, transformed.size)
+        // Argon2 result is used directly (no extra SHA-256)
+        val expected = crypto.argon2(compositeKeyHash, salt, Argon2Variant.ARGON2ID, 0x13, 32, 1, 1)
+        assertContentEquals(expected, transformed)
+    }
+
+    // --- Full key derivation ---
+
+    @Test
+    fun deriveKeys_producesCorrectMasterKey() {
+        val key = CompositeKey(password = "password")
+        val masterSeed = ByteArray(32) { (it * 5).toByte() }
+        val kdfSeed = ByteArray(32) { (it * 3).toByte() }
+        val kdfParams = KdfParameters.AesKdf(rounds = 5, seed = kdfSeed)
+
+        val result = kd.deriveKeys(key, masterSeed, kdfParams)
+        assertEquals(32, result.masterKey.size)
+        assertEquals(32, result.transformedKey.size)
+
+        // Verify master key = SHA-256(masterSeed || transformedKey)
+        val expectedMasterKey = crypto.sha256(masterSeed + result.transformedKey)
+        assertContentEquals(expectedMasterKey, result.masterKey)
+    }
+
+    @Test
+    fun deriveKeys_deterministic() {
+        val key = CompositeKey(password = "password")
+        val masterSeed = ByteArray(32) { it.toByte() }
+        val kdfParams = KdfParameters.AesKdf(rounds = 5, seed = ByteArray(32) { (it + 1).toByte() })
+        val r1 = kd.deriveKeys(key, masterSeed, kdfParams)
+        val r2 = kd.deriveKeys(key, masterSeed, kdfParams)
+        assertContentEquals(r1.masterKey, r2.masterKey)
+        assertContentEquals(r1.transformedKey, r2.transformedKey)
+    }
+
+    @Test
+    fun deriveKeys_differentPasswords_differentKeys() {
+        val masterSeed = ByteArray(32) { it.toByte() }
+        val kdfParams = KdfParameters.AesKdf(rounds = 5, seed = ByteArray(32) { (it + 1).toByte() })
+        val r1 = kd.deriveKeys(CompositeKey(password = "pass1"), masterSeed, kdfParams)
+        val r2 = kd.deriveKeys(CompositeKey(password = "pass2"), masterSeed, kdfParams)
+        assertFalse(r1.masterKey.contentEquals(r2.masterKey))
+    }
+
+    // --- HMAC base key ---
+
+    @Test
+    fun hmacBaseKey_correctLength() {
+        val masterSeed = ByteArray(32) { it.toByte() }
+        val transformedKey = ByteArray(32) { (it + 32).toByte() }
+        val hmacKey = kd.computeHmacBaseKey(masterSeed, transformedKey)
+        assertEquals(64, hmacKey.size) // SHA-512 output
+    }
+
+    @Test
+    fun hmacBaseKey_matchesExpectedComputation() {
+        val masterSeed = ByteArray(32) { it.toByte() }
+        val transformedKey = ByteArray(32) { (it + 32).toByte() }
+        val result = kd.computeHmacBaseKey(masterSeed, transformedKey)
+        val expected = crypto.sha512(masterSeed + transformedKey + byteArrayOf(0x01))
+        assertContentEquals(expected, result)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated key derivation logic from `KdbxReader` and `KdbxWriter` into shared `CompositeKeyDerivation` class
- Combines password hash + key file hash + hardware key, applies KDF (AES-KDF or Argon2), derives master key
- Also centralizes HMAC base key computation for KDBX 4.x
- Add 13 unit tests covering composite key hashing, KDF application, full derivation, and HMAC key

## Ticket
3.10

## Test plan
- [x] Composite key hash: password-only, key-file-only, combined, empty throws
- [x] Transformed key: AES-KDF and Argon2 paths
- [x] Full derivation: correct master key, determinism, password sensitivity
- [x] HMAC base key: correct length and computation
- [x] All existing KdbxReader/Writer round-trip tests continue to pass (verifies refactoring correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)