### PR TITLE
[14.4] Implement 1Password import

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/OnePasswordImporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/OnePasswordImporter.kt
@@ -1,0 +1,204 @@
+package org.github.keepasscompose.core.database
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+
+/**
+ * Imports entries from 1Password export files.
+ *
+ * Supports two formats:
+ * - **CSV** (modern): Exported from 1Password 8+ via File > Export
+ * - **1PIF** (legacy): JSON-per-line format from older 1Password versions
+ *
+ * 1Password CSV columns:
+ * ```
+ * title,website,username,password,notes,type,tags
+ * ```
+ */
+object OnePasswordImporter {
+
+    data class ImportResult(
+        val entries: List<KdbxEntry>,
+        val groupTree: KdbxGroup,
+        val totalItems: Int,
+        val logins: Int,
+        val secureNotes: Int,
+        val other: Int,
+    )
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    /**
+     * Import from 1Password CSV export.
+     */
+    fun importCsv(csvContent: String): ImportResult {
+        val rows = CsvImporter.parseCsvRows(csvContent, ',')
+        if (rows.size < 2) return emptyResult()
+
+        val headers = rows[0].map { it.lowercase().trim() }
+        val dataRows = rows.drop(1)
+
+        val titleIdx = headers.indexOfFirst { it in setOf("title", "name") }
+        val urlIdx = headers.indexOfFirst { it in setOf("website", "url", "urls") }
+        val userIdx = headers.indexOfFirst { it in setOf("username", "user") }
+        val passIdx = headers.indexOfFirst { it in setOf("password") }
+        val notesIdx = headers.indexOfFirst { it in setOf("notes", "notesplain") }
+        val typeIdx = headers.indexOfFirst { it in setOf("type") }
+        val tagsIdx = headers.indexOfFirst { it in setOf("tags") }
+
+        val entries = mutableListOf<KdbxEntry>()
+        val tagGroups = mutableMapOf<String, MutableList<KdbxEntry>>()
+        var logins = 0
+        var secureNotes = 0
+        var other = 0
+
+        for (row in dataRows) {
+            fun col(idx: Int): String = if (idx >= 0 && idx < row.size) row[idx] else ""
+
+            val title = col(titleIdx)
+            val url = col(urlIdx)
+            val userName = col(userIdx)
+            val password = col(passIdx)
+            val notes = col(notesIdx)
+            val type = col(typeIdx).lowercase()
+            val tags = col(tagsIdx)
+
+            if (title.isBlank() && userName.isBlank() && password.isBlank()) continue
+
+            when {
+                type.contains("secure note") || type.contains("note") -> secureNotes++
+                type.contains("login") || type.isEmpty() -> logins++
+                else -> other++
+            }
+
+            val fields = mutableListOf(
+                KdbxEntryField(KdbxEntry.FIELD_TITLE, title),
+                KdbxEntryField(KdbxEntry.FIELD_USER_NAME, userName),
+                KdbxEntryField(KdbxEntry.FIELD_PASSWORD, password, isProtected = true),
+                KdbxEntryField(KdbxEntry.FIELD_URL, url),
+                KdbxEntryField(KdbxEntry.FIELD_NOTES, notes),
+            )
+
+            val entryTags = if (tags.isNotBlank()) {
+                tags.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+            } else {
+                emptyList()
+            }
+
+            val entry = KdbxEntry(uuid = "1p-${entries.size}", fields = fields, tags = entryTags)
+            entries.add(entry)
+
+            val primaryTag = entryTags.firstOrNull() ?: "Imported"
+            tagGroups.getOrPut(primaryTag) { mutableListOf() }.add(entry)
+        }
+
+        val groupTree = buildGroupTree(tagGroups, entries)
+        return ImportResult(entries, groupTree, dataRows.size, logins, secureNotes, other)
+    }
+
+    /**
+     * Import from 1Password 1PIF (legacy) format.
+     *
+     * 1PIF is a text file with alternating JSON objects and separator lines (`***...***`).
+     */
+    fun importOnePif(content: String): ImportResult {
+        val lines = content.lines().filter { it.isNotBlank() && !it.startsWith("***") }
+        val entries = mutableListOf<KdbxEntry>()
+        var logins = 0
+        var secureNotes = 0
+        var other = 0
+
+        for (line in lines) {
+            val item = try {
+                json.decodeFromString<OnePifItem>(line)
+            } catch (_: Exception) {
+                continue
+            }
+
+            val typeName = item.typeName.orEmpty().lowercase()
+            when {
+                typeName.contains("securenote") -> secureNotes++
+                typeName.contains("login") || typeName.contains("webform") -> logins++
+                else -> other++
+            }
+
+            val title = item.title.orEmpty()
+            val url = item.location.orEmpty()
+            val notes = item.secureContents?.notesPlain.orEmpty()
+            val userName = item.secureContents?.fields?.firstOrNull {
+                it.designation == "username" || it.name == "username"
+            }?.value.orEmpty()
+            val password = item.secureContents?.fields?.firstOrNull {
+                it.designation == "password" || it.name == "password"
+            }?.value.orEmpty()
+
+            if (title.isBlank() && userName.isBlank() && password.isBlank()) continue
+
+            val fields = mutableListOf(
+                KdbxEntryField(KdbxEntry.FIELD_TITLE, title),
+                KdbxEntryField(KdbxEntry.FIELD_USER_NAME, userName),
+                KdbxEntryField(KdbxEntry.FIELD_PASSWORD, password, isProtected = true),
+                KdbxEntryField(KdbxEntry.FIELD_URL, url),
+                KdbxEntryField(KdbxEntry.FIELD_NOTES, notes),
+            )
+
+            // Add extra fields from secureContents.fields
+            item.secureContents?.fields?.filter {
+                it.designation != "username" && it.designation != "password" &&
+                    it.name != "username" && it.name != "password" &&
+                    !it.value.isNullOrBlank()
+            }?.forEach { field ->
+                fields.add(KdbxEntryField(field.name ?: field.designation.orEmpty(), field.value.orEmpty()))
+            }
+
+            entries.add(KdbxEntry(uuid = "1p-${entries.size}", fields = fields))
+        }
+
+        val groupTree = KdbxGroup(uuid = "1p-root", name = "1Password Import", entries = entries)
+        return ImportResult(entries, groupTree, lines.size, logins, secureNotes, other)
+    }
+
+    private fun buildGroupTree(tagGroups: Map<String, List<KdbxEntry>>, allEntries: List<KdbxEntry>): KdbxGroup {
+        val root = KdbxGroup(uuid = "1p-root", name = "1Password Import")
+        if (tagGroups.isEmpty()) return root.copy(entries = allEntries)
+        if (tagGroups.size == 1 && tagGroups.keys.first() == "Imported") {
+            return root.copy(entries = allEntries)
+        }
+
+        val subgroups = tagGroups.map { (name, groupEntries) ->
+            KdbxGroup(uuid = "1p-g-$name", name = name, entries = groupEntries)
+        }
+        return root.copy(groups = subgroups)
+    }
+
+    private fun emptyResult() = ImportResult(
+        emptyList(),
+        KdbxGroup(uuid = "1p-root", name = "1Password Import"),
+        0,
+        0,
+        0,
+        0,
+    )
+
+    // --- 1PIF JSON model ---
+
+    @Serializable
+    internal data class OnePifItem(
+        val title: String? = null,
+        val typeName: String? = null,
+        val location: String? = null,
+        val secureContents: OnePifSecureContents? = null,
+    )
+
+    @Serializable
+    internal data class OnePifSecureContents(val notesPlain: String? = null, val fields: List<OnePifField>? = null)
+
+    @Serializable
+    internal data class OnePifField(val designation: String? = null, val name: String? = null, val value: String? = null)
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/OnePasswordImporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/OnePasswordImporterTest.kt
@@ -1,0 +1,130 @@
+package org.github.keepasscompose.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OnePasswordImporterTest {
+
+    // --- CSV import ---
+
+    private val sampleCsv = """
+        title,website,username,password,notes,type,tags
+        GitHub,https://github.com,john@example.com,ghpass123,Dev account,Login,dev
+        Gmail,https://gmail.com,john@gmail.com,mailpass,,Login,"email,personal"
+        API Key,,,sk-1234567890,Keep safe,Secure Note,dev
+    """.trimIndent()
+
+    @Test
+    fun importCsv_parsesEntries() {
+        val result = OnePasswordImporter.importCsv(sampleCsv)
+        assertEquals(3, result.entries.size)
+        assertEquals(3, result.totalItems)
+    }
+
+    @Test
+    fun importCsv_mapsFieldsCorrectly() {
+        val result = OnePasswordImporter.importCsv(sampleCsv)
+        val github = result.entries[0]
+        assertEquals("GitHub", github.title)
+        assertEquals("john@example.com", github.userName)
+        assertEquals("ghpass123", github.password)
+        assertEquals("https://github.com", github.url)
+        assertEquals("Dev account", github.notes)
+    }
+
+    @Test
+    fun importCsv_parsesTags() {
+        val result = OnePasswordImporter.importCsv(sampleCsv)
+        val gmail = result.entries[1]
+        assertEquals(listOf("email", "personal"), gmail.tags)
+    }
+
+    @Test
+    fun importCsv_countsByType() {
+        val result = OnePasswordImporter.importCsv(sampleCsv)
+        assertEquals(2, result.logins)
+        assertEquals(1, result.secureNotes)
+    }
+
+    @Test
+    fun importCsv_groupsByFirstTag() {
+        val result = OnePasswordImporter.importCsv(sampleCsv)
+        val groupNames = result.groupTree.groups.map { it.name }.toSet()
+        assertTrue("dev" in groupNames)
+        assertTrue("email" in groupNames)
+    }
+
+    @Test
+    fun importCsv_empty() {
+        val result = OnePasswordImporter.importCsv("")
+        assertEquals(0, result.entries.size)
+    }
+
+    @Test
+    fun importCsv_headerOnly() {
+        val result = OnePasswordImporter.importCsv("title,website,username,password,notes,type,tags")
+        assertEquals(0, result.entries.size)
+    }
+
+    @Test
+    fun importCsv_skipsBlankRows() {
+        val csv = "title,username,password\nSite,user,pass\n,,"
+        val result = OnePasswordImporter.importCsv(csv)
+        assertEquals(1, result.entries.size)
+    }
+
+    // --- 1PIF import ---
+
+    private val samplePif = """
+        {"title":"GitHub","typeName":"webforms.WebForm","location":"https://github.com","secureContents":{"notesPlain":"Dev account","fields":[{"designation":"username","value":"john"},{"designation":"password","value":"ghpass"}]}}
+        ***5642dee7-9f07-4e28-8547-8e7e1a1a1a1a***
+        {"title":"Secret Note","typeName":"securenotes.SecureNote","secureContents":{"notesPlain":"Top secret content"}}
+        ***5642dee7-9f07-4e28-8547-8e7e1a1a1a1b***
+    """.trimIndent()
+
+    @Test
+    fun importOnePif_parsesEntries() {
+        val result = OnePasswordImporter.importOnePif(samplePif)
+        assertEquals(2, result.entries.size)
+    }
+
+    @Test
+    fun importOnePif_mapsLoginFields() {
+        val result = OnePasswordImporter.importOnePif(samplePif)
+        val github = result.entries[0]
+        assertEquals("GitHub", github.title)
+        assertEquals("john", github.userName)
+        assertEquals("ghpass", github.password)
+        assertEquals("https://github.com", github.url)
+        assertEquals("Dev account", github.notes)
+    }
+
+    @Test
+    fun importOnePif_handlesSecureNotes() {
+        val result = OnePasswordImporter.importOnePif(samplePif)
+        assertEquals(1, result.logins)
+        assertEquals(1, result.secureNotes)
+        val note = result.entries[1]
+        assertEquals("Secret Note", note.title)
+        assertEquals("Top secret content", note.notes)
+    }
+
+    @Test
+    fun importOnePif_skipsSeparatorLines() {
+        val result = OnePasswordImporter.importOnePif(samplePif)
+        assertEquals(2, result.entries.size) // separators filtered out
+    }
+
+    @Test
+    fun importOnePif_empty() {
+        val result = OnePasswordImporter.importOnePif("")
+        assertEquals(0, result.entries.size)
+    }
+
+    @Test
+    fun importOnePif_invalidJson() {
+        val result = OnePasswordImporter.importOnePif("not json\n{invalid")
+        assertEquals(0, result.entries.size)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `OnePasswordImporter` supporting CSV (1Password 8+) and 1PIF (legacy) formats
- CSV: maps title, website, username, password, notes, type, tags columns
- 1PIF: parses JSON-per-line with separator filtering, extracts fields from secureContents
- Groups entries by first tag into a group tree
- Counts logins, secure notes, and other item types
- Add 14 unit tests covering both formats

## Ticket
Resolves #95

## Test plan
- [x] CSV: field mapping, tags, type counting, grouping, empty/header-only/blank rows
- [x] 1PIF: login fields, secure notes, separator filtering, empty/invalid JSON
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)