### PR TITLE
[7.11] Implement "Open URL" action

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.android.kt
@@ -1,0 +1,13 @@
+package org.github.keepasscompose.core.common
+
+import android.content.Intent
+import android.net.Uri
+
+actual fun openUrl(url: String) {
+    val normalizedUrl = if (url.contains("://")) url else "https://$url"
+    val context = AndroidContextHolder.applicationContext ?: return
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(normalizedUrl)).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.kt
@@ -1,0 +1,3 @@
+package org.github.keepasscompose.core.common
+
+expect fun openUrl(url: String)

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.ios.kt
@@ -1,0 +1,10 @@
+package org.github.keepasscompose.core.common
+
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+
+actual fun openUrl(url: String) {
+    val normalizedUrl = if (url.contains("://")) url else "https://$url"
+    val nsUrl = NSURL.URLWithString(normalizedUrl) ?: return
+    UIApplication.sharedApplication.openURL(nsUrl)
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.jvm.kt
@@ -1,0 +1,11 @@
+package org.github.keepasscompose.core.common
+
+import java.awt.Desktop
+import java.net.URI
+
+actual fun openUrl(url: String) {
+    val normalizedUrl = if (url.contains("://")) url else "https://$url"
+    if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+        Desktop.getDesktop().browse(URI(normalizedUrl))
+    }
+}


### PR DESCRIPTION
## Summary
- Create `expect fun openUrl(url: String)` with platform actual implementations
- **JVM/Desktop**: `Desktop.browse()` via AWT
- **Android**: `Intent.ACTION_VIEW` with `Uri.parse()`
- **iOS**: `UIApplication.openURL()` via `NSURL`
- Auto-prepends `https://` if no scheme is present

Closes #65

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify URL opens in default browser on desktop
- [ ] Verify scheme-less URLs get https:// prepended

🤖 Generated with [Claude Code](https://claude.com/claude-code)