### PR TITLE
[7.5] Build "Edit Entry" screen/dialog

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryEditorScreen.kt
@@ -77,6 +77,7 @@ fun EntryEditorScreen(
     onSave: (EntryEditorResult) -> Unit = {},
     onCancel: () -> Unit = {},
     onGeneratePassword: () -> Unit = {},
+    onRevert: (() -> Unit)? = null,
 ) {
     var title by remember { mutableStateOf(initialTitle) }
     var userName by remember { mutableStateOf(initialUserName) }
@@ -89,6 +90,13 @@ fun EntryEditorScreen(
     var expires by remember { mutableStateOf(initialExpires) }
     var expiryDate by remember { mutableStateOf(initialExpiryDate) }
     var passwordVisible by remember { mutableStateOf(false) }
+
+    val isTitleModified = isEditMode && title != initialTitle
+    val isUserNameModified = isEditMode && userName != initialUserName
+    val isPasswordModified = isEditMode && password != initialPassword
+    val isUrlModified = isEditMode && url != initialUrl
+    val isNotesModified = isEditMode && notes != initialNotes
+    val hasAnyModification = isTitleModified || isUserNameModified || isPasswordModified || isUrlModified || isNotesModified
 
     Column(
         modifier = Modifier
@@ -244,7 +252,22 @@ fun EntryEditorScreen(
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
+            if (isEditMode && hasAnyModification) {
+                Text(
+                    text = "Modified",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+            }
+            if (onRevert != null && isEditMode && hasAnyModification) {
+                OutlinedButton(onClick = onRevert) {
+                    Text("Revert")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+            }
             TextButton(onClick = onCancel) {
                 Text("Cancel")
             }


### PR DESCRIPTION
## Summary
- Enhance `EntryEditorScreen` with "Modified" indicator comparing current values to initial values
- Add `onRevert` callback and Revert button (shown only when in edit mode with changes)
- Per-field modification tracking for title, username, password, URL, notes

Closes #59

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify "Modified" label appears when fields change in edit mode
- [ ] Verify Revert button triggers callback
- [ ] Verify no modified indicators in create mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)