### PR TITLE
[14.9] Implement XML export (KeePass XML format)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/XmlExporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/XmlExporter.kt
@@ -1,0 +1,105 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+
+/**
+ * Exports a KeePass database to plain XML for interoperability.
+ *
+ * This is an **unencrypted** export format intended for data exchange,
+ * not for secure storage. Passwords are included in plaintext.
+ *
+ * The output follows a simplified KeePass XML structure:
+ * ```xml
+ * <KeePassFile>
+ *   <Root>
+ *     <Group>
+ *       <Name>...</Name>
+ *       <Entry>
+ *         <String><Key>Title</Key><Value>...</Value></String>
+ *         ...
+ *       </Entry>
+ *       <Group>...</Group>
+ *     </Group>
+ *   </Root>
+ * </KeePassFile>
+ * ```
+ */
+object XmlExporter {
+
+    data class Config(
+        val includePasswords: Boolean = true,
+        val indent: Boolean = true,
+    )
+
+    fun export(rootGroup: KdbxGroup, config: Config = Config()): String {
+        val sb = StringBuilder()
+        val i = if (config.indent) "\t" else ""
+
+        sb.appendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+        sb.appendLine("<KeePassFile>")
+        sb.appendLine("$i<Root>")
+        writeGroup(sb, rootGroup, if (config.indent) 2 else 0, config)
+        sb.appendLine("$i</Root>")
+        sb.appendLine("</KeePassFile>")
+
+        return sb.toString()
+    }
+
+    private fun writeGroup(sb: StringBuilder, group: KdbxGroup, depth: Int, config: Config) {
+        val ind = if (config.indent) "\t".repeat(depth) else ""
+        val ind1 = if (config.indent) "\t".repeat(depth + 1) else ""
+        val ind2 = if (config.indent) "\t".repeat(depth + 2) else ""
+
+        sb.appendLine("$ind<Group>")
+        sb.appendLine("$ind1<UUID>${escapeXml(group.uuid)}</UUID>")
+        sb.appendLine("$ind1<Name>${escapeXml(group.name)}</Name>")
+        if (group.notes.isNotBlank()) {
+            sb.appendLine("$ind1<Notes>${escapeXml(group.notes)}</Notes>")
+        }
+
+        for (entry in group.entries) {
+            writeEntry(sb, entry, depth + 1, config)
+        }
+
+        for (subgroup in group.groups) {
+            writeGroup(sb, subgroup, depth + 1, config)
+        }
+
+        sb.appendLine("$ind</Group>")
+    }
+
+    private fun writeEntry(sb: StringBuilder, entry: KdbxEntry, depth: Int, config: Config) {
+        val ind = if (config.indent) "\t".repeat(depth) else ""
+        val ind1 = if (config.indent) "\t".repeat(depth + 1) else ""
+        val ind2 = if (config.indent) "\t".repeat(depth + 2) else ""
+
+        sb.appendLine("$ind<Entry>")
+        sb.appendLine("$ind1<UUID>${escapeXml(entry.uuid)}</UUID>")
+
+        for (field in entry.fields) {
+            if (!config.includePasswords && field.isProtected) continue
+            sb.appendLine("$ind1<String>")
+            sb.appendLine("$ind2<Key>${escapeXml(field.key)}</Key>")
+            if (field.isProtected) {
+                sb.appendLine("$ind2<Value Protected=\"True\">${escapeXml(field.value)}</Value>")
+            } else {
+                sb.appendLine("$ind2<Value>${escapeXml(field.value)}</Value>")
+            }
+            sb.appendLine("$ind1</String>")
+        }
+
+        if (entry.tags.isNotEmpty()) {
+            sb.appendLine("$ind1<Tags>${escapeXml(entry.tags.joinToString(";"))}</Tags>")
+        }
+
+        sb.appendLine("$ind</Entry>")
+    }
+
+    internal fun escapeXml(text: String): String = text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;")
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/XmlExporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/XmlExporterTest.kt
@@ -1,0 +1,102 @@
+package org.github.keepasscompose.core.database
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class XmlExporterTest {
+
+    private fun entry(title: String, userName: String = "", password: String = "", url: String = "", notes: String = "", tags: List<String> = emptyList()) =
+        KdbxEntry(uuid = title, fields = listOf(
+            KdbxEntryField("Title", title), KdbxEntryField("UserName", userName),
+            KdbxEntryField("Password", password, isProtected = true),
+            KdbxEntryField("URL", url), KdbxEntryField("Notes", notes),
+        ), tags = tags)
+
+    private val root = KdbxGroup(uuid = "root", name = "Root",
+        entries = listOf(entry("GitHub", "john", "secret", "https://github.com", "Dev", listOf("dev", "code"))),
+        groups = listOf(KdbxGroup(uuid = "sub", name = "Email",
+            entries = listOf(entry("Gmail", "john@gmail.com", "mailpass")))),
+    )
+
+    @Test
+    fun export_validXmlStructure() {
+        val xml = XmlExporter.export(root)
+        assertTrue(xml.contains("<?xml version=\"1.0\""))
+        assertTrue(xml.contains("<KeePassFile>"))
+        assertTrue(xml.contains("</KeePassFile>"))
+        assertTrue(xml.contains("<Root>"))
+        assertTrue(xml.contains("<Group>"))
+        assertTrue(xml.contains("<Entry>"))
+    }
+
+    @Test
+    fun export_containsEntryFields() {
+        val xml = XmlExporter.export(root)
+        assertTrue(xml.contains("<Key>Title</Key>"))
+        assertTrue(xml.contains("<Value>GitHub</Value>"))
+        assertTrue(xml.contains("<Key>UserName</Key>"))
+        assertTrue(xml.contains("<Value>john</Value>"))
+    }
+
+    @Test
+    fun export_passwordsIncludedByDefault() {
+        val xml = XmlExporter.export(root)
+        assertTrue(xml.contains("secret"))
+        assertTrue(xml.contains("Protected=\"True\""))
+    }
+
+    @Test
+    fun export_passwordsExcludedWhenConfigured() {
+        val xml = XmlExporter.export(root, XmlExporter.Config(includePasswords = false))
+        assertFalse(xml.contains("secret"))
+        assertFalse(xml.contains("mailpass"))
+    }
+
+    @Test
+    fun export_subgroups() {
+        val xml = XmlExporter.export(root)
+        assertTrue(xml.contains("<Name>Email</Name>"))
+        assertTrue(xml.contains("<Value>Gmail</Value>"))
+    }
+
+    @Test
+    fun export_tags() {
+        val xml = XmlExporter.export(root)
+        assertTrue(xml.contains("<Tags>dev;code</Tags>"))
+    }
+
+    @Test
+    fun export_escapesXml() {
+        val xssEntry = entry("Title <script>", "user&admin")
+        val group = KdbxGroup(uuid = "r", name = "Root & \"Stuff\"", entries = listOf(xssEntry))
+        val xml = XmlExporter.export(group)
+        assertTrue(xml.contains("&lt;script&gt;"))
+        assertTrue(xml.contains("user&amp;admin"))
+        assertTrue(xml.contains("Root &amp; &quot;Stuff&quot;"))
+    }
+
+    @Test
+    fun export_emptyDatabase() {
+        val empty = KdbxGroup(uuid = "r", name = "Root")
+        val xml = XmlExporter.export(empty)
+        assertTrue(xml.contains("<Name>Root</Name>"))
+        assertFalse(xml.contains("<Entry>"))
+    }
+
+    @Test
+    fun export_noIndent() {
+        val xml = XmlExporter.export(root, XmlExporter.Config(indent = false))
+        assertFalse(xml.contains("\t"))
+    }
+
+    @Test
+    fun export_containsUuids() {
+        val xml = XmlExporter.export(root)
+        assertTrue(xml.contains("<UUID>root</UUID>"))
+        assertTrue(xml.contains("<UUID>GitHub</UUID>"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `XmlExporter` producing plain XML in simplified KeePass format
- Group hierarchy with entries, fields (with Protected attribute), tags, UUIDs
- Passwords included by default, optionally excluded
- Configurable indentation (indented or compact)
- Proper XML entity escaping
- Add 10 unit tests

## Ticket
14.9

## Test plan
- [x] Valid XML structure with KeePassFile/Root/Group/Entry
- [x] Entry fields with Key/Value pairs
- [x] Passwords included/excluded by config
- [x] Subgroups, tags, UUIDs
- [x] XML escaping prevents injection
- [x] Empty database, no-indent mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)