### PR TITLE
[10.1] Implement multiplatform clipboard abstraction

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.android.kt
@@ -1,0 +1,31 @@
+package org.github.keepasscompose.core.common
+
+import android.content.ClipData
+import android.content.ClipboardManager as AndroidClipboardManager
+import android.content.Context
+import android.os.Build
+
+actual class ClipboardManager actual constructor() {
+
+    private val clipboard: AndroidClipboardManager
+        get() = AndroidContextHolder.applicationContext
+            .getSystemService(Context.CLIPBOARD_SERVICE) as AndroidClipboardManager
+
+    actual fun copyToClipboard(text: String) {
+        val clip = ClipData.newPlainText("KeePassCompose", text)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            clip.description.extras = android.os.PersistableBundle().apply {
+                putBoolean("android.content.extra.IS_SENSITIVE", true)
+            }
+        }
+        clipboard.setPrimaryClip(clip)
+    }
+
+    actual fun clearClipboard() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            clipboard.clearPrimaryClip()
+        } else {
+            clipboard.setPrimaryClip(ClipData.newPlainText("", ""))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.kt
@@ -1,0 +1,6 @@
+package org.github.keepasscompose.core.common
+
+expect class ClipboardManager() {
+    fun copyToClipboard(text: String)
+    fun clearClipboard()
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.ios.kt
@@ -1,0 +1,14 @@
+package org.github.keepasscompose.core.common
+
+import platform.UIKit.UIPasteboard
+
+actual class ClipboardManager actual constructor() {
+
+    actual fun copyToClipboard(text: String) {
+        UIPasteboard.generalPasteboard.string = text
+    }
+
+    actual fun clearClipboard() {
+        UIPasteboard.generalPasteboard.string = ""
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.jvm.kt
@@ -1,0 +1,18 @@
+package org.github.keepasscompose.core.common
+
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+actual class ClipboardManager actual constructor() {
+
+    private val clipboard: java.awt.datatransfer.Clipboard
+        get() = Toolkit.getDefaultToolkit().systemClipboard
+
+    actual fun copyToClipboard(text: String) {
+        clipboard.setContents(StringSelection(text), null)
+    }
+
+    actual fun clearClipboard() {
+        clipboard.setContents(StringSelection(""), null)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `expect class ClipboardManager` with `copyToClipboard(text)` and `clearClipboard()` in commonMain
- Android: Uses `ClipboardManager` with sensitive content flag (API 24+) and `clearPrimaryClip` (API 28+)
- Desktop (JVM): Uses AWT `Toolkit.getDefaultToolkit().systemClipboard` with `StringSelection`
- iOS: Uses `UIPasteboard.generalPasteboard`

Closes #75

## Test plan
- [ ] Verify JVM build compiles (`./gradlew composeApp:compileKotlinJvm`) ✅
- [ ] Verify clipboard copy works on Desktop
- [ ] Verify clipboard clear works on Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)