### PR TITLE
[14.8] Implement HTML export

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/HtmlExporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/HtmlExporter.kt
@@ -1,0 +1,96 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+
+/**
+ * Exports a KeePass database to formatted HTML (suitable for printing).
+ *
+ * Produces a self-contained HTML document with a group hierarchy table.
+ * Passwords can optionally be included or masked.
+ */
+object HtmlExporter {
+
+    data class Config(
+        val includePasswords: Boolean = false,
+        val title: String = "KeePass Database Export",
+    )
+
+    fun export(rootGroup: KdbxGroup, config: Config = Config()): String {
+        val sb = StringBuilder()
+        sb.appendLine("<!DOCTYPE html>")
+        sb.appendLine("<html lang=\"en\">")
+        sb.appendLine("<head>")
+        sb.appendLine("<meta charset=\"UTF-8\">")
+        sb.appendLine("<title>${escapeHtml(config.title)}</title>")
+        sb.appendLine("<style>")
+        sb.appendLine(CSS)
+        sb.appendLine("</style>")
+        sb.appendLine("</head>")
+        sb.appendLine("<body>")
+        sb.appendLine("<h1>${escapeHtml(config.title)}</h1>")
+        renderGroup(sb, rootGroup, 2, config)
+        sb.appendLine("</body>")
+        sb.appendLine("</html>")
+        return sb.toString()
+    }
+
+    private fun renderGroup(sb: StringBuilder, group: KdbxGroup, level: Int, config: Config) {
+        sb.appendLine("<h$level>${escapeHtml(group.name)}</h$level>")
+
+        if (group.entries.isNotEmpty()) {
+            sb.appendLine("<table>")
+            sb.appendLine("<thead><tr><th>Title</th><th>Username</th>")
+            if (config.includePasswords) sb.append("<th>Password</th>")
+            sb.appendLine("<th>URL</th><th>Notes</th></tr></thead>")
+            sb.appendLine("<tbody>")
+            for (entry in group.entries) {
+                renderEntry(sb, entry, config)
+            }
+            sb.appendLine("</tbody>")
+            sb.appendLine("</table>")
+        }
+
+        val nextLevel = minOf(level + 1, 6)
+        for (subgroup in group.groups) {
+            renderGroup(sb, subgroup, nextLevel, config)
+        }
+    }
+
+    private fun renderEntry(sb: StringBuilder, entry: KdbxEntry, config: Config) {
+        sb.append("<tr>")
+        sb.append("<td>${escapeHtml(entry.title)}</td>")
+        sb.append("<td>${escapeHtml(entry.userName)}</td>")
+        if (config.includePasswords) {
+            sb.append("<td>${escapeHtml(entry.password)}</td>")
+        }
+        val url = entry.url
+        if (url.isNotBlank()) {
+            sb.append("<td><a href=\"${escapeHtml(url)}\">${escapeHtml(url)}</a></td>")
+        } else {
+            sb.append("<td></td>")
+        }
+        sb.append("<td>${escapeHtml(entry.notes)}</td>")
+        sb.appendLine("</tr>")
+    }
+
+    internal fun escapeHtml(text: String): String = text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&#39;")
+
+    private val CSS = """
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 2em; color: #333; }
+        h1 { border-bottom: 2px solid #333; padding-bottom: 0.3em; }
+        h2, h3, h4, h5, h6 { margin-top: 1.5em; color: #555; }
+        table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; vertical-align: top; }
+        th { background-color: #f5f5f5; font-weight: 600; }
+        tr:nth-child(even) { background-color: #fafafa; }
+        a { color: #0366d6; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        @media print { body { margin: 0; } }
+    """.trimIndent()
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/HtmlExporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/HtmlExporterTest.kt
@@ -1,0 +1,99 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HtmlExporterTest {
+
+    private fun entry(title: String, userName: String = "", password: String = "", url: String = "", notes: String = "") =
+        KdbxEntry(uuid = title, fields = listOf(
+            KdbxEntryField("Title", title), KdbxEntryField("UserName", userName),
+            KdbxEntryField("Password", password, isProtected = true),
+            KdbxEntryField("URL", url), KdbxEntryField("Notes", notes),
+        ))
+
+    private val root = KdbxGroup(uuid = "root", name = "Root",
+        entries = listOf(entry("GitHub", "john", "secret", "https://github.com", "Dev")),
+        groups = listOf(KdbxGroup(uuid = "sub", name = "Email",
+            entries = listOf(entry("Gmail", "john@gmail.com", "mailpass", "https://gmail.com")))),
+    )
+
+    @Test
+    fun export_producesValidHtml() {
+        val html = HtmlExporter.export(root)
+        assertTrue(html.contains("<!DOCTYPE html>"))
+        assertTrue(html.contains("<html"))
+        assertTrue(html.contains("</html>"))
+    }
+
+    @Test
+    fun export_containsTitle() {
+        val html = HtmlExporter.export(root, HtmlExporter.Config(title = "My DB"))
+        assertTrue(html.contains("<title>My DB</title>"))
+        assertTrue(html.contains("<h1>My DB</h1>"))
+    }
+
+    @Test
+    fun export_containsEntryData() {
+        val html = HtmlExporter.export(root)
+        assertTrue(html.contains("GitHub"))
+        assertTrue(html.contains("john"))
+        assertTrue(html.contains("https://github.com"))
+    }
+
+    @Test
+    fun export_passwordsExcludedByDefault() {
+        val html = HtmlExporter.export(root)
+        assertFalse(html.contains("secret"))
+        assertFalse(html.contains("mailpass"))
+    }
+
+    @Test
+    fun export_passwordsIncludedWhenConfigured() {
+        val html = HtmlExporter.export(root, HtmlExporter.Config(includePasswords = true))
+        assertTrue(html.contains("secret"))
+        assertTrue(html.contains("mailpass"))
+    }
+
+    @Test
+    fun export_subgroups() {
+        val html = HtmlExporter.export(root)
+        assertTrue(html.contains("Email"))
+        assertTrue(html.contains("Gmail"))
+    }
+
+    @Test
+    fun export_urlAsLink() {
+        val html = HtmlExporter.export(root)
+        assertTrue(html.contains("href=\"https://github.com\""))
+    }
+
+    @Test
+    fun export_escapesHtml() {
+        val xssEntry = entry("Title <script>alert(1)</script>", "user&admin")
+        val group = KdbxGroup(uuid = "r", name = "Root", entries = listOf(xssEntry))
+        val html = HtmlExporter.export(group)
+        assertFalse(html.contains("<script>"))
+        assertTrue(html.contains("&lt;script&gt;"))
+        assertTrue(html.contains("user&amp;admin"))
+    }
+
+    @Test
+    fun export_emptyDatabase() {
+        val empty = KdbxGroup(uuid = "r", name = "Root")
+        val html = HtmlExporter.export(empty)
+        assertTrue(html.contains("Root"))
+        assertFalse(html.contains("<table>"))
+    }
+
+    @Test
+    fun export_containsCss() {
+        val html = HtmlExporter.export(root)
+        assertTrue(html.contains("<style>"))
+        assertTrue(html.contains("font-family"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HtmlExporter` producing self-contained HTML with group hierarchy and entry tables
- Print-friendly CSS, linked URLs, configurable title
- Passwords excluded by default, optionally included
- Proper HTML escaping (prevents XSS)
- Add 10 unit tests

## Ticket
14.8

## Test plan
- [x] Valid HTML structure, custom title
- [x] Entry data in output, subgroups rendered
- [x] Passwords excluded/included by config
- [x] URLs rendered as links
- [x] HTML escaping prevents XSS
- [x] Empty database, CSS included

🤖 Generated with [Claude Code](https://claude.com/claude-code)