### PR TITLE
[SEC-10] Add Android network security config

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">

--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Block all cleartext (HTTP) traffic. Only HTTPS is allowed. -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- Add `network_security_config.xml` that blocks all cleartext (HTTP) traffic
- Only system-trusted HTTPS connections are allowed
- Reference config in AndroidManifest.xml via `android:networkSecurityConfig`
- Defense-in-depth: even if INTERNET permission were added in the future, cleartext is blocked

Closes #279

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify manifest references the config correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)