### PR TITLE
[7.6] Implement "Delete Entry" with confirmation

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/DeleteEntryDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/DeleteEntryDialog.kt
@@ -1,0 +1,51 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import org.github.keepasscompose.core.model.KdbxEntry
+
+@Composable
+fun DeleteEntryDialog(
+    entries: List<KdbxEntry>,
+    hasRecycleBin: Boolean,
+    isPermanent: Boolean = false,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val isBatch = entries.size > 1
+    val actionText = when {
+        isPermanent -> "permanently deleted"
+        hasRecycleBin -> "moved to the Recycle Bin"
+        else -> "permanently deleted"
+    }
+
+    val titleText = if (isBatch) "Delete ${entries.size} Entries" else "Delete Entry"
+    val messageText = if (isBatch) {
+        "Are you sure you want to delete ${entries.size} entries?\n\nAll selected entries will be $actionText."
+    } else {
+        val entryTitle = entries.firstOrNull()?.title ?: "Untitled"
+        "Are you sure you want to delete \"$entryTitle\"?\n\nThis entry will be $actionText."
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(titleText) },
+        text = { Text(messageText) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    if (isPermanent) "Delete Permanently" else "Delete",
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}


### PR DESCRIPTION
## Summary
- Create `DeleteEntryDialog` supporting single and batch delete
- Recycle bin awareness ("moved to Recycle Bin" vs "permanently deleted")
- `isPermanent` flag for shift+delete or recycle bin items

Closes #60

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify single entry delete shows entry title
- [ ] Verify batch delete shows count
- [ ] Verify permanent delete wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)