### PR TITLE
[10.3] Build copy confirmation toast/snackbar

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/CopyToast.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/CopyToast.kt
@@ -1,0 +1,70 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CopyToast(
+    label: String?,
+    secondsRemaining: Int?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val visible = label != null && secondsRemaining != null
+
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+        AnimatedVisibility(
+            visible = visible,
+            enter = fadeIn() + slideInVertically { it },
+            exit = fadeOut() + slideOutVertically { it },
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.inverseSurface,
+                contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                shape = MaterialTheme.shapes.medium,
+                shadowElevation = 6.dp,
+                modifier = Modifier.padding(16.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
+                ) {
+                    Icon(Icons.Filled.ContentCopy, contentDescription = null)
+                    Text(
+                        text = if (secondsRemaining != null && secondsRemaining > 0) {
+                            "$label copied — clearing in ${secondsRemaining}s"
+                        } else {
+                            "$label copied"
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Filled.Close, contentDescription = "Dismiss")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CopyToast` composable with animated slide-in/fade snackbar
- Shows "X copied — clearing in Ns" with countdown from `ClipboardClearTimer.secondsRemaining`
- Includes copy icon and dismiss button
- Uses Material3 inverse surface colors for contrast

Closes #77

## Test plan
- [ ] Verify JVM build compiles (`./gradlew composeApp:compileKotlinJvm`) ✅
- [ ] Verify toast appears when copy action is triggered
- [ ] Verify countdown displays correctly
- [ ] Verify dismiss button hides the toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)