### PR TITLE
[10.2] Implement auto-clear clipboard

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/ClipboardClearTimer.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/ClipboardClearTimer.kt
@@ -1,0 +1,46 @@
+package org.github.keepasscompose.core.common
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ClipboardClearTimer(
+    private val scope: CoroutineScope,
+    private val clipboardManager: ClipboardManager,
+) {
+    private var timerJob: Job? = null
+    private var copiedText: String? = null
+
+    private val _secondsRemaining = MutableStateFlow<Int?>(null)
+    val secondsRemaining: StateFlow<Int?> = _secondsRemaining.asStateFlow()
+
+    fun copyAndScheduleClear(text: String, timeoutSeconds: Int) {
+        cancel()
+        clipboardManager.copyToClipboard(text)
+        copiedText = text
+
+        if (timeoutSeconds <= 0) return
+
+        timerJob = scope.launch {
+            for (remaining in timeoutSeconds downTo 1) {
+                _secondsRemaining.value = remaining
+                delay(1000L)
+            }
+            _secondsRemaining.value = 0
+            clipboardManager.clearClipboard()
+            copiedText = null
+            _secondsRemaining.value = null
+        }
+    }
+
+    fun cancel() {
+        timerJob?.cancel()
+        timerJob = null
+        copiedText = null
+        _secondsRemaining.value = null
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ClipboardClearTimer` that copies text and schedules automatic clipboard clearing
- Configurable timeout (uses existing `clipboardClearTimeoutSeconds` setting, default 30s)
- Exposes `secondsRemaining` StateFlow for countdown UI (used by ticket 10.3)
- Clears clipboard only after timer expires; `cancel()` stops the timer

Closes #76

## Test plan
- [ ] Verify JVM build compiles (`./gradlew composeApp:compileKotlinJvm`) ✅
- [ ] Verify clipboard is cleared after timeout period
- [ ] Verify `secondsRemaining` counts down correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)