### PR TITLE
[14.2] Implement CSV export

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/CsvExporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/CsvExporter.kt
@@ -1,0 +1,94 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+
+/**
+ * Exports KeePass entries to CSV format.
+ *
+ * Supports configurable field selection, custom delimiters, and
+ * optional group path column. Produces RFC 4180 compliant output
+ * with proper quoting of fields containing delimiters or newlines.
+ */
+object CsvExporter {
+
+    /**
+     * Which fields to include in the export.
+     */
+    data class Config(
+        val includeTitle: Boolean = true,
+        val includeUserName: Boolean = true,
+        val includePassword: Boolean = true,
+        val includeUrl: Boolean = true,
+        val includeNotes: Boolean = true,
+        val includeGroup: Boolean = false,
+        val delimiter: Char = ',',
+    )
+
+    /**
+     * Export all entries from the group tree to CSV.
+     *
+     * @param rootGroup The root group to export recursively.
+     * @param config Export configuration.
+     * @return The CSV content as a string.
+     */
+    fun export(rootGroup: KdbxGroup, config: Config = Config()): String {
+        val sb = StringBuilder()
+
+        // Header row
+        val headers = buildHeaders(config)
+        sb.appendLine(headers.joinToString(config.delimiter.toString()) { escapeField(it, config.delimiter) })
+
+        // Data rows
+        val entries = collectEntries(rootGroup, emptyList())
+        for ((entry, path) in entries) {
+            val row = buildRow(entry, path, config)
+            sb.appendLine(row.joinToString(config.delimiter.toString()) { escapeField(it, config.delimiter) })
+        }
+
+        return sb.toString()
+    }
+
+    private fun buildHeaders(config: Config): List<String> = buildList {
+        if (config.includeGroup) add("Group")
+        if (config.includeTitle) add("Title")
+        if (config.includeUserName) add("Username")
+        if (config.includePassword) add("Password")
+        if (config.includeUrl) add("URL")
+        if (config.includeNotes) add("Notes")
+    }
+
+    private fun buildRow(
+        entry: KdbxEntry,
+        groupPath: List<String>,
+        config: Config,
+    ): List<String> = buildList {
+        if (config.includeGroup) add(groupPath.joinToString("/"))
+        if (config.includeTitle) add(entry.title)
+        if (config.includeUserName) add(entry.userName)
+        if (config.includePassword) add(entry.password)
+        if (config.includeUrl) add(entry.url)
+        if (config.includeNotes) add(entry.notes)
+    }
+
+    internal fun escapeField(field: String, delimiter: Char): String {
+        val needsQuoting = field.contains(delimiter) || field.contains('"') ||
+            field.contains('\n') || field.contains('\r')
+        return if (needsQuoting) {
+            "\"${field.replace("\"", "\"\"")}\""
+        } else {
+            field
+        }
+    }
+
+    private fun collectEntries(
+        group: KdbxGroup,
+        path: List<String>,
+    ): List<Pair<KdbxEntry, List<String>>> {
+        val currentPath = path + group.name
+        val results = mutableListOf<Pair<KdbxEntry, List<String>>>()
+        for (entry in group.entries) results.add(entry to currentPath)
+        for (subgroup in group.groups) results.addAll(collectEntries(subgroup, currentPath))
+        return results
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/CsvExporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/CsvExporterTest.kt
@@ -1,0 +1,167 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CsvExporterTest {
+
+    private fun entry(
+        title: String = "",
+        userName: String = "",
+        password: String = "",
+        url: String = "",
+        notes: String = "",
+    ) = KdbxEntry(
+        uuid = title,
+        fields = listOf(
+            KdbxEntryField("Title", title),
+            KdbxEntryField("UserName", userName),
+            KdbxEntryField("Password", password, isProtected = true),
+            KdbxEntryField("URL", url),
+            KdbxEntryField("Notes", notes),
+        ),
+    )
+
+    @Test
+    fun export_basicEntries() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(entry("GitHub", "john", "pass123", "https://github.com", "Dev")),
+        )
+        val csv = CsvExporter.export(root)
+        val lines = csv.trim().lines()
+        assertEquals("Title,Username,Password,URL,Notes", lines[0])
+        assertEquals("GitHub,john,pass123,https://github.com,Dev", lines[1])
+    }
+
+    @Test
+    fun export_multipleEntries() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(
+                entry("Site1", "user1", "pass1"),
+                entry("Site2", "user2", "pass2"),
+            ),
+        )
+        val csv = CsvExporter.export(root)
+        assertEquals(3, csv.trim().lines().size) // header + 2 data rows
+    }
+
+    @Test
+    fun export_emptyDatabase() {
+        val root = KdbxGroup(uuid = "root", name = "Root")
+        val csv = CsvExporter.export(root)
+        assertEquals(1, csv.trim().lines().size) // header only
+    }
+
+    @Test
+    fun export_withGroupColumn() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            groups = listOf(
+                KdbxGroup(uuid = "email", name = "Email",
+                    entries = listOf(entry("Gmail", "john"))),
+            ),
+        )
+        val config = CsvExporter.Config(includeGroup = true)
+        val csv = CsvExporter.export(root, config)
+        val lines = csv.trim().lines()
+        assertTrue(lines[0].startsWith("Group,"))
+        assertTrue(lines[1].startsWith("Root/Email,"))
+    }
+
+    @Test
+    fun export_excludePassword() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(entry("Site", "user", "secret")),
+        )
+        val config = CsvExporter.Config(includePassword = false)
+        val csv = CsvExporter.export(root, config)
+        val header = csv.trim().lines()[0]
+        assertTrue("Password" !in header)
+    }
+
+    @Test
+    fun export_semicolonDelimiter() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(entry("Site", "user", "pass")),
+        )
+        val config = CsvExporter.Config(delimiter = ';')
+        val csv = CsvExporter.export(root, config)
+        assertTrue(csv.contains(";"))
+    }
+
+    // --- Escaping ---
+
+    @Test
+    fun escapeField_noSpecialChars() {
+        assertEquals("hello", CsvExporter.escapeField("hello", ','))
+    }
+
+    @Test
+    fun escapeField_containsComma() {
+        assertEquals("\"hello, world\"", CsvExporter.escapeField("hello, world", ','))
+    }
+
+    @Test
+    fun escapeField_containsQuote() {
+        assertEquals("\"say \"\"hi\"\"\"", CsvExporter.escapeField("say \"hi\"", ','))
+    }
+
+    @Test
+    fun escapeField_containsNewline() {
+        assertEquals("\"line1\nline2\"", CsvExporter.escapeField("line1\nline2", ','))
+    }
+
+    @Test
+    fun export_fieldWithComma_isQuoted() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(entry("Site, Inc.", "user")),
+        )
+        val csv = CsvExporter.export(root)
+        assertTrue(csv.contains("\"Site, Inc.\""))
+    }
+
+    // --- Subgroups ---
+
+    @Test
+    fun export_nestedSubgroups() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(entry("TopEntry")),
+            groups = listOf(
+                KdbxGroup(uuid = "sub", name = "Sub",
+                    entries = listOf(entry("SubEntry"))),
+            ),
+        )
+        val csv = CsvExporter.export(root)
+        assertEquals(3, csv.trim().lines().size) // header + 2 entries
+    }
+
+    // --- Round-trip with CsvImporter ---
+
+    @Test
+    fun export_import_roundTrip() {
+        val root = KdbxGroup(
+            uuid = "root", name = "Root",
+            entries = listOf(
+                entry("GitHub", "john", "pass123", "https://github.com", "Dev account"),
+                entry("Gmail", "john@gmail.com", "secret456", "https://gmail.com", ""),
+            ),
+        )
+        val csv = CsvExporter.export(root)
+        val imported = CsvImporter.parse(csv)
+        assertEquals(2, imported.entries.size)
+        assertEquals("GitHub", imported.entries[0].title)
+        assertEquals("john", imported.entries[0].userName)
+        assertEquals("pass123", imported.entries[0].password)
+        assertEquals("Gmail", imported.entries[1].title)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CsvExporter` in `core/database` with RFC 4180 compliant CSV output
- Configurable field selection (title, username, password, URL, notes, group path)
- Custom delimiter support, proper quoting of special characters
- Recursive group traversal with group path output
- Add 13 unit tests including round-trip test with CsvImporter

## Ticket
14.2

## Test plan
- [x] Basic single/multi-entry export
- [x] Empty database, group column, exclude password
- [x] Semicolon delimiter
- [x] Escaping: commas, quotes, newlines properly quoted
- [x] Nested subgroups
- [x] Round-trip: export → import preserves data

🤖 Generated with [Claude Code](https://claude.com/claude-code)