### PR TITLE
[SEC-8] Enable R8/ProGuard code obfuscation for release builds

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -32,7 +32,12 @@ android {
 
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,0 +1,25 @@
+# BouncyCastle — keep crypto provider classes used via reflection
+-keep class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**
+
+# KotlinX Serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Compose — keep @Composable metadata
+-keep class androidx.compose.** { *; }
+
+# DataStore
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
+    <fields>;
+}
+
+# Keep the app's model classes used in serialization
+-keep class org.github.keepasscompose.core.model.** { *; }


### PR DESCRIPTION
## Summary
- Enable `isMinifyEnabled = true` and `isShrinkResources = true` for release builds
- Add `proguard-rules.pro` with keep rules for BouncyCastle, KotlinX Serialization, Compose, DataStore, and model classes

Closes #277

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify Android release build succeeds with minification
- [ ] Verify app runs correctly in release mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)