### PR TITLE
[19.2] Implement dynamic color (Material You) on Android

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.android.kt
@@ -1,0 +1,15 @@
+package org.github.keepasscompose.ui.theme
+
+import android.os.Build
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun dynamicColorScheme(darkTheme: Boolean): ColorScheme? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+    val context = LocalContext.current
+    return if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.kt
@@ -1,0 +1,11 @@
+package org.github.keepasscompose.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+
+/**
+ * Returns a platform-specific dynamic color scheme if available (e.g., Material You on Android 12+),
+ * or null to indicate the static scheme should be used instead.
+ */
+@Composable
+expect fun dynamicColorScheme(darkTheme: Boolean): ColorScheme?

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/KeePassTheme.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/KeePassTheme.kt
@@ -17,8 +17,13 @@ fun resolveIsDarkTheme(preference: String): Boolean = when (preference) {
 }
 
 @Composable
-fun KeePassTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
-    val targetScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+fun KeePassTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    useDynamicColor: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    val dynamicScheme = if (useDynamicColor) dynamicColorScheme(darkTheme) else null
+    val targetScheme = dynamicScheme ?: if (darkTheme) DarkColorScheme else LightColorScheme
     val animatedScheme = animateColorScheme(targetScheme)
 
     MaterialTheme(

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.ios.kt
@@ -1,0 +1,7 @@
+package org.github.keepasscompose.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun dynamicColorScheme(darkTheme: Boolean): ColorScheme? = null

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/ui/theme/DynamicColor.jvm.kt
@@ -1,0 +1,7 @@
+package org.github.keepasscompose.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun dynamicColorScheme(darkTheme: Boolean): ColorScheme? = null


### PR DESCRIPTION
## Summary
- Create `expect/actual dynamicColorScheme()` — Android 12+ uses `dynamicDarkColorScheme`/`dynamicLightColorScheme`, JVM/iOS return null (fallback to static)
- Wire into `KeePassTheme` with `useDynamicColor` parameter (default true)
- Dynamic colors still get smooth animated transitions from 19.1

Closes #123

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify Android 12+ uses wallpaper-based colors
- [ ] Verify older Android/Desktop/iOS fall back to static scheme
- [ ] Verify `useDynamicColor=false` uses static scheme on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)