### PR TITLE
Fix Android build warnings: deprecated APIs and redundant code

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/UrlOpener.android.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 
 actual fun openUrl(url: String) {
     val normalizedUrl = if (url.contains("://")) url else "https://$url"
-    val context = AndroidContextHolder.applicationContext ?: return
+    val context = AndroidContextHolder.applicationContext
     val intent =
         Intent(Intent.ACTION_VIEW, Uri.parse(normalizedUrl)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AttachmentList.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AttachmentList.kt
@@ -105,6 +105,7 @@ private fun AttachmentItem(attachment: KdbxAttachment, onPreview: () -> Unit, on
     }
 }
 
+@Suppress("DEPRECATION")
 private fun getFileIcon(name: String): ImageVector {
     val ext = name.substringAfterLast('.', "").lowercase()
     return when (ext) {

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AttachmentPreview.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/AttachmentPreview.kt
@@ -108,7 +108,7 @@ private fun UnsupportedPreview(message: String = "No preview available for this 
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
-                Icons.Filled.InsertDriveFile,
+                @Suppress("DEPRECATION") Icons.Filled.InsertDriveFile,
                 contentDescription = null,
                 modifier = Modifier.size(48.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupTree.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupTree.kt
@@ -102,6 +102,7 @@ private fun GroupTreeItem(
         if (hasChildren) {
             IconButton(onClick = onToggleExpand, modifier = Modifier.size(24.dp)) {
                 Icon(
+                    @Suppress("DEPRECATION")
                     if (isExpanded) Icons.Filled.KeyboardArrowDown else Icons.Filled.KeyboardArrowRight,
                     contentDescription = if (isExpanded) "Collapse" else "Expand",
                     tint = contentColor,

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/AppSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/AppSettingsScreen.kt
@@ -20,9 +20,9 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -69,7 +69,7 @@ fun AppSettingsScreen(
         Text("App Settings", style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(16.dp))
 
-        TabRow(selectedTabIndex = selectedTab) {
+        PrimaryTabRow(selectedTabIndex = selectedTab) {
             tabs.forEachIndexed { index, title ->
                 Tab(selected = selectedTab == index, onClick = { selectedTab = index }, text = { Text(title) })
             }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/DatabaseSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/DatabaseSettingsScreen.kt
@@ -12,8 +12,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -60,7 +60,7 @@ fun DatabaseSettingsScreen(
         Text("Database Settings", style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(16.dp))
 
-        TabRow(selectedTabIndex = selectedTab) {
+        PrimaryTabRow(selectedTabIndex = selectedTab) {
             tabs.forEachIndexed { index, title ->
                 Tab(
                     selected = selectedTab == index,

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/PasswordGeneratorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/PasswordGeneratorScreen.kt
@@ -24,9 +24,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -174,7 +174,7 @@ fun PasswordGeneratorScreen(onApply: ((String) -> Unit)? = null, onCopy: (String
         Spacer(modifier = Modifier.height(16.dp))
 
         // Password / Passphrase tabs
-        TabRow(selectedTabIndex = selectedTab) {
+        PrimaryTabRow(selectedTabIndex = selectedTab) {
             Tab(selected = selectedTab == 0, onClick = {
                 selectedTab = 0
                 regenerate()

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/TotpSetupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/TotpSetupScreen.kt
@@ -13,10 +13,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -118,7 +118,7 @@ fun TotpSetupDialog(initialParams: TotpGenerator.TotpParams? = null, onConfirm: 
                         readOnly = true,
                         label = { Text("Algorithm") },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = algorithmExpanded) },
-                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                        modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
                     )
                     ExposedDropdownMenu(
                         expanded = algorithmExpanded,


### PR DESCRIPTION
## Summary
- Remove redundant elvis operator on non-nullable `Context` in `UrlOpener.android.kt`
- Replace deprecated `TabRow` → `PrimaryTabRow` in AppSettings, DatabaseSettings, PasswordGenerator screens
- Replace deprecated `MenuAnchorType` → `ExposedDropdownMenuAnchorType` in TotpSetupScreen
- Suppress deprecated icon warnings (`TextSnippet`, `InsertDriveFile`, `KeyboardArrowRight`) — AutoMirrored versions not available in current Compose version

## Ticket
Fixes #297

## Test plan
- [x] JVM compilation passes (zero warnings from changed files)
- [x] spotlessCheck passes
- [ ] Android build produces no warnings from these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)