### PR TITLE
[7.9] Build entry history viewer

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryHistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryHistoryScreen.kt
@@ -1,0 +1,124 @@
+package org.github.keepasscompose.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.github.keepasscompose.core.model.KdbxEntry
+
+@Composable
+fun EntryHistoryScreen(
+    entry: KdbxEntry,
+    onViewVersion: (KdbxEntry) -> Unit = {},
+    onRestoreVersion: (KdbxEntry) -> Unit = {},
+    onDeleteVersion: (Int) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        Text(
+            text = "History: ${entry.title}",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Text(
+            text = "${entry.history.size} version${if (entry.history.size != 1) "s" else ""}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (entry.history.isEmpty()) {
+            Text(
+                text = "No history available",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                itemsIndexed(
+                    entry.history.reversed(),
+                    key = { index, _ -> index },
+                ) { index, version ->
+                    val actualIndex = entry.history.lastIndex - index
+                    HistoryVersionCard(
+                        version = version,
+                        versionNumber = actualIndex + 1,
+                        onView = { onViewVersion(version) },
+                        onRestore = { onRestoreVersion(version) },
+                        onDelete = { onDeleteVersion(actualIndex) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryVersionCard(
+    version: KdbxEntry,
+    versionNumber: Int,
+    onView: () -> Unit,
+    onRestore: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onView),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Version $versionNumber",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                version.lastModificationTime?.let {
+                    Text(
+                        text = it.toString().take(19),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = "Title: ${version.title}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = onView) {
+                Icon(Icons.Filled.Visibility, contentDescription = "View")
+            }
+            IconButton(onClick = onRestore) {
+                Icon(Icons.Filled.Restore, contentDescription = "Restore")
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Filled.Delete, contentDescription = "Delete", tint = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create `EntryHistoryScreen` listing historical versions with timestamps in reverse chronological order
- View (read-only), restore, and delete individual history entries
- Version cards with title, modification time, and action buttons

Closes #63

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify history list renders versions in reverse order
- [ ] Verify view/restore/delete callbacks fire correctly
- [ ] Verify empty state when no history

🤖 Generated with [Claude Code](https://claude.com/claude-code)