### PR TITLE
[5.7] Implement database locking

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/InactivityTimer.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/InactivityTimer.kt
@@ -1,0 +1,48 @@
+package org.github.keepasscompose.core.common
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class InactivityTimer(
+    private val scope: CoroutineScope,
+) {
+    private var timerJob: Job? = null
+
+    private val _isExpired = MutableStateFlow(false)
+    val isExpired: StateFlow<Boolean> = _isExpired.asStateFlow()
+
+    private var timeoutMillis: Long = 0L
+
+    fun start(timeoutSeconds: Int) {
+        timeoutMillis = timeoutSeconds * 1000L
+        resetTimer()
+    }
+
+    fun resetTimer() {
+        _isExpired.value = false
+        timerJob?.cancel()
+        if (timeoutMillis <= 0) return
+
+        timerJob = scope.launch {
+            delay(timeoutMillis)
+            _isExpired.value = true
+        }
+    }
+
+    fun onUserActivity() {
+        if (!_isExpired.value && timerJob?.isActive == true) {
+            resetTimer()
+        }
+    }
+
+    fun stop() {
+        timerJob?.cancel()
+        timerJob = null
+        _isExpired.value = false
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/DatabaseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/DatabaseViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.github.keepasscompose.core.common.FileSystem
+import org.github.keepasscompose.core.common.InactivityTimer
 import org.github.keepasscompose.core.database.KdbxWriter
 import org.github.keepasscompose.core.model.CompositeKey
 import org.github.keepasscompose.core.model.KdbxDatabase
@@ -38,11 +39,25 @@ class DatabaseViewModel(
     private val _saveState = MutableStateFlow<SaveState>(SaveState.Idle)
     val saveState: StateFlow<SaveState> = _saveState.asStateFlow()
 
+    private val _isLocked = MutableStateFlow(false)
+    val isLocked: StateFlow<Boolean> = _isLocked.asStateFlow()
+
+    val inactivityTimer = InactivityTimer(viewModelScope)
+
+    init {
+        viewModelScope.launch {
+            inactivityTimer.isExpired.collect { expired ->
+                if (expired) lock()
+            }
+        }
+    }
+
     fun setDatabase(database: KdbxDatabase, filePath: String, compositeKey: CompositeKey) {
         _database.value = database
         _filePath.value = filePath
         _compositeKey.value = compositeKey
         _isDirty.value = false
+        _isLocked.value = false
     }
 
     fun markDirty() {
@@ -93,11 +108,26 @@ class DatabaseViewModel(
 
     fun needsSaveBeforeClose(): Boolean = _isDirty.value
 
+    fun lock() {
+        // Clear sensitive data but preserve file path for re-unlock
+        _database.value = null
+        _compositeKey.value = null
+        _isLocked.value = true
+        _isDirty.value = false
+        inactivityTimer.stop()
+    }
+
     fun close() {
         _database.value = null
         _filePath.value = null
         _compositeKey.value = null
         _isDirty.value = false
+        _isLocked.value = false
         _saveState.value = SaveState.Idle
+        inactivityTimer.stop()
+    }
+
+    fun onUserActivity() {
+        inactivityTimer.onUserActivity()
     }
 }


### PR DESCRIPTION
## Summary
- Create `InactivityTimer` with configurable timeout, reset on user activity, and expiration state flow
- Add lock/unlock support to `DatabaseViewModel`: `lock()` clears sensitive data (database, key) but preserves file path for re-unlock, `isLocked` state flow
- Auto-lock via `InactivityTimer` integration — timer expiration triggers `lock()`
- `onUserActivity()` method to reset timer on user interaction
- Timer stopped on lock/close

Closes #46

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify manual lock clears database but preserves file path
- [ ] Verify inactivity timer triggers lock after timeout
- [ ] Verify user activity resets timer
- [ ] Verify unlock restores database state

🤖 Generated with [Claude Code](https://claude.com/claude-code)