### PR TITLE
[19.3] Implement custom accent color picker

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AccentColorPicker.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AccentColorPicker.kt
@@ -1,0 +1,131 @@
+package org.github.keepasscompose.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+val accentColorPresets = listOf(
+    AccentColor("Blue", Color(0xFF2C5F8A)),
+    AccentColor("Indigo", Color(0xFF3F51B5)),
+    AccentColor("Purple", Color(0xFF6750A4)),
+    AccentColor("Teal", Color(0xFF00897B)),
+    AccentColor("Green", Color(0xFF388E3C)),
+    AccentColor("Orange", Color(0xFFE65100)),
+    AccentColor("Red", Color(0xFFC62828)),
+    AccentColor("Pink", Color(0xFFAD1457)),
+    AccentColor("Cyan", Color(0xFF00838F)),
+    AccentColor("Brown", Color(0xFF5D4037)),
+    AccentColor("Gray", Color(0xFF546E7A)),
+    AccentColor("Deep Purple", Color(0xFF4527A0)),
+)
+
+data class AccentColor(
+    val name: String,
+    val color: Color,
+)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun AccentColorPicker(
+    selectedColor: Color,
+    onColorSelected: (Color) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var preview by remember { mutableStateOf(selectedColor) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Choose Accent Color") },
+        text = {
+            Column {
+                // Preview
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp)
+                        .clip(MaterialTheme.shapes.medium)
+                        .background(preview),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "Preview",
+                        color = Color.White,
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+                Text("Preset Colors", style = MaterialTheme.typography.labelMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    accentColorPresets.forEach { accent ->
+                        val isSelected = accent.color == preview
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(accent.color)
+                                .then(
+                                    if (isSelected) Modifier.border(3.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                    else Modifier.border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
+                                )
+                                .clickable { preview = accent.color },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            if (isSelected) {
+                                Icon(
+                                    Icons.Filled.Check,
+                                    contentDescription = "Selected",
+                                    tint = Color.White,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onColorSelected(preview); onDismiss() }) {
+                Text("Apply")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}


### PR DESCRIPTION
## Summary
- Create `AccentColorPicker` dialog with 12 preset color swatches in a flow grid
- Live preview bar showing selected color
- Check mark on selected swatch
- `AccentColor` data class and `accentColorPresets` list

Closes #124

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify color swatches render in grid
- [ ] Verify selection updates preview and shows check mark
- [ ] Verify Apply returns selected color

🤖 Generated with [Claude Code](https://claude.com/claude-code)