### PR TITLE
[8.3] Implement password strength estimator

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/PasswordStrength.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/PasswordStrength.kt
@@ -1,0 +1,194 @@
+package org.github.keepasscompose.core.common
+
+import kotlin.math.ln
+import kotlin.math.pow
+
+/**
+ * Estimates password strength based on entropy calculation, pattern detection,
+ * and crack time estimation.
+ */
+object PasswordStrength {
+
+    /**
+     * Strength levels with associated thresholds and display properties.
+     */
+    enum class Level {
+        VERY_WEAK,
+        WEAK,
+        FAIR,
+        STRONG,
+        VERY_STRONG,
+    }
+
+    /**
+     * Result of a password strength estimation.
+     *
+     * @param entropyBits Estimated entropy in bits.
+     * @param level Qualitative strength level.
+     * @param crackTimeSeconds Estimated time to crack at 10 billion guesses/second.
+     * @param crackTimeDisplay Human-readable crack time string.
+     * @param penalties Descriptions of detected weaknesses (repeated chars, patterns, etc.).
+     */
+    data class Result(
+        val entropyBits: Double,
+        val level: Level,
+        val crackTimeSeconds: Double,
+        val crackTimeDisplay: String,
+        val penalties: List<String>,
+    )
+
+    /**
+     * Estimate the strength of a password.
+     */
+    fun estimate(password: String): Result {
+        if (password.isEmpty()) {
+            return Result(0.0, Level.VERY_WEAK, 0.0, "instant", emptyList())
+        }
+
+        val penalties = mutableListOf<String>()
+        var entropy = calculateCharsetEntropy(password)
+
+        // Penalty: repeated characters
+        val repeatPenalty = calculateRepeatPenalty(password)
+        if (repeatPenalty > 0) {
+            entropy -= repeatPenalty
+            penalties.add("Repeated characters")
+        }
+
+        // Penalty: sequential patterns (abc, 123)
+        val sequentialPenalty = calculateSequentialPenalty(password)
+        if (sequentialPenalty > 0) {
+            entropy -= sequentialPenalty
+            penalties.add("Sequential patterns")
+        }
+
+        // Penalty: common patterns (keyboard rows, etc.)
+        if (isCommonPattern(password)) {
+            entropy *= 0.5
+            penalties.add("Common pattern detected")
+        }
+
+        // Penalty: all same character
+        if (password.toSet().size == 1) {
+            entropy = ln(password.length.toDouble() + 1.0) / ln(2.0)
+            penalties.add("All identical characters")
+        }
+
+        entropy = entropy.coerceAtLeast(0.0)
+
+        val crackTimeSeconds = estimateCrackTime(entropy)
+        val crackTimeDisplay = formatCrackTime(crackTimeSeconds)
+        val level = entropyToLevel(entropy)
+
+        return Result(entropy, level, crackTimeSeconds, crackTimeDisplay, penalties)
+    }
+
+    /**
+     * Calculate entropy based on the character sets used in the password.
+     * Entropy = length * log2(charsetSize)
+     */
+    internal fun calculateCharsetEntropy(password: String): Double {
+        var charsetSize = 0
+        if (password.any { it in 'a'..'z' }) charsetSize += 26
+        if (password.any { it in 'A'..'Z' }) charsetSize += 26
+        if (password.any { it in '0'..'9' }) charsetSize += 10
+        if (password.any { it.isSymbol() }) charsetSize += 32
+        if (password.any { it == ' ' }) charsetSize += 1
+        // Unicode/other characters
+        if (password.any { !it.isLetterOrDigit() && !it.isSymbol() && it != ' ' }) charsetSize += 64
+
+        if (charsetSize == 0) charsetSize = 1
+
+        return password.length * (ln(charsetSize.toDouble()) / ln(2.0))
+    }
+
+    private fun Char.isSymbol(): Boolean =
+        this in "!@#\$%^&*()-_=+[]{}|;:',.<>?/\\`~\""
+
+    /**
+     * Penalize passwords with many repeated characters.
+     * Returns entropy bits to subtract.
+     */
+    internal fun calculateRepeatPenalty(password: String): Double {
+        if (password.length < 3) return 0.0
+        val charCounts = password.groupBy { it }.mapValues { it.value.size }
+        val maxRepeat = charCounts.values.maxOrNull() ?: 0
+        val ratio = maxRepeat.toDouble() / password.length
+        return if (ratio > 0.3) (ratio * 10.0) else 0.0
+    }
+
+    /**
+     * Penalize passwords with sequential character patterns (abc, 123, cba, 321).
+     * Returns entropy bits to subtract.
+     */
+    internal fun calculateSequentialPenalty(password: String): Double {
+        if (password.length < 3) return 0.0
+        var sequentialCount = 0
+        for (i in 0 until password.length - 2) {
+            val c1 = password[i].code
+            val c2 = password[i + 1].code
+            val c3 = password[i + 2].code
+            // Ascending or descending sequence
+            if ((c2 - c1 == 1 && c3 - c2 == 1) || (c1 - c2 == 1 && c2 - c3 == 1)) {
+                sequentialCount++
+            }
+        }
+        return sequentialCount * 2.0
+    }
+
+    /**
+     * Check for common keyboard patterns and well-known passwords.
+     */
+    internal fun isCommonPattern(password: String): Boolean {
+        val lower = password.lowercase()
+        val commonPatterns = listOf(
+            "password", "123456", "qwerty", "abc123", "letmein",
+            "admin", "welcome", "monkey", "master", "dragon",
+            "login", "princess", "football", "shadow", "sunshine",
+            "trustno1", "iloveyou", "batman", "access", "hello",
+            "charlie", "donald", "qwerty123", "password1",
+            "1234567890", "12345678", "1234567", "123456789",
+            "qwertyuiop", "asdfghjkl", "zxcvbnm",
+        )
+        return commonPatterns.any { lower.contains(it) }
+    }
+
+    /**
+     * Estimate crack time assuming 10 billion guesses per second (modern GPU cluster).
+     */
+    private fun estimateCrackTime(entropyBits: Double): Double {
+        if (entropyBits <= 0) return 0.0
+        val guesses = 2.0.pow(entropyBits)
+        // Average case: half the keyspace
+        return (guesses / 2.0) / 10_000_000_000.0
+    }
+
+    private fun entropyToLevel(entropy: Double): Level = when {
+        entropy < 28 -> Level.VERY_WEAK
+        entropy < 36 -> Level.WEAK
+        entropy < 60 -> Level.FAIR
+        entropy < 80 -> Level.STRONG
+        else -> Level.VERY_STRONG
+    }
+
+    /**
+     * Format crack time as a human-readable string.
+     */
+    internal fun formatCrackTime(seconds: Double): String {
+        val minute = 60.0
+        val hour = 3600.0
+        val day = 86400.0
+        val year = day * 365.0
+        return when {
+            seconds < 1 -> "instant"
+            seconds < minute -> "${seconds.toLong()} seconds"
+            seconds < hour -> "${(seconds / minute).toLong()} minutes"
+            seconds < day -> "${(seconds / hour).toLong()} hours"
+            seconds < year -> "${(seconds / day).toLong()} days"
+            seconds < year * 100 -> "${(seconds / year).toLong()} years"
+            seconds < year * 1_000_000 -> "${(seconds / (year * 1000)).toLong()} thousand years"
+            seconds < year * 1e9 -> "${(seconds / (year * 1e6)).toLong()} million years"
+            else -> "billions of years"
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/common/PasswordStrengthTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/common/PasswordStrengthTest.kt
@@ -1,0 +1,185 @@
+package org.github.keepasscompose.core.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PasswordStrengthTest {
+
+    // --- Strength levels ---
+
+    @Test
+    fun estimate_emptyPassword_veryWeak() {
+        val result = PasswordStrength.estimate("")
+        assertEquals(PasswordStrength.Level.VERY_WEAK, result.level)
+        assertEquals(0.0, result.entropyBits)
+        assertEquals("instant", result.crackTimeDisplay)
+    }
+
+    @Test
+    fun estimate_singleChar_veryWeak() {
+        val result = PasswordStrength.estimate("a")
+        assertEquals(PasswordStrength.Level.VERY_WEAK, result.level)
+    }
+
+    @Test
+    fun estimate_shortNumeric_veryWeak() {
+        val result = PasswordStrength.estimate("1234")
+        assertEquals(PasswordStrength.Level.VERY_WEAK, result.level)
+    }
+
+    @Test
+    fun estimate_commonPassword_penalized() {
+        val result = PasswordStrength.estimate("password")
+        assertTrue(result.penalties.any { "Common pattern" in it })
+    }
+
+    @Test
+    fun estimate_mediumPassword_fairOrBetter() {
+        // 10 chars mixed case + digits, no common patterns
+        val result = PasswordStrength.estimate("Kx7mP2nQ9w")
+        assertTrue(result.level >= PasswordStrength.Level.FAIR, "Should be at least FAIR: ${result.level}")
+    }
+
+    @Test
+    fun estimate_strongPassword() {
+        // 16 chars with all character types
+        val result = PasswordStrength.estimate("Tr0ub4dor&3!xYzW")
+        assertTrue(result.level >= PasswordStrength.Level.FAIR, "Should be at least FAIR: ${result.level}")
+        assertTrue(result.entropyBits > 50, "Should have > 50 bits entropy")
+    }
+
+    @Test
+    fun estimate_longRandomPassword_veryStrong() {
+        // 32 random-looking chars
+        val result = PasswordStrength.estimate("k8#Lm2!qR5@vN7&pX3\$wZ9*cF4^bY6+")
+        assertEquals(PasswordStrength.Level.VERY_STRONG, result.level)
+        assertTrue(result.entropyBits > 80)
+    }
+
+    // --- Entropy calculation ---
+
+    @Test
+    fun entropy_lowercaseOnly() {
+        // 8 lowercase chars: 8 * log2(26) ≈ 37.6 bits
+        val entropy = PasswordStrength.calculateCharsetEntropy("abcdefgh")
+        assertTrue(entropy > 37 && entropy < 39, "Expected ~37.6, got $entropy")
+    }
+
+    @Test
+    fun entropy_mixedCase() {
+        // 8 mixed case: 8 * log2(52) ≈ 45.6 bits
+        val entropy = PasswordStrength.calculateCharsetEntropy("AbCdEfGh")
+        assertTrue(entropy > 45 && entropy < 47, "Expected ~45.6, got $entropy")
+    }
+
+    @Test
+    fun entropy_mixedCaseDigits() {
+        // 8 chars: 8 * log2(62) ≈ 47.6 bits
+        val entropy = PasswordStrength.calculateCharsetEntropy("Abc12345")
+        assertTrue(entropy > 47 && entropy < 49, "Expected ~47.6, got $entropy")
+    }
+
+    @Test
+    fun entropy_allCharTypes() {
+        // 8 chars with symbols: 8 * log2(94) ≈ 52.4 bits
+        val entropy = PasswordStrength.calculateCharsetEntropy("Ab1!Cd2@")
+        assertTrue(entropy > 50 && entropy < 55, "Expected ~52, got $entropy")
+    }
+
+    // --- Penalty detection ---
+
+    @Test
+    fun repeatPenalty_highRepetition() {
+        val penalty = PasswordStrength.calculateRepeatPenalty("aaaaaabb")
+        assertTrue(penalty > 0, "Should penalize 75% repetition")
+    }
+
+    @Test
+    fun repeatPenalty_noRepetition() {
+        val penalty = PasswordStrength.calculateRepeatPenalty("abcdefgh")
+        assertEquals(0.0, penalty)
+    }
+
+    @Test
+    fun sequentialPenalty_ascending() {
+        val penalty = PasswordStrength.calculateSequentialPenalty("abcdef")
+        assertTrue(penalty > 0, "Should detect ascending sequence")
+    }
+
+    @Test
+    fun sequentialPenalty_descending() {
+        val penalty = PasswordStrength.calculateSequentialPenalty("fedcba")
+        assertTrue(penalty > 0, "Should detect descending sequence")
+    }
+
+    @Test
+    fun sequentialPenalty_numeric() {
+        val penalty = PasswordStrength.calculateSequentialPenalty("123456")
+        assertTrue(penalty > 0, "Should detect numeric sequence")
+    }
+
+    @Test
+    fun sequentialPenalty_none() {
+        val penalty = PasswordStrength.calculateSequentialPenalty("azbycx")
+        assertEquals(0.0, penalty)
+    }
+
+    // --- Common patterns ---
+
+    @Test
+    fun commonPattern_qwerty() {
+        assertTrue(PasswordStrength.isCommonPattern("qwerty"))
+    }
+
+    @Test
+    fun commonPattern_password123() {
+        assertTrue(PasswordStrength.isCommonPattern("password123"))
+    }
+
+    @Test
+    fun commonPattern_randomString_notCommon() {
+        assertTrue(!PasswordStrength.isCommonPattern("k8Lm2qR5vN7"))
+    }
+
+    // --- Crack time formatting ---
+
+    @Test
+    fun formatCrackTime_instant() {
+        assertEquals("instant", PasswordStrength.formatCrackTime(0.5))
+    }
+
+    @Test
+    fun formatCrackTime_seconds() {
+        assertEquals("30 seconds", PasswordStrength.formatCrackTime(30.0))
+    }
+
+    @Test
+    fun formatCrackTime_minutes() {
+        assertEquals("5 minutes", PasswordStrength.formatCrackTime(300.0))
+    }
+
+    @Test
+    fun formatCrackTime_hours() {
+        assertEquals("2 hours", PasswordStrength.formatCrackTime(7200.0))
+    }
+
+    @Test
+    fun formatCrackTime_days() {
+        assertEquals("30 days", PasswordStrength.formatCrackTime(30.0 * 86400))
+    }
+
+    @Test
+    fun formatCrackTime_years() {
+        assertEquals("10 years", PasswordStrength.formatCrackTime(10.0 * 86400 * 365))
+    }
+
+    // --- All same character ---
+
+    @Test
+    fun estimate_allSameChar_penalized() {
+        val result = PasswordStrength.estimate("aaaaaaaaaa")
+        assertTrue(result.penalties.any { "identical" in it })
+        assertEquals(PasswordStrength.Level.VERY_WEAK, result.level)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PasswordStrength` in `core/common` with entropy-based password strength estimation
- Calculates entropy bits based on character set diversity (lowercase, uppercase, digits, symbols)
- Detects and penalizes: repeated characters, sequential patterns (abc, 123), common passwords (qwerty, password, etc.), identical characters
- Estimates crack time at 10 billion guesses/second with human-readable display
- Five strength levels: Very Weak (< 28 bits) → Very Strong (≥ 80 bits)
- Add 27 unit tests covering all strength levels, entropy calculation, penalties, patterns, and crack time formatting

## Ticket
8.3

## Test plan
- [x] Empty/single char/short passwords → Very Weak
- [x] Common passwords detected and penalized
- [x] Medium passwords → Fair or better
- [x] Long random passwords → Very Strong with > 80 bits entropy
- [x] Entropy calculation matches expected ranges for each charset combination
- [x] Repeat, sequential, and common pattern penalties
- [x] Crack time formatting: instant through billions of years

🤖 Generated with [Claude Code](https://claude.com/claude-code)