### PR TITLE
Fix Android build: namespace conflict and Skia references

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "org.github.keepasscompose"
+    namespace = "org.github.keepasscompose.app"
     compileSdk =
         libs.versions.android.compileSdk
             .get()

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AttachmentPreview.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AttachmentPreview.kt
@@ -1,6 +1,5 @@
 package org.github.keepasscompose.ui.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -20,12 +20,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.toComposeImageBitmap
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.model.KdbxAttachment
-import org.jetbrains.skia.Image as SkiaImage
 
 private enum class PreviewType { IMAGE, TEXT, UNSUPPORTED }
 
@@ -49,7 +45,7 @@ fun AttachmentPreview(attachment: KdbxAttachment, modifier: Modifier = Modifier)
         Spacer(modifier = Modifier.height(16.dp))
 
         when (previewType) {
-            PreviewType.IMAGE -> ImagePreview(attachment.data)
+            PreviewType.IMAGE -> ImagePlaceholder(attachment.name, attachment.data.size.toLong())
             PreviewType.TEXT -> TextPreview(attachment.data)
             PreviewType.UNSUPPORTED -> UnsupportedPreview()
         }
@@ -57,24 +53,29 @@ fun AttachmentPreview(attachment: KdbxAttachment, modifier: Modifier = Modifier)
 }
 
 @Composable
-private fun ImagePreview(data: ByteArray) {
-    val imageBitmap = remember(data) {
-        try {
-            SkiaImage.makeFromEncoded(data).toComposeImageBitmap()
-        } catch (_: Exception) {
-            null
+private fun ImagePlaceholder(name: String, size: Long) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxWidth().padding(32.dp),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Filled.Image,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = formatFileSize(size),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
-    }
-
-    if (imageBitmap != null) {
-        Image(
-            bitmap = imageBitmap,
-            contentDescription = "Image preview",
-            contentScale = ContentScale.Fit,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    } else {
-        UnsupportedPreview(message = "Failed to decode image")
     }
 }
 
@@ -82,7 +83,7 @@ private fun ImagePreview(data: ByteArray) {
 private fun TextPreview(data: ByteArray) {
     val text = remember(data) {
         try {
-            data.decodeToString().take(50_000) // Limit preview to 50K chars
+            data.decodeToString().take(50_000)
         } catch (_: Exception) {
             null
         }
@@ -92,9 +93,7 @@ private fun TextPreview(data: ByteArray) {
         Text(
             text = text,
             style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
         )
     } else {
         UnsupportedPreview(message = "Failed to decode text")


### PR DESCRIPTION
## Summary
- Change `androidApp` namespace from `org.github.keepasscompose` to `org.github.keepasscompose.app` (avoids duplicate namespace with `:composeApp` library)
- Remove Desktop-only Skia imports (`toComposeImageBitmap`, `SkiaImage`) from `AttachmentPreview.kt` in commonMain
- Replace with platform-neutral image placeholder
- Remove duplicate `formatFileSize` (already defined in `AttachmentList.kt`)

## Ticket
Fixes #267

## Test plan
- [x] JVM compilation passes
- [x] spotlessCheck passes
- [x] All tests pass
- [ ] `./gradlew :androidApp:assembleDebug` succeeds (needs Android SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)