### PR TITLE
[19.5] Implement font size scaling

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/FontScaling.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/FontScaling.kt
@@ -1,0 +1,48 @@
+package org.github.keepasscompose.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+enum class FontScale(val factor: Float) {
+    SMALL(0.85f),
+    MEDIUM(1.0f),
+    LARGE(1.2f),
+}
+
+val LocalFontScale = compositionLocalOf { FontScale.MEDIUM }
+
+@Composable
+fun ProvideFontScale(fontScale: FontScale, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalFontScale provides fontScale, content = content)
+}
+
+fun Typography.scaled(factor: Float): Typography = Typography(
+    displayLarge = displayLarge.scaledStyle(factor),
+    displayMedium = displayMedium.scaledStyle(factor),
+    displaySmall = displaySmall.scaledStyle(factor),
+    headlineLarge = headlineLarge.scaledStyle(factor),
+    headlineMedium = headlineMedium.scaledStyle(factor),
+    headlineSmall = headlineSmall.scaledStyle(factor),
+    titleLarge = titleLarge.scaledStyle(factor),
+    titleMedium = titleMedium.scaledStyle(factor),
+    titleSmall = titleSmall.scaledStyle(factor),
+    bodyLarge = bodyLarge.scaledStyle(factor),
+    bodyMedium = bodyMedium.scaledStyle(factor),
+    bodySmall = bodySmall.scaledStyle(factor),
+    labelLarge = labelLarge.scaledStyle(factor),
+    labelMedium = labelMedium.scaledStyle(factor),
+    labelSmall = labelSmall.scaledStyle(factor),
+)
+
+private fun TextStyle.scaledStyle(factor: Float): TextStyle = copy(
+    fontSize = fontSize.scaled(factor),
+    lineHeight = lineHeight.scaled(factor),
+)
+
+private fun TextUnit.scaled(factor: Float): TextUnit =
+    if (this == TextUnit.Unspecified) this else (this.value * factor).sp

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/KeePassTheme.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/theme/KeePassTheme.kt
@@ -20,18 +20,22 @@ fun resolveIsDarkTheme(preference: String): Boolean = when (preference) {
 fun KeePassTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     useDynamicColor: Boolean = true,
+    fontScale: FontScale = FontScale.MEDIUM,
     content: @Composable () -> Unit,
 ) {
     val dynamicScheme = if (useDynamicColor) dynamicColorScheme(darkTheme) else null
     val targetScheme = dynamicScheme ?: if (darkTheme) DarkColorScheme else LightColorScheme
     val animatedScheme = animateColorScheme(targetScheme)
+    val scaledTypography = KeePassTypography.scaled(fontScale.factor)
 
-    MaterialTheme(
-        colorScheme = animatedScheme,
-        typography = KeePassTypography,
-        shapes = KeePassShapes,
-        content = content,
-    )
+    ProvideFontScale(fontScale) {
+        MaterialTheme(
+            colorScheme = animatedScheme,
+            typography = scaledTypography,
+            shapes = KeePassShapes,
+            content = content,
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Create `FontScaling.kt` with `FontScale` enum (SMALL 0.85x, MEDIUM 1.0x, LARGE 1.2x)
- `Typography.scaled()` extension to scale all 15 text styles' fontSize and lineHeight
- `LocalFontScale` CompositionLocal and `ProvideFontScale` provider
- Wire into `KeePassTheme` — accepts `fontScale` parameter, scales typography accordingly

Closes #126

## Test plan
- [x] JVM target compiles cleanly
- [ ] Verify SMALL/MEDIUM/LARGE render at correct sizes
- [ ] Verify layout adapts without clipping at LARGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)