### PR TITLE
[9.1] Implement search engine

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/SearchEngine.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/SearchEngine.kt
@@ -1,0 +1,231 @@
+package org.github.keepasscompose.core.common
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+
+/**
+ * Full-text search engine for KeePass entries.
+ *
+ * Supports:
+ * - Case-insensitive matching across title, username, URL, notes, custom fields, and tags
+ * - Search operators: terms are AND-ed by default; prefix with `-` to exclude
+ * - Field-specific search: `title:bank`, `user:john`, `url:github`, `tag:finance`
+ * - Regex search when the query starts with `regex:`
+ * - Recursive group traversal
+ */
+object SearchEngine {
+
+    /**
+     * A search result containing the matched entry and its group path.
+     */
+    data class SearchResult(
+        val entry: KdbxEntry,
+        val groupPath: List<String>,
+    )
+
+    /**
+     * Search all entries under [rootGroup] matching the [query].
+     *
+     * @param rootGroup The root group to search recursively.
+     * @param query The search query string.
+     * @param includeProtected Whether to search protected field values (e.g., passwords).
+     * @return List of matching entries with their group paths.
+     */
+    fun search(
+        rootGroup: KdbxGroup,
+        query: String,
+        includeProtected: Boolean = false,
+    ): List<SearchResult> {
+        if (query.isBlank()) return emptyList()
+
+        val matcher = parseQuery(query)
+        val results = mutableListOf<SearchResult>()
+        searchGroup(rootGroup, matcher, includeProtected, emptyList(), results)
+        return results
+    }
+
+    /**
+     * Flatten all entries from a group tree into a list with group paths.
+     */
+    fun allEntries(rootGroup: KdbxGroup): List<SearchResult> {
+        val results = mutableListOf<SearchResult>()
+        collectEntries(rootGroup, emptyList(), results)
+        return results
+    }
+
+    // --- Query parsing ---
+
+    private sealed class Matcher {
+        abstract fun matches(entry: KdbxEntry, includeProtected: Boolean): Boolean
+    }
+
+    private class AndMatcher(val terms: List<Matcher>) : Matcher() {
+        override fun matches(entry: KdbxEntry, includeProtected: Boolean) =
+            terms.all { it.matches(entry, includeProtected) }
+    }
+
+    private class NotMatcher(val inner: Matcher) : Matcher() {
+        override fun matches(entry: KdbxEntry, includeProtected: Boolean) =
+            !inner.matches(entry, includeProtected)
+    }
+
+    private class TextMatcher(val text: String) : Matcher() {
+        override fun matches(entry: KdbxEntry, includeProtected: Boolean) =
+            entryContainsText(entry, text, includeProtected)
+    }
+
+    private class FieldMatcher(val field: String, val text: String) : Matcher() {
+        override fun matches(entry: KdbxEntry, includeProtected: Boolean): Boolean {
+            val lower = text.lowercase()
+            return when (field) {
+                "title" -> entry.title.lowercase().contains(lower)
+                "user", "username" -> entry.userName.lowercase().contains(lower)
+                "url" -> entry.url.lowercase().contains(lower)
+                "notes" -> entry.notes.lowercase().contains(lower)
+                "tag" -> entry.tags.any { it.lowercase().contains(lower) }
+                else -> {
+                    // Search custom field by key name
+                    entry.fields.any {
+                        it.key.equals(field, ignoreCase = true) &&
+                            (!it.isProtected || includeProtected) &&
+                            it.value.lowercase().contains(lower)
+                    }
+                }
+            }
+        }
+    }
+
+    private class RegexMatcher(val pattern: Regex) : Matcher() {
+        override fun matches(entry: KdbxEntry, includeProtected: Boolean) =
+            entryMatchesRegex(entry, pattern, includeProtected)
+    }
+
+    private fun parseQuery(query: String): Matcher {
+        // Regex mode
+        if (query.startsWith("regex:")) {
+            val pattern = query.removePrefix("regex:")
+            return RegexMatcher(Regex(pattern, RegexOption.IGNORE_CASE))
+        }
+
+        // Tokenize: split by whitespace, respecting quoted strings
+        val tokens = tokenize(query)
+        val matchers = tokens.map { token ->
+            when {
+                // Negation
+                token.startsWith("-") && token.length > 1 -> {
+                    NotMatcher(parseSingleTerm(token.substring(1)))
+                }
+                else -> parseSingleTerm(token)
+            }
+        }
+
+        return if (matchers.size == 1) matchers[0] else AndMatcher(matchers)
+    }
+
+    private fun parseSingleTerm(term: String): Matcher {
+        // Field-specific: field:value
+        val colonIndex = term.indexOf(':')
+        if (colonIndex > 0 && colonIndex < term.length - 1) {
+            val field = term.substring(0, colonIndex).lowercase()
+            val value = term.substring(colonIndex + 1)
+            if (field in KNOWN_FIELDS) {
+                return FieldMatcher(field, value)
+            }
+        }
+        return TextMatcher(term)
+    }
+
+    private val KNOWN_FIELDS = setOf("title", "user", "username", "url", "notes", "tag")
+
+    private fun tokenize(query: String): List<String> {
+        val tokens = mutableListOf<String>()
+        var i = 0
+        while (i < query.length) {
+            // Skip whitespace
+            while (i < query.length && query[i].isWhitespace()) i++
+            if (i >= query.length) break
+
+            if (query[i] == '"') {
+                // Quoted string
+                val end = query.indexOf('"', i + 1)
+                if (end == -1) {
+                    tokens.add(query.substring(i + 1))
+                    break
+                } else {
+                    tokens.add(query.substring(i + 1, end))
+                    i = end + 1
+                }
+            } else {
+                // Unquoted token
+                val start = i
+                while (i < query.length && !query[i].isWhitespace()) i++
+                tokens.add(query.substring(start, i))
+            }
+        }
+        return tokens
+    }
+
+    // --- Matching helpers ---
+
+    private fun entryContainsText(entry: KdbxEntry, text: String, includeProtected: Boolean): Boolean {
+        val lower = text.lowercase()
+        if (entry.title.lowercase().contains(lower)) return true
+        if (entry.userName.lowercase().contains(lower)) return true
+        if (entry.url.lowercase().contains(lower)) return true
+        if (entry.notes.lowercase().contains(lower)) return true
+        if (entry.tags.any { it.lowercase().contains(lower) }) return true
+        // Search all fields (key and value)
+        for (field in entry.fields) {
+            if (field.key.lowercase().contains(lower)) return true
+            if ((!field.isProtected || includeProtected) && field.value.lowercase().contains(lower)) return true
+        }
+        return false
+    }
+
+    private fun entryMatchesRegex(entry: KdbxEntry, pattern: Regex, includeProtected: Boolean): Boolean {
+        if (pattern.containsMatchIn(entry.title)) return true
+        if (pattern.containsMatchIn(entry.userName)) return true
+        if (pattern.containsMatchIn(entry.url)) return true
+        if (pattern.containsMatchIn(entry.notes)) return true
+        if (entry.tags.any { pattern.containsMatchIn(it) }) return true
+        for (field in entry.fields) {
+            if (pattern.containsMatchIn(field.key)) return true
+            if ((!field.isProtected || includeProtected) && pattern.containsMatchIn(field.value)) return true
+        }
+        return false
+    }
+
+    // --- Group traversal ---
+
+    private fun searchGroup(
+        group: KdbxGroup,
+        matcher: Matcher,
+        includeProtected: Boolean,
+        path: List<String>,
+        results: MutableList<SearchResult>,
+    ) {
+        val currentPath = path + group.name
+        for (entry in group.entries) {
+            if (matcher.matches(entry, includeProtected)) {
+                results.add(SearchResult(entry, currentPath))
+            }
+        }
+        for (subgroup in group.groups) {
+            searchGroup(subgroup, matcher, includeProtected, currentPath, results)
+        }
+    }
+
+    private fun collectEntries(
+        group: KdbxGroup,
+        path: List<String>,
+        results: MutableList<SearchResult>,
+    ) {
+        val currentPath = path + group.name
+        for (entry in group.entries) {
+            results.add(SearchResult(entry, currentPath))
+        }
+        for (subgroup in group.groups) {
+            collectEntries(subgroup, currentPath, results)
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/common/SearchEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/common/SearchEngineTest.kt
@@ -1,0 +1,241 @@
+package org.github.keepasscompose.core.common
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SearchEngineTest {
+
+    private fun entry(
+        title: String = "",
+        userName: String = "",
+        url: String = "",
+        notes: String = "",
+        tags: List<String> = emptyList(),
+        extraFields: List<KdbxEntryField> = emptyList(),
+    ): KdbxEntry {
+        val fields = mutableListOf(
+            KdbxEntryField("Title", title),
+            KdbxEntryField("UserName", userName),
+            KdbxEntryField("Password", "secret", isProtected = true),
+            KdbxEntryField("URL", url),
+            KdbxEntryField("Notes", notes),
+        ) + extraFields
+        return KdbxEntry(uuid = title.hashCode().toString(), fields = fields, tags = tags)
+    }
+
+    private val rootGroup = KdbxGroup(
+        uuid = "root", name = "Root",
+        entries = listOf(
+            entry(title = "GitHub", userName = "john@github.com", url = "https://github.com", tags = listOf("dev", "code")),
+            entry(title = "Gmail", userName = "john@gmail.com", url = "https://mail.google.com", notes = "Personal email"),
+            entry(title = "Bank of America", userName = "john_doe", url = "https://bankofamerica.com", tags = listOf("finance")),
+        ),
+        groups = listOf(
+            KdbxGroup(
+                uuid = "work", name = "Work",
+                entries = listOf(
+                    entry(title = "Slack", userName = "john@work.com", url = "https://slack.com"),
+                    entry(
+                        title = "AWS Console", userName = "admin",
+                        extraFields = listOf(KdbxEntryField("AccountId", "123456789")),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    // --- Basic text search ---
+
+    @Test
+    fun search_byTitle() {
+        val results = SearchEngine.search(rootGroup, "GitHub")
+        assertEquals(1, results.size)
+        assertEquals("GitHub", results[0].entry.title)
+    }
+
+    @Test
+    fun search_caseInsensitive() {
+        val results = SearchEngine.search(rootGroup, "github")
+        assertEquals(1, results.size)
+        assertEquals("GitHub", results[0].entry.title)
+    }
+
+    @Test
+    fun search_byUserName() {
+        val results = SearchEngine.search(rootGroup, "john@gmail")
+        assertEquals(1, results.size)
+        assertEquals("Gmail", results[0].entry.title)
+    }
+
+    @Test
+    fun search_byUrl() {
+        val results = SearchEngine.search(rootGroup, "bankofamerica")
+        assertEquals(1, results.size)
+        assertEquals("Bank of America", results[0].entry.title)
+    }
+
+    @Test
+    fun search_byNotes() {
+        val results = SearchEngine.search(rootGroup, "Personal email")
+        assertEquals(1, results.size)
+        assertEquals("Gmail", results[0].entry.title)
+    }
+
+    @Test
+    fun search_byTag() {
+        val results = SearchEngine.search(rootGroup, "finance")
+        assertEquals(1, results.size)
+        assertEquals("Bank of America", results[0].entry.title)
+    }
+
+    @Test
+    fun search_byCustomField() {
+        val results = SearchEngine.search(rootGroup, "123456789")
+        assertEquals(1, results.size)
+        assertEquals("AWS Console", results[0].entry.title)
+    }
+
+    @Test
+    fun search_inSubgroups() {
+        val results = SearchEngine.search(rootGroup, "Slack")
+        assertEquals(1, results.size)
+        assertEquals(listOf("Root", "Work"), results[0].groupPath)
+    }
+
+    @Test
+    fun search_multipleResults() {
+        val results = SearchEngine.search(rootGroup, "john")
+        assertEquals(4, results.size) // GitHub, Gmail, Bank, Slack
+    }
+
+    @Test
+    fun search_noResults() {
+        val results = SearchEngine.search(rootGroup, "nonexistent")
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun search_emptyQuery() {
+        val results = SearchEngine.search(rootGroup, "")
+        assertEquals(0, results.size)
+    }
+
+    // --- Protected fields ---
+
+    @Test
+    fun search_protectedFieldsExcludedByDefault() {
+        val results = SearchEngine.search(rootGroup, "secret")
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun search_protectedFieldsIncludedWhenRequested() {
+        val results = SearchEngine.search(rootGroup, "secret", includeProtected = true)
+        assertEquals(5, results.size) // all entries have "secret" password
+    }
+
+    // --- AND (multiple terms) ---
+
+    @Test
+    fun search_multipleTerms_andLogic() {
+        val results = SearchEngine.search(rootGroup, "john github")
+        assertEquals(1, results.size)
+        assertEquals("GitHub", results[0].entry.title)
+    }
+
+    // --- Negation ---
+
+    @Test
+    fun search_negation() {
+        val results = SearchEngine.search(rootGroup, "john -gmail")
+        assertTrue(results.none { it.entry.title == "Gmail" })
+        assertTrue(results.any { it.entry.title == "GitHub" })
+    }
+
+    // --- Field-specific search ---
+
+    @Test
+    fun search_fieldSpecific_title() {
+        val results = SearchEngine.search(rootGroup, "title:bank")
+        assertEquals(1, results.size)
+        assertEquals("Bank of America", results[0].entry.title)
+    }
+
+    @Test
+    fun search_fieldSpecific_user() {
+        val results = SearchEngine.search(rootGroup, "user:admin")
+        assertEquals(1, results.size)
+        assertEquals("AWS Console", results[0].entry.title)
+    }
+
+    @Test
+    fun search_fieldSpecific_url() {
+        val results = SearchEngine.search(rootGroup, "url:slack")
+        assertEquals(1, results.size)
+        assertEquals("Slack", results[0].entry.title)
+    }
+
+    @Test
+    fun search_fieldSpecific_tag() {
+        val results = SearchEngine.search(rootGroup, "tag:dev")
+        assertEquals(1, results.size)
+        assertEquals("GitHub", results[0].entry.title)
+    }
+
+    @Test
+    fun search_fieldSpecific_combined() {
+        val results = SearchEngine.search(rootGroup, "title:g user:john")
+        assertEquals(2, results.size) // GitHub and Gmail both have title starting with G and user john
+    }
+
+    // --- Regex search ---
+
+    @Test
+    fun search_regex() {
+        val results = SearchEngine.search(rootGroup, "regex:G(it|ma).*")
+        assertEquals(2, results.size)
+        val titles = results.map { it.entry.title }.toSet()
+        assertTrue("GitHub" in titles)
+        assertTrue("Gmail" in titles)
+    }
+
+    @Test
+    fun search_regex_url() {
+        val results = SearchEngine.search(rootGroup, "regex:https://.*\\.com")
+        assertEquals(4, results.size) // 4 entries have .com URLs (AWS Console has no URL)
+    }
+
+    // --- Quoted strings ---
+
+    @Test
+    fun search_quotedString() {
+        val results = SearchEngine.search(rootGroup, "\"Bank of America\"")
+        assertEquals(1, results.size)
+        assertEquals("Bank of America", results[0].entry.title)
+    }
+
+    @Test
+    fun search_quotedString_noPartialMatch() {
+        val results = SearchEngine.search(rootGroup, "\"Bank of\"")
+        assertEquals(1, results.size)
+    }
+
+    // --- allEntries ---
+
+    @Test
+    fun allEntries_collectsAll() {
+        val all = SearchEngine.allEntries(rootGroup)
+        assertEquals(5, all.size)
+    }
+
+    @Test
+    fun allEntries_groupPaths() {
+        val all = SearchEngine.allEntries(rootGroup)
+        val slackResult = all.first { it.entry.title == "Slack" }
+        assertEquals(listOf("Root", "Work"), slackResult.groupPath)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SearchEngine` in `core/common` for full-text search across KeePass entries
- Case-insensitive matching across: title, username, URL, notes, custom field keys/values, tags
- Search operators: AND (multiple terms), negation (`-term`), quoted phrases (`"exact match"`)
- Field-specific search: `title:bank`, `user:john`, `url:github`, `tag:finance`
- Regex mode: `regex:pattern`
- Protected fields excluded by default, optionally included
- Recursive group traversal with group path tracking
- Add 25 unit tests covering all features

## Ticket
9.1

## Test plan
- [x] Basic search by title, username, URL, notes, tags, custom fields
- [x] Case-insensitive matching
- [x] Subgroup search with correct group paths
- [x] Multiple results, no results, empty query
- [x] Protected field exclusion/inclusion
- [x] AND logic with multiple terms
- [x] Negation with `-` prefix
- [x] Field-specific search (title:, user:, url:, tag:)
- [x] Regex search mode
- [x] Quoted string search
- [x] allEntries helper
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)