### PR TITLE
[SEC-9] Reduce default clipboard clear timeout from 30s to 12s

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
@@ -21,7 +21,7 @@ class AppSettings(private val dataStore: DataStore<Preferences>) {
     object Defaults {
         const val AUTO_LOCK_TIMEOUT_SECONDS = 300 // 5 minutes
         const val THEME_PREFERENCE = "system" // "system", "light", "dark"
-        const val CLIPBOARD_CLEAR_TIMEOUT_SECONDS = 30 // 30 seconds
+        const val CLIPBOARD_CLEAR_TIMEOUT_SECONDS = 12 // 12 seconds
     }
 
     @OptIn(ExperimentalEncodingApi::class)


### PR DESCRIPTION
## Summary
- Reduce `CLIPBOARD_CLEAR_TIMEOUT_SECONDS` default from 30 to 12 seconds
- Minimizes the window during which sensitive data is available on clipboard
- Users can still configure a custom timeout in settings

Closes #278

## Test plan
- [ ] Verify JVM build compiles ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)