### PR TITLE
[SEC-5] Clear decrypted data from memory on database lock

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/DatabaseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/DatabaseViewModel.kt
@@ -107,18 +107,20 @@ class DatabaseViewModel(private val kdbxWriter: KdbxWriter, private val fileSyst
     fun needsSaveBeforeClose(): Boolean = _isDirty.value
 
     fun lock() {
-        // Clear sensitive data but preserve file path for re-unlock
-        _database.value = null
+        // Zero sensitive byte arrays in CompositeKey before releasing references
+        _compositeKey.value?.close()
         _compositeKey.value = null
+        _database.value = null
         _isLocked.value = true
         _isDirty.value = false
         inactivityTimer.stop()
     }
 
     fun close() {
+        _compositeKey.value?.close()
+        _compositeKey.value = null
         _database.value = null
         _filePath.value = null
-        _compositeKey.value = null
         _isDirty.value = false
         _isLocked.value = false
         _saveState.value = SaveState.Idle

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/MultiDatabaseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/MultiDatabaseViewModel.kt
@@ -99,6 +99,7 @@ class MultiDatabaseViewModel(private val kdbxWriter: KdbxWriter, private val fil
     }
 
     fun lock(id: String) {
+        _instances.value.find { it.id == id }?.compositeKey?.close()
         updateInstance(id) {
             it.copy(database = null, compositeKey = null, isLocked = true, isDirty = false)
         }
@@ -117,6 +118,7 @@ class MultiDatabaseViewModel(private val kdbxWriter: KdbxWriter, private val fil
     }
 
     fun close(id: String) {
+        _instances.value.find { it.id == id }?.compositeKey?.close()
         _instances.update { list -> list.filter { it.id != id } }
         if (_activeId.value == id) {
             _activeId.value = _instances.value.firstOrNull()?.id


### PR DESCRIPTION
## Summary
- Call `compositeKey.close()` to zero sensitive byte arrays before releasing references in `DatabaseViewModel.lock()` and `close()`
- Apply same fix to `MultiDatabaseViewModel.lock()` and `close()`

Closes #274

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify lock/unlock cycle works correctly
- [ ] Verify close clears data

🤖 Generated with [Claude Code](https://claude.com/claude-code)