### PR TITLE
Fix Desktop OOM crash: increase JVM heap for Argon2 KDF

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -92,10 +92,15 @@ compose.desktop {
     application {
         mainClass = "org.github.keepasscompose.MainKt"
 
+        // Argon2 KDF requires ~64MB for key derivation; ensure enough heap
+        jvmArgs += listOf("-Xmx512m")
+
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "org.github.keepasscompose"
             packageVersion = "1.0.0"
+
+            jvmArgs += listOf("-Xmx512m")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `-Xmx512m` JVM arg for both `jvmRun` and `nativeDistributions`
- Argon2 KDF allocates ~64MB for key derivation, which exceeds the default JVM heap alongside the rest of the app
- 512MB provides comfortable headroom for Argon2 + Compose rendering + database parsing

Closes #301

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Open a KDBX database on Desktop — no more OOM crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)