### PR TITLE
[6.2] Implement group selection and navigation

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/BreadcrumbBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/BreadcrumbBar.kt
@@ -1,0 +1,68 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.github.keepasscompose.core.model.KdbxGroup
+
+@Composable
+fun BreadcrumbBar(
+    breadcrumb: List<KdbxGroup>,
+    onGroupClick: (KdbxGroup) -> Unit,
+    onNavigateUp: () -> Unit,
+    hasParent: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        if (hasParent) {
+            IconButton(onClick = onNavigateUp, modifier = Modifier.size(28.dp)) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Go to parent",
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+
+        breadcrumb.forEachIndexed { index, group ->
+            if (index > 0) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            val isLast = index == breadcrumb.lastIndex
+            Text(
+                text = group.name,
+                style = MaterialTheme.typography.labelMedium,
+                color = if (isLast) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
+                modifier = if (!isLast) {
+                    Modifier.clickable { onGroupClick(group) }.padding(horizontal = 4.dp)
+                } else {
+                    Modifier.padding(horizontal = 4.dp)
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/GroupNavigationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/GroupNavigationViewModel.kt
@@ -1,0 +1,60 @@
+package org.github.keepasscompose.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.github.keepasscompose.core.model.KdbxGroup
+
+class GroupNavigationViewModel : ViewModel() {
+
+    private val _selectedGroup = MutableStateFlow<KdbxGroup?>(null)
+    val selectedGroup: StateFlow<KdbxGroup?> = _selectedGroup.asStateFlow()
+
+    private val _breadcrumb = MutableStateFlow<List<KdbxGroup>>(emptyList())
+    val breadcrumb: StateFlow<List<KdbxGroup>> = _breadcrumb.asStateFlow()
+
+    private var rootGroup: KdbxGroup? = null
+
+    fun setRootGroup(group: KdbxGroup) {
+        rootGroup = group
+        navigateTo(group)
+    }
+
+    fun navigateTo(group: KdbxGroup) {
+        _selectedGroup.value = group
+        _breadcrumb.value = buildBreadcrumb(group)
+    }
+
+    fun navigateToParent() {
+        val crumb = _breadcrumb.value
+        if (crumb.size > 1) {
+            navigateTo(crumb[crumb.size - 2])
+        }
+    }
+
+    fun hasParent(): Boolean = _breadcrumb.value.size > 1
+
+    private fun buildBreadcrumb(target: KdbxGroup): List<KdbxGroup> {
+        val root = rootGroup ?: return listOf(target)
+        val path = mutableListOf<KdbxGroup>()
+        if (findPath(root, target.uuid, path)) {
+            return path
+        }
+        return listOf(target)
+    }
+
+    private fun findPath(
+        current: KdbxGroup,
+        targetUuid: String,
+        path: MutableList<KdbxGroup>,
+    ): Boolean {
+        path.add(current)
+        if (current.uuid == targetUuid) return true
+        for (child in current.groups) {
+            if (findPath(child, targetUuid, path)) return true
+        }
+        path.removeAt(path.lastIndex)
+        return false
+    }
+}


### PR DESCRIPTION
## Summary
- Create `GroupNavigationViewModel` with group selection, breadcrumb path computation (DFS), and "go to parent" navigation
- Create `BreadcrumbBar` composable showing clickable breadcrumb trail with separator arrows and back button

Closes #49

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify clicking group updates selected group and breadcrumb
- [ ] Verify breadcrumb trail shows full path from root
- [ ] Verify "go to parent" navigates up one level

🤖 Generated with [Claude Code](https://claude.com/claude-code)