### PR TITLE
[14.6] Implement Bitwarden import

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/BitwardenImporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/BitwardenImporter.kt
@@ -1,0 +1,165 @@
+package org.github.keepasscompose.core.database
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+
+/**
+ * Imports entries from Bitwarden JSON export files.
+ *
+ * Bitwarden JSON structure:
+ * ```json
+ * {
+ *   "folders": [{"id": "...", "name": "..."}],
+ *   "items": [{"type": 1, "name": "...", "login": {"username": "...", ...}, ...}]
+ * }
+ * ```
+ *
+ * Also supports Bitwarden CSV exports via [CsvImporter].
+ */
+object BitwardenImporter {
+
+    data class ImportResult(
+        val entries: List<KdbxEntry>,
+        val groupTree: KdbxGroup,
+        val totalItems: Int,
+        val secureNotes: Int,
+        val cards: Int,
+        val identities: Int,
+    )
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    fun import(jsonContent: String): ImportResult {
+        val export = json.decodeFromString<BitwardenExport>(jsonContent)
+
+        val folderMap = export.folders?.associate { it.id to it.name } ?: emptyMap()
+        val entries = mutableListOf<KdbxEntry>()
+        val groupEntries = mutableMapOf<String, MutableList<KdbxEntry>>()
+        var secureNotes = 0
+        var cards = 0
+        var identities = 0
+
+        for (item in export.items.orEmpty()) {
+            when (item.type) {
+                2 -> { secureNotes++; /* process below */ }
+                3 -> { cards++; continue } // Card items — skip for now
+                4 -> { identities++; continue } // Identity items — skip for now
+            }
+
+            val fields = mutableListOf(
+                KdbxEntryField(KdbxEntry.FIELD_TITLE, item.name.orEmpty()),
+                KdbxEntryField(KdbxEntry.FIELD_USER_NAME, item.login?.username.orEmpty()),
+                KdbxEntryField(KdbxEntry.FIELD_PASSWORD, item.login?.password.orEmpty(), isProtected = true),
+                KdbxEntryField(KdbxEntry.FIELD_URL, item.login?.uris?.firstOrNull()?.uri.orEmpty()),
+                KdbxEntryField(KdbxEntry.FIELD_NOTES, item.notes.orEmpty()),
+            )
+
+            // TOTP
+            item.login?.totp?.let { totp ->
+                if (totp.isNotBlank()) fields.add(KdbxEntryField("otp", totp))
+            }
+
+            // Custom fields
+            item.fields?.forEach { cf ->
+                val isHidden = cf.type == 1
+                fields.add(KdbxEntryField(cf.name.orEmpty(), cf.value.orEmpty(), isProtected = isHidden))
+            }
+
+            val entry = KdbxEntry(uuid = "bw-${entries.size}", fields = fields)
+            entries.add(entry)
+
+            val folderName = item.folderId?.let { folderMap[it] } ?: "No Folder"
+            groupEntries.getOrPut(folderName) { mutableListOf() }.add(entry)
+        }
+
+        val groupTree = buildGroupTree(groupEntries)
+        return ImportResult(
+            entries, groupTree, export.items?.size ?: 0,
+            secureNotes, cards, identities,
+        )
+    }
+
+    /**
+     * Import from Bitwarden CSV export format.
+     * Bitwarden CSV: folder,favorite,type,name,notes,fields,reprompt,login_uri,login_username,login_password,login_totp
+     */
+    fun importCsv(csvContent: String): ImportResult {
+        val config = CsvImporter.Config(
+            mapping = CsvImporter.ColumnMapping(
+                groupColumn = 0,
+                titleColumn = 3,
+                notesColumn = 4,
+                urlColumn = 7,
+                userNameColumn = 8,
+                passwordColumn = 9,
+            ),
+        )
+        val preview = CsvImporter.parse(csvContent, config)
+        return ImportResult(
+            entries = preview.entries,
+            groupTree = preview.groupTree,
+            totalItems = preview.totalRows,
+            secureNotes = 0, cards = 0, identities = 0,
+        )
+    }
+
+    private fun buildGroupTree(groupEntries: Map<String, List<KdbxEntry>>): KdbxGroup {
+        val root = KdbxGroup(uuid = "bw-root", name = "Bitwarden Import")
+        if (groupEntries.isEmpty()) return root
+
+        val rootEntries = groupEntries["No Folder"] ?: emptyList()
+        val subgroups = groupEntries.filterKeys { it != "No Folder" }.map { (name, entries) ->
+            KdbxGroup(uuid = "bw-g-$name", name = name, entries = entries)
+        }
+
+        return root.copy(entries = rootEntries, groups = subgroups)
+    }
+
+    // --- Bitwarden JSON model ---
+
+    @Serializable
+    internal data class BitwardenExport(
+        val folders: List<BitwardenFolder>? = null,
+        val items: List<BitwardenItem>? = null,
+    )
+
+    @Serializable
+    internal data class BitwardenFolder(
+        val id: String,
+        val name: String,
+    )
+
+    @Serializable
+    internal data class BitwardenItem(
+        val type: Int = 1,
+        val name: String? = null,
+        val notes: String? = null,
+        val login: BitwardenLogin? = null,
+        val fields: List<BitwardenCustomField>? = null,
+        val folderId: String? = null,
+    )
+
+    @Serializable
+    internal data class BitwardenLogin(
+        val username: String? = null,
+        val password: String? = null,
+        val totp: String? = null,
+        val uris: List<BitwardenUri>? = null,
+    )
+
+    @Serializable
+    internal data class BitwardenUri(
+        val uri: String? = null,
+    )
+
+    @Serializable
+    internal data class BitwardenCustomField(
+        val name: String? = null,
+        val value: String? = null,
+        val type: Int = 0, // 0=text, 1=hidden, 2=boolean
+    )
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/BitwardenImporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/BitwardenImporterTest.kt
@@ -1,0 +1,134 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BitwardenImporterTest {
+
+    private val sampleJson = """
+    {
+      "folders": [
+        {"id": "f1", "name": "Email"},
+        {"id": "f2", "name": "Social"}
+      ],
+      "items": [
+        {
+          "type": 1,
+          "name": "Gmail",
+          "notes": "Personal email",
+          "folderId": "f1",
+          "login": {
+            "username": "john@gmail.com",
+            "password": "mailpass",
+            "totp": "otpauth://totp/Gmail?secret=ABC",
+            "uris": [{"uri": "https://gmail.com"}]
+          }
+        },
+        {
+          "type": 1,
+          "name": "Twitter",
+          "folderId": "f2",
+          "login": {
+            "username": "john",
+            "password": "tweetpass",
+            "uris": [{"uri": "https://twitter.com"}]
+          },
+          "fields": [
+            {"name": "Recovery Email", "value": "backup@email.com", "type": 0},
+            {"name": "PIN", "value": "1234", "type": 1}
+          ]
+        },
+        {
+          "type": 2,
+          "name": "Secret Note",
+          "notes": "Very secret"
+        },
+        {
+          "type": 3,
+          "name": "Visa Card"
+        },
+        {
+          "type": 4,
+          "name": "My Identity"
+        }
+      ]
+    }
+    """.trimIndent()
+
+    @Test
+    fun import_parsesLoginItems() {
+        val result = BitwardenImporter.import(sampleJson)
+        assertEquals(3, result.entries.size) // 2 logins + 1 secure note (cards/identities skipped)
+        assertEquals(5, result.totalItems)
+    }
+
+    @Test
+    fun import_mapsFieldsCorrectly() {
+        val result = BitwardenImporter.import(sampleJson)
+        val gmail = result.entries[0]
+        assertEquals("Gmail", gmail.title)
+        assertEquals("john@gmail.com", gmail.userName)
+        assertEquals("mailpass", gmail.password)
+        assertEquals("https://gmail.com", gmail.url)
+        assertEquals("Personal email", gmail.notes)
+    }
+
+    @Test
+    fun import_handlesTotp() {
+        val result = BitwardenImporter.import(sampleJson)
+        val gmail = result.entries[0]
+        val otpField = gmail.fields.firstOrNull { it.key == "otp" }
+        assertTrue(otpField != null)
+        assertTrue(otpField.value.startsWith("otpauth://"))
+    }
+
+    @Test
+    fun import_customFields() {
+        val result = BitwardenImporter.import(sampleJson)
+        val twitter = result.entries[1]
+        val recoveryField = twitter.fields.firstOrNull { it.key == "Recovery Email" }
+        assertTrue(recoveryField != null)
+        assertEquals("backup@email.com", recoveryField.value)
+
+        val pinField = twitter.fields.firstOrNull { it.key == "PIN" }
+        assertTrue(pinField != null)
+        assertTrue(pinField.isProtected) // type=1 is hidden
+    }
+
+    @Test
+    fun import_countsByType() {
+        val result = BitwardenImporter.import(sampleJson)
+        assertEquals(1, result.secureNotes)
+        assertEquals(1, result.cards)
+        assertEquals(1, result.identities)
+    }
+
+    @Test
+    fun import_folderMapping() {
+        val result = BitwardenImporter.import(sampleJson)
+        val groupNames = result.groupTree.groups.map { it.name }.toSet()
+        assertTrue("Email" in groupNames)
+        assertTrue("Social" in groupNames)
+    }
+
+    @Test
+    fun import_noFolderGoesToRoot() {
+        val result = BitwardenImporter.import(sampleJson)
+        // Secret note has no folderId → "No Folder" → root entries
+        val rootEntries = result.groupTree.entries
+        assertTrue(rootEntries.any { it.title == "Secret Note" })
+    }
+
+    @Test
+    fun import_emptyJson() {
+        val result = BitwardenImporter.import("""{"items": []}""")
+        assertEquals(0, result.entries.size)
+    }
+
+    @Test
+    fun import_minimalJson() {
+        val result = BitwardenImporter.import("""{}""")
+        assertEquals(0, result.entries.size)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BitwardenImporter` that parses Bitwarden JSON export format
- Handles login items (username, password, URL, TOTP), secure notes, custom fields (text/hidden)
- Folder → group tree mapping, items without folders go to root
- Counts skipped card and identity items
- Also supports Bitwarden CSV format via `CsvImporter` delegation
- Add 9 unit tests

## Ticket
14.6

## Test plan
- [x] Login items parsed with correct field mapping
- [x] TOTP migration to otp field
- [x] Custom fields with hidden/text types
- [x] Type counting (secure notes, cards, identities)
- [x] Folder → group mapping, no-folder → root
- [x] Empty JSON, minimal JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)