### PR TITLE
[9.2] Build search bar component

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/SearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/SearchBar.kt
@@ -1,0 +1,107 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@Composable
+fun SearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onAdvancedSearch: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    // Debounce: emit search after 300ms of inactivity
+    var debouncedQuery by remember { mutableStateOf(query) }
+    LaunchedEffect(query) {
+        delay(300)
+        debouncedQuery = query
+        onSearch(query)
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        if (!expanded) {
+            IconButton(onClick = { onExpandedChange(true) }) {
+                Icon(Icons.Filled.Search, contentDescription = "Search")
+            }
+        }
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandHorizontally(),
+            exit = shrinkHorizontally(),
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                placeholder = { Text("Search entries...", style = MaterialTheme.typography.bodySmall) },
+                singleLine = true,
+                leadingIcon = {
+                    Icon(Icons.Filled.Search, contentDescription = null, modifier = Modifier.size(18.dp))
+                },
+                trailingIcon = {
+                    Row {
+                        if (query.isNotEmpty()) {
+                            IconButton(onClick = { onQueryChange(""); onSearch("") }) {
+                                Icon(Icons.Filled.Clear, contentDescription = "Clear", modifier = Modifier.size(18.dp))
+                            }
+                        }
+                        if (onAdvancedSearch != null) {
+                            IconButton(onClick = onAdvancedSearch) {
+                                Icon(Icons.Filled.Tune, contentDescription = "Advanced search", modifier = Modifier.size(18.dp))
+                            }
+                        }
+                    }
+                },
+                textStyle = MaterialTheme.typography.bodySmall,
+                colors = OutlinedTextFieldDefaults.colors(
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                    .focusRequester(focusRequester),
+            )
+        }
+
+        LaunchedEffect(expanded) {
+            if (expanded) {
+                focusRequester.requestFocus()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SearchBar` composable with expandable animation (expand/collapse via search icon)
- Real-time search-as-you-type with 300ms debounce via `LaunchedEffect`
- Clear button to reset query
- Optional advanced search button (tune icon) for future filter dialog
- Auto-focus on expand via `FocusRequester`

Closes #72

## Test plan
- [ ] Verify JVM build compiles (`./gradlew composeApp:compileKotlinJvm`) ✅
- [ ] Click search icon — bar expands and receives focus
- [ ] Type query — `onSearch` fires after 300ms debounce
- [ ] Click clear — query resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)