### PR TITLE
[15.4] Build "Weak Passwords" report view

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/WeakPasswordsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/WeakPasswordsScreen.kt
@@ -1,0 +1,143 @@
+package org.github.keepasscompose.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.github.keepasscompose.core.common.PasswordHealthAnalyzer
+import org.github.keepasscompose.core.common.PasswordStrength
+
+@Composable
+fun WeakPasswordsScreen(
+    weakEntries: List<PasswordHealthAnalyzer.EntryHealth>,
+    onEntryClick: (PasswordHealthAnalyzer.EntryHealth) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth().padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
+        Text("Weak Passwords", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "${weakEntries.size} ${if (weakEntries.size == 1) "entry" else "entries"} with weak passwords",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (weakEntries.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.Filled.CheckCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        "All passwords are strong!",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            return
+        }
+
+        val sorted = weakEntries.sortedBy { it.strength.level.ordinal }
+
+        LazyColumn {
+            items(sorted, key = { it.entry.uuid }) { entryHealth ->
+                WeakPasswordRow(entryHealth = entryHealth, onClick = { onEntryClick(entryHealth) })
+                HorizontalDivider()
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeakPasswordRow(entryHealth: PasswordHealthAnalyzer.EntryHealth, onClick: () -> Unit) {
+    val strengthColor = when (entryHealth.strength.level) {
+        PasswordStrength.Level.VERY_WEAK -> MaterialTheme.colorScheme.error
+        PasswordStrength.Level.WEAK -> MaterialTheme.colorScheme.error
+        PasswordStrength.Level.FAIR -> MaterialTheme.colorScheme.tertiary
+        PasswordStrength.Level.STRONG, PasswordStrength.Level.VERY_STRONG -> MaterialTheme.colorScheme.primary
+    }
+    val strengthFraction = when (entryHealth.strength.level) {
+        PasswordStrength.Level.VERY_WEAK -> 0.1f
+        PasswordStrength.Level.WEAK -> 0.3f
+        PasswordStrength.Level.FAIR -> 0.5f
+        PasswordStrength.Level.STRONG -> 0.75f
+        PasswordStrength.Level.VERY_STRONG -> 1.0f
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 0.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Filled.Key,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = entryHealth.entry.title,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = entryHealth.groupPath.joinToString(" / "),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                LinearProgressIndicator(
+                    progress = { strengthFraction },
+                    modifier = Modifier.weight(1f).height(4.dp),
+                    color = strengthColor,
+                )
+                Text(
+                    text = entryHealth.strength.level.name.replace('_', ' ').lowercase()
+                        .replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = strengthColor,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WeakPasswordsScreen` listing entries with weak passwords sorted by severity
- Each row shows entry title, group path, and strength indicator bar with level label
- Empty state with checkmark icon when all passwords are strong
- Click row to navigate to entry for editing

Closes #104

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify entries sorted by severity (very weak first)
- [ ] Verify strength bars and labels display correctly
- [ ] Verify empty state shows when no weak passwords

🤖 Generated with [Claude Code](https://claude.com/claude-code)