### PR TITLE
Wire app navigation: Welcome → Unlock → Main with real database

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/AppModule.kt
@@ -5,6 +5,12 @@ import org.github.keepasscompose.core.common.FileSystem
 import org.github.keepasscompose.core.common.PlatformFileSystem
 import org.github.keepasscompose.core.common.createDataStore
 import org.github.keepasscompose.core.common.dataStoreFilePath
+import org.github.keepasscompose.core.crypto.PlatformCryptoProvider
+import org.github.keepasscompose.core.database.KdbxReader
+import org.github.keepasscompose.core.database.KdbxWriter
+import org.github.keepasscompose.viewmodel.DatabaseViewModel
+import org.github.keepasscompose.viewmodel.GroupNavigationViewModel
+import org.github.keepasscompose.viewmodel.UnlockViewModel
 import org.koin.dsl.module
 
 val appModule =
@@ -12,4 +18,14 @@ val appModule =
         single<FileSystem> { PlatformFileSystem() }
         single { createDataStore { dataStoreFilePath() } }
         single { AppSettings(get()) }
+
+        // Crypto & database
+        single { PlatformCryptoProvider() }
+        single { KdbxReader(get<PlatformCryptoProvider>()) }
+        single { KdbxWriter(get<PlatformCryptoProvider>()) }
+
+        // ViewModels
+        single { UnlockViewModel(get(), get()) }
+        single { DatabaseViewModel(get(), get()) }
+        single { GroupNavigationViewModel() }
     }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -1,9 +1,149 @@
 package org.github.keepasscompose.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
+import org.github.keepasscompose.core.common.FilePicker
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.ui.screens.EntryDetailScreen
 import org.github.keepasscompose.ui.screens.MainScreen
