### PR TITLE
[10.4] Implement one-time clipboard (Desktop)

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/OneTimeClipboard.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/OneTimeClipboard.kt
@@ -1,0 +1,25 @@
+package org.github.keepasscompose.core.common
+
+import java.awt.Toolkit
+import java.awt.datatransfer.ClipboardOwner
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+
+object OneTimeClipboard {
+
+    private val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+
+    private val owner = ClipboardOwner { _, _ ->
+        // Ownership lost means another app consumed/replaced the content.
+        // Clear the clipboard so the sensitive data cannot be pasted again.
+        try {
+            clipboard.setContents(StringSelection(""), null)
+        } catch (_: IllegalStateException) {
+            // Clipboard may be unavailable momentarily; safe to ignore.
+        }
+    }
+
+    fun copy(text: String) {
+        clipboard.setContents(StringSelection(text), owner)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `OneTimeClipboard` object for Desktop (JVM) that clears clipboard after first paste
- Uses AWT `ClipboardOwner.lostOwnership()` callback to detect when content is consumed
- Automatically sets clipboard to empty string once ownership is lost

Closes #78

## Test plan
- [ ] Verify JVM build compiles (`./gradlew composeApp:compileKotlinJvm`) ✅
- [ ] Copy text via `OneTimeClipboard.copy()`, paste once — should work
- [ ] Try pasting a second time — clipboard should be empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)