### PR TITLE
Fix Android crash: ClassNotFoundException for MainActivity

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
             android:exported="true"
-            android:name=".MainActivity">
+            android:name="org.github.keepasscompose.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
## Summary
- Fix `ClassNotFoundException: org.github.keepasscompose.app.MainActivity` crash on Android launch
- **Root cause:** Manifest used relative class name `.MainActivity` which resolves against the namespace `org.github.keepasscompose.app`, but the actual class is in package `org.github.keepasscompose`
- **Fix:** Use fully qualified class name `org.github.keepasscompose.MainActivity` in the manifest

Closes #298

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Verify Android app launches without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)