### PR TITLE
[Security] Fix critical audit findings: export defaults and allowBackup

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/CsvExporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/CsvExporter.kt
@@ -17,7 +17,7 @@ object CsvExporter {
     data class Config(
         val includeTitle: Boolean = true,
         val includeUserName: Boolean = true,
-        val includePassword: Boolean = true,
+        val includePassword: Boolean = false,
         val includeUrl: Boolean = true,
         val includeNotes: Boolean = true,
         val includeGroup: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/XmlExporter.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/database/XmlExporter.kt
@@ -26,7 +26,7 @@ import org.github.keepasscompose.core.model.KdbxGroup
  * ```
  */
 object XmlExporter {
-    data class Config(val includePasswords: Boolean = true, val indent: Boolean = true)
+    data class Config(val includePasswords: Boolean = false, val indent: Boolean = true)
 
     fun export(rootGroup: KdbxGroup, config: Config = Config()): String {
         val sb = StringBuilder()


### PR DESCRIPTION
## Summary
- **SEC-1:** Change `CsvExporter.Config.includePassword` default from `true` to `false` — prevents accidental plaintext password export
- **SEC-2:** Change `XmlExporter.Config.includePasswords` default from `true` to `false` — same protection for XML exports
- **SEC-3:** Set `android:allowBackup="false"` in AndroidManifest — prevents system backup from capturing app data

These are the 3 critical findings from the security audit. HtmlExporter already defaults to `false`.

Closes #270
Closes #271
Closes #272

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify CSV export without explicit `includePassword=true` excludes password column
- [ ] Verify XML export without explicit `includePasswords=true` excludes password values
- [ ] Verify Android manifest has `allowBackup="false"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)