### PR TITLE
[6.7] Implement group search/filter in tree

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupSearchBar.kt
@@ -1,0 +1,46 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun GroupSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        placeholder = { Text("Filter groups...", style = MaterialTheme.typography.bodySmall) },
+        singleLine = true,
+        leadingIcon = {
+            Icon(Icons.Filled.Search, contentDescription = null, modifier = Modifier.size(18.dp))
+        },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(Icons.Filled.Clear, contentDescription = "Clear", modifier = Modifier.size(18.dp))
+                }
+            }
+        },
+        textStyle = MaterialTheme.typography.bodySmall,
+        colors = OutlinedTextFieldDefaults.colors(
+            unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+        ),
+        modifier = modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupSearchFilter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupSearchFilter.kt
@@ -1,0 +1,44 @@
+package org.github.keepasscompose.ui.components
+
+import org.github.keepasscompose.core.model.KdbxGroup
+
+data class GroupFilterResult(
+    val matchingUuids: Set<String>,
+    val expandedUuids: Set<String>,
+)
+
+/**
+ * Filters a group tree by name, returning the UUIDs of matching groups
+ * and all ancestor UUIDs that should be auto-expanded to reveal matches.
+ */
+fun filterGroupTree(root: KdbxGroup, query: String): GroupFilterResult {
+    if (query.isBlank()) {
+        return GroupFilterResult(emptySet(), setOf(root.uuid))
+    }
+
+    val matchingUuids = mutableSetOf<String>()
+    val expandedUuids = mutableSetOf<String>()
+
+    fun search(group: KdbxGroup): Boolean {
+        val nameMatches = group.name.contains(query, ignoreCase = true)
+        if (nameMatches) {
+            matchingUuids.add(group.uuid)
+        }
+
+        var hasMatchingDescendant = false
+        for (child in group.groups) {
+            if (search(child)) {
+                hasMatchingDescendant = true
+            }
+        }
+
+        if (nameMatches || hasMatchingDescendant) {
+            expandedUuids.add(group.uuid)
+            return true
+        }
+        return false
+    }
+
+    search(root)
+    return GroupFilterResult(matchingUuids, expandedUuids)
+}


### PR DESCRIPTION
## Summary
- Create `GroupSearchFilter.kt` with `filterGroupTree()` — returns matching group UUIDs and auto-expanded ancestor UUIDs
- Create `GroupSearchBar.kt` — compact search field with search icon, clear button, and placeholder text
- Case-insensitive name matching with recursive ancestor expansion
- Ready to integrate with `GroupTree` component for highlight + expand behavior

Closes #54

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify filter returns correct matching UUIDs
- [ ] Verify ancestor UUIDs are included for auto-expansion
- [ ] Verify empty query returns default state
- [ ] Verify search bar clear button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)