### PR TITLE
[5.2] Implement file picker (expect/actual)

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/FilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/FilePicker.android.kt
@@ -1,0 +1,14 @@
+package org.github.keepasscompose.core.common
+
+actual class FilePicker actual constructor() {
+
+    actual suspend fun pickFile(extensions: List<String>): String? {
+        // TODO: Wire to ActivityResultContracts.OpenDocument via AndroidContextHolder
+        return null
+    }
+
+    actual suspend fun pickSaveLocation(defaultName: String, extensions: List<String>): String? {
+        // TODO: Wire to ActivityResultContracts.CreateDocument via AndroidContextHolder
+        return null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/FilePicker.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/FilePicker.kt
@@ -1,0 +1,6 @@
+package org.github.keepasscompose.core.common
+
+expect class FilePicker() {
+    suspend fun pickFile(extensions: List<String>): String?
+    suspend fun pickSaveLocation(defaultName: String, extensions: List<String>): String?
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/FilePicker.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/FilePicker.ios.kt
@@ -1,0 +1,14 @@
+package org.github.keepasscompose.core.common
+
+actual class FilePicker actual constructor() {
+
+    actual suspend fun pickFile(extensions: List<String>): String? {
+        // TODO: Wire to UIDocumentPickerViewController
+        return null
+    }
+
+    actual suspend fun pickSaveLocation(defaultName: String, extensions: List<String>): String? {
+        // TODO: Wire to UIDocumentPickerViewController in export mode
+        return null
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/FilePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/FilePicker.jvm.kt
@@ -1,0 +1,34 @@
+package org.github.keepasscompose.core.common
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.FilenameFilter
+
+actual class FilePicker actual constructor() {
+
+    actual suspend fun pickFile(extensions: List<String>): String? = withContext(Dispatchers.IO) {
+        val dialog = FileDialog(null as Frame?, "Open Database", FileDialog.LOAD)
+        dialog.filenameFilter = FilenameFilter { _, name ->
+            extensions.isEmpty() || extensions.any { name.endsWith(".$it", ignoreCase = true) }
+        }
+        dialog.isVisible = true
+        val directory = dialog.directory
+        val file = dialog.file
+        if (directory != null && file != null) "$directory$file" else null
+    }
+
+    actual suspend fun pickSaveLocation(defaultName: String, extensions: List<String>): String? =
+        withContext(Dispatchers.IO) {
+            val dialog = FileDialog(null as Frame?, "Save Database", FileDialog.SAVE)
+            dialog.file = defaultName
+            dialog.filenameFilter = FilenameFilter { _, name ->
+                extensions.isEmpty() || extensions.any { name.endsWith(".$it", ignoreCase = true) }
+            }
+            dialog.isVisible = true
+            val directory = dialog.directory
+            val file = dialog.file
+            if (directory != null && file != null) "$directory$file" else null
+        }
+}


### PR DESCRIPTION
## Summary
- Create `expect class FilePicker` with `pickFile()` and `pickSaveLocation()` suspend functions
- **JVM/Desktop**: Full implementation using AWT `FileDialog` with extension filtering
- **Android**: Stub implementation (TODO: wire to `ActivityResultContracts.OpenDocument`/`CreateDocument`)
- **iOS**: Stub implementation (TODO: wire to `UIDocumentPickerViewController`)

Closes #41

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify desktop file picker opens and returns selected file path
- [ ] Verify desktop save dialog opens with default filename
- [ ] Verify cancellation returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)