### PR TITLE
[11.4] Integrate TOTP with entry detail view

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/EntryContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/EntryContextMenu.kt
@@ -1,13 +1,13 @@
 package org.github.keepasscompose.ui.components
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -20,6 +20,7 @@ data class EntryContextMenuCallbacks(
     val onCopyUsername: () -> Unit = {},
     val onCopyPassword: () -> Unit = {},
     val onCopyUrl: () -> Unit = {},
+    val onCopyTotp: (() -> Unit)? = null,
     val onEdit: () -> Unit = {},
     val onDelete: () -> Unit = {},
     val onOpenUrl: () -> Unit = {},
@@ -56,6 +57,16 @@ fun EntryContextMenu(expanded: Boolean, onDismissRequest: () -> Unit, callbacks:
             },
             leadingIcon = { Icon(Icons.Filled.Link, contentDescription = null) },
         )
+        if (callbacks.onCopyTotp != null) {
+            DropdownMenuItem(
+                text = { Text("Copy TOTP") },
+                onClick = {
+                    callbacks.onCopyTotp.invoke()
+                    onDismissRequest()
+                },
+                leadingIcon = { Icon(Icons.Filled.Timer, contentDescription = null) },
+            )
+        }
         HorizontalDivider()
         DropdownMenuItem(
             text = { Text("Edit Entry") },

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
@@ -33,7 +33,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.github.keepasscompose.core.common.TotpGenerator
 import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.ui.components.TotpDisplay
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -97,6 +99,20 @@ fun EntryDetailScreen(entry: KdbxEntry, onCopyField: (String) -> Unit = {}, modi
             IconButton(onClick = { onCopyField(entry.password) }) {
                 Icon(Icons.Filled.ContentCopy, contentDescription = "Copy")
             }
+        }
+
+        // TOTP
+        val totpParams = remember(entry) {
+            val fieldMap = entry.fields.associate { it.key to it.value }
+            TotpGenerator.parseKeePassAttributes(fieldMap)
+        }
+        if (totpParams != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            TotpDisplay(
+                params = totpParams,
+                onCopy = { code -> onCopyField(code) },
+            )
+            Spacer(modifier = Modifier.height(8.dp))
         }
 
         // URL

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryEditorScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.BasicAlertDialog
@@ -45,6 +46,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import org.github.keepasscompose.core.common.TotpGenerator
 
 data class EntryEditorField(val key: String, val value: String, val isProtected: Boolean = false)
 
@@ -271,6 +273,34 @@ fun EntryEditorScreen(
             }
         }
 
+        // TOTP setup
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(8.dp))
+        var showTotpSetup by remember { mutableStateOf(false) }
+        val hasTotpField = customFields.any { it.key == "otp" || it.key.startsWith("TimeOtp-") }
+        OutlinedButton(
+            onClick = { showTotpSetup = true },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(Icons.Filled.Timer, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(if (hasTotpField) "Edit TOTP" else "Set up TOTP")
+        }
+        if (showTotpSetup) {
+            TotpSetupDialog(
+                onConfirm = { params ->
+                    // Remove old TOTP fields
+                    customFields.removeAll { it.key == "otp" || it.key.startsWith("TimeOtp-") }
+                    // Add otpauth:// URI as the "otp" custom field
+                    val uri = buildOtpauthUri(params)
+                    customFields.add(EntryEditorField(key = "otp", value = uri))
+                    showTotpSetup = false
+                },
+                onDismiss = { showTotpSetup = false },
+            )
+        }
+
         // Action buttons
         Spacer(modifier = Modifier.height(24.dp))
         Row(
@@ -317,6 +347,39 @@ fun EntryEditorScreen(
             ) {
                 Text(if (isEditMode) "Save" else "Create")
             }
+        }
+    }
+}
+
+private const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+private fun buildOtpauthUri(params: TotpGenerator.TotpParams): String {
+    val secret = buildString {
+        var buffer = 0
+        var bitsLeft = 0
+        for (byte in params.secret) {
+            buffer = (buffer shl 8) or (byte.toInt() and 0xFF)
+            bitsLeft += 8
+            while (bitsLeft >= 5) {
+                bitsLeft -= 5
+                append(BASE32_ALPHABET[(buffer shr bitsLeft) and 0x1F])
+            }
+        }
+        if (bitsLeft > 0) {
+            append(BASE32_ALPHABET[(buffer shl (5 - bitsLeft)) and 0x1F])
+        }
+    }
+    return buildString {
+        append("otpauth://totp/Entry?secret=")
+        append(secret)
+        if (params.algorithm != TotpGenerator.Algorithm.SHA1) {
+            append("&algorithm=${params.algorithm.name}")
+        }
+        if (params.digits != 6) {
+            append("&digits=${params.digits}")
+        }
+        if (params.period != 30) {
+            append("&period=${params.period}")
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Entry detail screen**: Show `TotpDisplay` when TOTP is configured (auto-detected from `otp`/`TimeOtp-*` fields)
- **Entry context menu**: Add "Copy TOTP" option (only shown for entries with TOTP configured)
- **Entry editor**: Add "Set up TOTP" / "Edit TOTP" button that opens `TotpSetupDialog` and stores config as `otpauth://` URI

## Ticket
11.4

## Test plan
- [x] JVM compilation passes
- [x] spotlessCheck passes
- [x] All existing tests pass
- [ ] Visual verification: TOTP display appears for entries with otp field (manual)
- [ ] Visual verification: Copy TOTP in context menu (manual)
- [ ] Visual verification: TOTP setup button in editor (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)