### PR TITLE
[SEC-7] Add iOS clipboard sensitive data handling

### DIFF
--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/ClipboardManager.ios.kt
@@ -1,10 +1,21 @@
 package org.github.keepasscompose.core.common
 
+import platform.Foundation.NSDate
+import platform.Foundation.dateByAddingTimeInterval
 import platform.UIKit.UIPasteboard
 
 actual class ClipboardManager actual constructor() {
     actual fun copyToClipboard(text: String) {
-        UIPasteboard.generalPasteboard.string = text
+        // Set pasteboard item with local-only option and short expiration
+        // to prevent clipboard content from syncing via Universal Clipboard
+        // and to auto-expire after 2 minutes.
+        UIPasteboard.generalPasteboard.setItems(
+            listOf(mapOf("public.utf8-plain-text" to text)),
+            mapOf(
+                UIPasteboard.localOnly to true,
+                UIPasteboard.expirationDate to NSDate().dateByAddingTimeInterval(120.0),
+            ),
+        )
     }
 
     actual fun clearClipboard() {


### PR DESCRIPTION
## Summary
- Use `UIPasteboard.setItems()` with `localOnly: true` to prevent Universal Clipboard sync
- Set `expirationDate` to 2 minutes to auto-expire sensitive clipboard content
- Prevents passwords from syncing across Apple devices via Handoff

Closes #276

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify iOS clipboard copy still works
- [ ] Verify clipboard content doesn't sync via Universal Clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)