### PR TITLE
Fix stuck loading spinner when database open fails with OOM

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/UnlockViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/viewmodel/UnlockViewModel.kt
@@ -69,7 +69,7 @@ class UnlockViewModel(private val kdbxReader: KdbxReader, private val fileSystem
                     kdbxReader.readDatabase(data, key)
                 }
                 _state.value = UnlockState.Success(database)
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 _state.value =
                     UnlockState.Error(
                         e.message ?: "Failed to unlock database",


### PR DESCRIPTION
## Summary
- Change `catch (e: Exception)` to `catch (e: Throwable)` in `UnlockViewModel.unlock()`
- `OutOfMemoryError` extends `Error` → `Throwable`, not `Exception`, so it was uncaught
- Now any failure (including OOM, StackOverflow, etc.) properly transitions the UI to the error state

Closes #303

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Trigger a database open failure — error message shown instead of stuck spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)