+import org.github.keepasscompose.ui.screens.UnlockScreen
+import org.github.keepasscompose.ui.screens.WelcomeScreen
+import org.github.keepasscompose.viewmodel.DatabaseViewModel
+import org.github.keepasscompose.viewmodel.GroupNavigationViewModel
+import org.github.keepasscompose.viewmodel.UnlockState
+import org.github.keepasscompose.viewmodel.UnlockViewModel
+import org.koin.compose.koinInject
+
+private sealed interface AppScreen {
+    data object Welcome : AppScreen
+    data class Unlock(val databasePath: String) : AppScreen
+    data object Main : AppScreen
+    data class Detail(val entry: KdbxEntry) : AppScreen
+}
 
 @Composable
 fun AppNavigator() {
-    MainScreen()
+    val unlockViewModel: UnlockViewModel = koinInject()
+    val databaseViewModel: DatabaseViewModel = koinInject()
+    val groupNavViewModel: GroupNavigationViewModel = koinInject()
+    val filePicker = remember { FilePicker() }
+    val scope = rememberCoroutineScope()
+
+    var currentScreen: AppScreen by remember { mutableStateOf(AppScreen.Welcome) }
+    val unlockState by unlockViewModel.state.collectAsState()
+
+    // React to successful unlock
+    when (val state = unlockState) {
+        is UnlockState.Success -> {
+            val path = (currentScreen as? AppScreen.Unlock)?.databasePath ?: ""
+            databaseViewModel.setDatabase(state.database, path)
+            groupNavViewModel.setRootGroup(state.database.rootGroup)
+            unlockViewModel.resetState()
+            currentScreen = AppScreen.Main
+        }
+
+        else -> {}
+    }
+
+    when (val screen = currentScreen) {
+        is AppScreen.Welcome -> {
+            WelcomeScreen(
+                onOpenDatabase = {
+                    scope.launch {
+                        val path = filePicker.pickFile(listOf("kdbx"))
+                        if (path != null) {
+                            currentScreen = AppScreen.Unlock(path)
+                        }
+                    }
+                },
+                onNewDatabase = {},
+            )
+        }
+
+        is AppScreen.Unlock -> {
+            val keyFilePath by unlockViewModel.keyFilePath.collectAsState()
+
+            UnlockScreen(
+                databasePath = screen.databasePath,
+                keyFilePath = keyFilePath,
+                isLoading = unlockState is UnlockState.Loading,
+                errorMessage = (unlockState as? UnlockState.Error)?.message,
+                onPasswordSubmit = { password -> unlockViewModel.unlock(screen.databasePath, password) },
+                onSelectKeyFile = {
+                    scope.launch {
+                        val path = filePicker.pickFile(listOf("keyx", "key"))
+                        if (path != null) unlockViewModel.setKeyFilePath(path)
+                    }
+                },
+                onClearKeyFile = { unlockViewModel.clearKeyFile() },
+            )
+        }
+
+        is AppScreen.Main -> {
+            val database by databaseViewModel.database.collectAsState()
+            val selectedGroup by groupNavViewModel.selectedGroup.collectAsState()
+
+            MainScreen(
+                databaseName = database?.meta?.databaseName ?: "Database",
+                entryCount = selectedGroup?.entries?.size ?: 0,
+                groups = buildGroupNames(database?.rootGroup),
+                entries = selectedGroup?.entries ?: emptyList(),
+                onGroupSelected = { groupName ->
+                    val root = database?.rootGroup ?: return@MainScreen
+                    findGroup(root, groupName)?.let { groupNavViewModel.navigateTo(it) }
+                },
+                onEntrySelected = { entry -> currentScreen = AppScreen.Detail(entry) },
+                onLockDatabase = {
+                    databaseViewModel.lock()
+                    unlockViewModel.resetState()
+                    currentScreen = AppScreen.Welcome
+                },
+                onOpenDatabase = {
+                    scope.launch {
+                        val path = filePicker.pickFile(listOf("kdbx"))
+                        if (path != null) {
+                            databaseViewModel.close()
+                            currentScreen = AppScreen.Unlock(path)
+                        }
+                    }
+                },
+            )
+        }
+
+        is AppScreen.Detail -> {
+            EntryDetailScreen(
+                entry = screen.entry,
+                onBack = { currentScreen = AppScreen.Main },
+            )
+        }
+    }
+}
+
+private fun buildGroupNames(root: KdbxGroup?): List<String> {
+    if (root == null) return emptyList()
+    val names = mutableListOf<String>()
+    collectGroupNames(root, names)
+    return names
+}
+
+private fun collectGroupNames(group: KdbxGroup, names: MutableList<String>) {
+    names.add(group.name)
+    for (child in group.groups) {
+        collectGroupNames(child, names)
+    }
+}
+
+private fun findGroup(group: KdbxGroup, name: String): KdbxGroup? {
+    if (group.name == name) return group
+    for (child in group.groups) {
+        findGroup(child, name)?.let { return it }
+    }
+    return null
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
@@ -39,7 +39,7 @@ import org.github.keepasscompose.ui.components.TotpDisplay
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun EntryDetailScreen(entry: KdbxEntry, onCopyField: (String) -> Unit = {}, modifier: Modifier = Modifier) {
+fun EntryDetailScreen(entry: KdbxEntry, onCopyField: (String) -> Unit = {}, onBack: () -> Unit = {}, modifier: Modifier = Modifier) {
     var passwordVisible by remember { mutableStateOf(false) }
 
     Column(

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/HibpReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/HibpReportScreen.kt
@@ -67,7 +67,8 @@ fun HibpReportScreen(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "This check sends the first 5 characters of each password's SHA-1 hash to the Have I Been Pwned API. Your full passwords are never transmitted.",
+                    text = "This check sends the first 5 characters of each password's SHA-1 hash to the " +
+                        "Have I Been Pwned API. Your full passwords are never transmitted.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onTertiaryContainer,
                 )

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.launch
+import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.ui.components.DatabaseTab
 import org.github.keepasscompose.ui.components.DatabaseTabBar
 import org.github.keepasscompose.ui.components.Toolbar
@@ -56,6 +57,12 @@ import org.github.keepasscompose.ui.shortcuts.keyboardShortcuts
 fun MainScreen(
     databaseName: String = "",
     entryCount: Int = 0,
+    groups: List<String> = emptyList(),
+    entries: List<KdbxEntry> = emptyList(),
+    onGroupSelected: (String) -> Unit = {},
+    onEntrySelected: (KdbxEntry) -> Unit = {},
+    onLockDatabase: () -> Unit = {},
+    onOpenDatabase: () -> Unit = {},
     tabs: List<DatabaseTab> = emptyList(),
     selectedTabId: String = "",
     hasSelectedEntry: Boolean = false,
@@ -69,15 +76,23 @@ fun MainScreen(
     if (isCompact) {
         MobileMainScreen(
             databaseName = databaseName,
+            groups = groups,
+            entries = entries,
+            onGroupSelected = onGroupSelected,
+            onEntrySelected = onEntrySelected,
             onNewEntry = toolbarCallbacks.onNewEntry,
-            onOpenDatabase = toolbarCallbacks.onOpenDatabase,
-            onLockDatabase = toolbarCallbacks.onLockDatabase,
+            onOpenDatabase = onOpenDatabase,
+            onLockDatabase = onLockDatabase,
             onSearch = toolbarCallbacks.onSearch,
         )
     } else {
         DesktopMainScreen(
             databaseName = databaseName,
             entryCount = entryCount,
+            groups = groups,
+            entries = entries,
+            onGroupSelected = onGroupSelected,
+            onEntrySelected = onEntrySelected,
             tabs = tabs,
             selectedTabId = selectedTabId,
             hasSelectedEntry = hasSelectedEntry,
@@ -97,6 +112,10 @@ fun MainScreen(
 private fun DesktopMainScreen(
     databaseName: String,
     entryCount: Int,
+    groups: List<String>,
+    entries: List<KdbxEntry>,
+    onGroupSelected: (String) -> Unit,
+    onEntrySelected: (KdbxEntry) -> Unit,
     tabs: List<DatabaseTab>,
     selectedTabId: String,
     hasSelectedEntry: Boolean,
@@ -144,9 +163,9 @@ private fun DesktopMainScreen(
                 .fillMaxSize()
                 .padding(padding),
         ) {
-            GroupTreeSidebar(modifier = Modifier.width(260.dp).fillMaxHeight())
+            GroupTreeSidebar(groups = groups, onGroupSelected = onGroupSelected, modifier = Modifier.width(260.dp).fillMaxHeight())
             VerticalDivider()
-            EntryListPane(modifier = Modifier.weight(1f).fillMaxHeight())
+            EntryListPane(entries = entries, onEntrySelected = onEntrySelected, modifier = Modifier.weight(1f).fillMaxHeight())
         }
     }
 }
@@ -159,6 +178,10 @@ private fun DesktopMainScreen(
 @Composable
 private fun MobileMainScreen(
     databaseName: String,
+    groups: List<String>,
+    entries: List<KdbxEntry>,
+    onGroupSelected: (String) -> Unit,
+    onEntrySelected: (KdbxEntry) -> Unit,
     onNewEntry: () -> Unit,
     onOpenDatabase: () -> Unit,
     onLockDatabase: () -> Unit,
@@ -179,9 +202,11 @@ private fun MobileMainScreen(
                 )
                 HorizontalDivider()
                 GroupTreeSidebar(
+                    groups = groups,
                     modifier = Modifier.fillMaxWidth(),
                     onGroupSelected = { group ->
                         selectedGroup = group
+                        onGroupSelected(group)
                         scope.launch { drawerState.close() }
                     },
                 )
@@ -230,7 +255,7 @@ private fun MobileMainScreen(
                     .fillMaxSize()
                     .padding(padding),
             ) {
-                EntryListPane(modifier = Modifier.fillMaxSize())
+                EntryListPane(entries = entries, onEntrySelected = onEntrySelected, modifier = Modifier.fillMaxSize())
             }
         }
     }
@@ -241,10 +266,9 @@ private fun MobileMainScreen(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun GroupTreeSidebar(modifier: Modifier = Modifier, onGroupSelected: (String) -> Unit = {}) {
-    val placeholderGroups = listOf("Root", "General", "Email", "Internet", "Banking")
+private fun GroupTreeSidebar(groups: List<String>, modifier: Modifier = Modifier, onGroupSelected: (String) -> Unit = {}) {
     LazyColumn(modifier = modifier.background(MaterialTheme.colorScheme.surfaceContainerLow)) {
-        items(placeholderGroups) { group ->
+        items(groups) { group ->
             Text(
                 text = group,
                 style = MaterialTheme.typography.bodyLarge,
@@ -258,9 +282,8 @@ private fun GroupTreeSidebar(modifier: Modifier = Modifier, onGroupSelected: (St
 }
 
 @Composable
-private fun EntryListPane(modifier: Modifier = Modifier) {
-    val placeholderEntries = listOf("Entry 1", "Entry 2", "Entry 3")
-    if (placeholderEntries.isEmpty()) {
+private fun EntryListPane(entries: List<KdbxEntry>, onEntrySelected: (KdbxEntry) -> Unit = {}, modifier: Modifier = Modifier) {
+    if (entries.isEmpty()) {
         Box(modifier = modifier, contentAlignment = Alignment.Center) {
             Text(
                 text = "No entries",
@@ -270,15 +293,23 @@ private fun EntryListPane(modifier: Modifier = Modifier) {
         }
     } else {
         LazyColumn(modifier = modifier) {
-            items(placeholderEntries) { entry ->
-                Text(
-                    text = entry,
-                    style = MaterialTheme.typography.bodyLarge,
+            items(entries) { entry ->
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { }
+                        .clickable { onEntrySelected(entry) }
                         .padding(horizontal = 16.dp, vertical = 12.dp),
-                )
+                ) {
+                    Text(text = entry.title.ifEmpty { "Untitled" }, style = MaterialTheme.typography.bodyLarge)
+                    if (entry.userName.isNotEmpty()) {
+                        Text(
+                            text = entry.userName,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                HorizontalDivider()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ReusedPasswordsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ReusedPasswordsScreen.kt
@@ -39,7 +39,8 @@ fun ReusedPasswordsScreen(
         Text("Reused Passwords", style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = "$totalEntries ${if (totalEntries == 1) "entry" else "entries"} sharing ${reusedGroups.size} ${if (reusedGroups.size == 1) "password" else "passwords"}",
+            text = "$totalEntries ${if (totalEntries == 1) "entry" else "entries"} sharing " +
+                "${reusedGroups.size} ${if (reusedGroups.size == 1) "password" else "passwords"}",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -88,10 +89,7 @@ fun ReusedPasswordsScreen(
 }
 
 @Composable
-private fun ReusedPasswordRow(
-    entryHealth: PasswordHealthAnalyzer.EntryHealth,
-    onClick: () -> Unit,
-) {
+private fun ReusedPasswordRow(entryHealth: PasswordHealthAnalyzer.EntryHealth, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/DatabaseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/DatabaseViewModel.kt
@@ -58,6 +58,13 @@ class DatabaseViewModel(private val kdbxWriter: KdbxWriter, private val fileSyst
         _isLocked.value = false
     }
 
+    fun setDatabase(database: KdbxDatabase, filePath: String) {
+        _database.value = database
+        _filePath.value = filePath
+        _isDirty.value = false
+        _isLocked.value = false
+    }
+
     fun markDirty() {
         _isDirty.value = true
     }


### PR DESCRIPTION
## Summary
- Implement navigation state machine in `AppNavigator`: Welcome → Unlock → Main → EntryDetail
- Wire `WelcomeScreen` "Open Database" to platform `FilePicker`
- Wire `UnlockScreen` to `UnlockViewModel` → `KdbxReader` for real database decryption
- Replace `MainScreen` hardcoded placeholders with real group/entry data from `DatabaseViewModel` + `GroupNavigationViewModel`
- Wire entry click → `EntryDetailScreen` with real entry data
- Wire "Lock Database" → return to Welcome
- Register all ViewModels and crypto providers in Koin DI

## Ticket
Fixes #293

## Test plan
- [x] JVM compilation passes
- [x] spotlessCheck passes
- [x] Desktop: app launches showing Welcome screen
- [x] Desktop: "Open Database" opens file picker
- [ ] Desktop: selecting a .kdbx file → unlock screen → enter password → see real entries (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)