### PR TITLE
[21.6] Write ViewModel / integration tests

### DIFF
--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/viewmodel/EntryEditorViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/viewmodel/EntryEditorViewModelTest.kt
@@ -1,0 +1,78 @@
+package org.github.keepasscompose.viewmodel
+
+import org.github.keepasscompose.TestFixtures
+import org.github.keepasscompose.ui.screens.EntryEditorResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EntryEditorViewModelTest {
+
+    private val vm = EntryEditorViewModel()
+
+    private fun createResult(
+        title: String = "Test",
+        userName: String = "user",
+        password: String = "pass",
+    ) = EntryEditorResult(
+        title = title,
+        userName = userName,
+        password = password,
+        url = "https://example.com",
+        notes = "",
+        iconIndex = 0,
+        tags = listOf("tag1"),
+        customFields = emptyList(),
+        expires = false,
+        expiryDate = "",
+    )
+
+    @Test
+    fun saveCreatesNewEntryWithGeneratedUuid() {
+        vm.startCreating()
+        val entry = vm.save(createResult())
+        assertNotNull(entry)
+        assertTrue(entry.uuid.isNotEmpty())
+        assertEquals("Test", entry.title)
+        assertEquals("user", entry.userName)
+        assertNotNull(entry.creationTime)
+    }
+
+    @Test
+    fun saveWithBlankTitleReturnsNull() {
+        vm.startCreating()
+        val entry = vm.save(createResult(title = ""))
+        assertNull(entry)
+        assertIs<EntryEditorState.ValidationError>(vm.state.value)
+    }
+
+    @Test
+    fun editPreservesHistoryAndUuid() {
+        val original = TestFixtures.createEntry(uuid = "orig-uuid", title = "V1")
+        vm.startEditing(original)
+        val entry = vm.save(createResult(title = "V2"))
+        assertNotNull(entry)
+        assertEquals("orig-uuid", entry.uuid)
+        assertEquals("V2", entry.title)
+        assertEquals(1, entry.history.size)
+        assertEquals("V1", entry.history[0].title)
+    }
+
+    @Test
+    fun saveSetsSavedState() {
+        vm.startCreating()
+        vm.save(createResult())
+        assertIs<EntryEditorState.Saved>(vm.state.value)
+    }
+
+    @Test
+    fun resetStateClearsToIdle() {
+        vm.startCreating()
+        vm.save(createResult())
+        vm.resetState()
+        assertIs<EntryEditorState.Idle>(vm.state.value)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/viewmodel/GroupNavigationViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/viewmodel/GroupNavigationViewModelTest.kt
@@ -1,0 +1,56 @@
+package org.github.keepasscompose.viewmodel
+
+import org.github.keepasscompose.TestFixtures
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GroupNavigationViewModelTest {
+
+    private val vm = GroupNavigationViewModel()
+
+    @Test
+    fun setRootGroupSelectsRoot() {
+        val tree = TestFixtures.createGroupTree()
+        vm.setRootGroup(tree)
+        assertEquals("Root", vm.selectedGroup.value?.name)
+    }
+
+    @Test
+    fun navigateToUpdatesSelectedGroup() {
+        val tree = TestFixtures.createGroupTree()
+        vm.setRootGroup(tree)
+        val general = tree.groups.first { it.name == "General" }
+        vm.navigateTo(general)
+        assertEquals("General", vm.selectedGroup.value?.name)
+    }
+
+    @Test
+    fun breadcrumbShowsPathFromRoot() {
+        val tree = TestFixtures.createGroupTree()
+        vm.setRootGroup(tree)
+        val creditCards = tree.groups.first { it.name == "Banking" }.groups[0]
+        vm.navigateTo(creditCards)
+        val names = vm.breadcrumb.value.map { it.name }
+        assertEquals(listOf("Root", "Banking", "Credit Cards"), names)
+    }
+
+    @Test
+    fun navigateToParentGoesUp() {
+        val tree = TestFixtures.createGroupTree()
+        vm.setRootGroup(tree)
+        val creditCards = tree.groups.first { it.name == "Banking" }.groups[0]
+        vm.navigateTo(creditCards)
+        assertTrue(vm.hasParent())
+        vm.navigateToParent()
+        assertEquals("Banking", vm.selectedGroup.value?.name)
+    }
+
+    @Test
+    fun rootHasNoParent() {
+        val tree = TestFixtures.createGroupTree()
+        vm.setRootGroup(tree)
+        assertFalse(vm.hasParent())
+    }
+}


### PR DESCRIPTION
## Summary
- `EntryEditorViewModelTest`: create new entry, blank title validation, edit preserves history/UUID, state transitions (5 tests)
- `GroupNavigationViewModelTest`: set root, navigate to group, breadcrumb path, navigate to parent, root has no parent (5 tests)

Closes #140

## Test plan
- [x] All 10 ViewModel tests pass on JVM
- Note: pre-existing `XmlExporterTest.export_passwordsIncludedByDefault` failure unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)