### PR TITLE
[21.7] Write UI tests (Compose)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -76,6 +76,10 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.turbine)
         }
+        jvmTest.dependencies {
+            implementation(compose.desktop.uiTestJUnit4)
+            implementation(compose.desktop.currentOs)
+        }
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/ui/WelcomeScreenUiTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/ui/WelcomeScreenUiTest.kt
@@ -1,0 +1,56 @@
+package org.github.keepasscompose.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.github.keepasscompose.ui.screens.RecentDatabase
+import org.github.keepasscompose.ui.screens.WelcomeScreen
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class WelcomeScreenUiTest {
+
+    @Test
+    fun welcomeScreenShowsBrandingAndButtons() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                WelcomeScreen()
+            }
+        }
+        onNodeWithText("KeePass Compose").assertIsDisplayed()
+        onNodeWithText("Open Database").assertIsDisplayed()
+        onNodeWithText("New Database").assertIsDisplayed()
+    }
+
+    @Test
+    fun openDatabaseButtonTriggersCallback() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                WelcomeScreen(onOpenDatabase = { clicked = true })
+            }
+        }
+        onNodeWithText("Open Database").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun recentDatabasesAreDisplayed() = runComposeUiTest {
+        val recents = listOf(
+            RecentDatabase("MyDB", "/path/to/db.kdbx", "2025-01-01"),
+            RecentDatabase("WorkDB", "/path/to/work.kdbx", "2025-02-15"),
+        )
+        setContent {
+            MaterialTheme {
+                WelcomeScreen(recentDatabases = recents)
+            }
+        }
+        onNodeWithText("Recent Databases").assertIsDisplayed()
+        onNodeWithText("MyDB").assertIsDisplayed()
+        onNodeWithText("WorkDB").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `compose.desktop.uiTestJUnit4` dependency for Compose UI testing on JVM
- Create `WelcomeScreenUiTest` with 3 UI tests: branding/buttons visible, open database callback, recent databases display
- Uses `runComposeUiTest` API

Closes #141

## Test plan
- [x] Test sources compile on JVM
- [ ] UI tests pass with desktop rendering (requires display or virtual framebuffer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)