### PR TITLE
Implement Android FilePicker and content URI support

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/AndroidContextHolder.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/AndroidContextHolder.kt
@@ -2,13 +2,23 @@ package org.github.keepasscompose.core.common
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.activity.ComponentActivity
+import java.lang.ref.WeakReference
 
 @SuppressLint("StaticFieldLeak")
 object AndroidContextHolder {
     lateinit var applicationContext: Context
         private set
 
+    private var activityRef: WeakReference<ComponentActivity>? = null
+
+    val activity: ComponentActivity?
+        get() = activityRef?.get()
+
     fun init(context: Context) {
         applicationContext = context.applicationContext
+        if (context is ComponentActivity) {
+            activityRef = WeakReference(context)
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/FilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/FilePicker.android.kt
@@ -1,13 +1,82 @@
 package org.github.keepasscompose.core.common
 
+import androidx.activity.result.contract.ActivityResultContracts
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.UUID
+import kotlin.coroutines.resume
+
 actual class FilePicker actual constructor() {
-    actual suspend fun pickFile(extensions: List<String>): String? {
-        // TODO: Wire to ActivityResultContracts.OpenDocument via AndroidContextHolder
-        return null
+
+    actual suspend fun pickFile(extensions: List<String>): String? = suspendCancellableCoroutine { cont ->
+        val activity = AndroidContextHolder.activity
+        if (activity == null) {
+            cont.resume(null)
+            return@suspendCancellableCoroutine
+        }
+
+        val key = "file_pick_${UUID.randomUUID()}"
+        val mimeTypes = extensions.map { extensionToMimeType(it) }.toTypedArray()
+            .ifEmpty { arrayOf("*/*") }
+
+        val launcher = activity.activityResultRegistry.register(key, ActivityResultContracts.OpenDocument()) { uri ->
+            val path = uri?.toString()
+            // Take persistable read permission so the URI works across app restarts
+            if (uri != null) {
+                try {
+                    activity.contentResolver.takePersistableUriPermission(
+                        uri,
+                        android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                    )
+                } catch (_: SecurityException) {
+                    // Best-effort; some providers don't support persistable permissions
+                }
+            }
+            cont.resume(path)
+        }
+
+        cont.invokeOnCancellation { launcher.unregister() }
+        launcher.launch(mimeTypes)
     }
 
-    actual suspend fun pickSaveLocation(defaultName: String, extensions: List<String>): String? {
-        // TODO: Wire to ActivityResultContracts.CreateDocument via AndroidContextHolder
-        return null
+    actual suspend fun pickSaveLocation(defaultName: String, extensions: List<String>): String? = suspendCancellableCoroutine { cont ->
+        val activity = AndroidContextHolder.activity
+        if (activity == null) {
+            cont.resume(null)
+            return@suspendCancellableCoroutine
+        }
+
+        val key = "file_save_${UUID.randomUUID()}"
+        val mimeType = extensions.firstOrNull()?.let { extensionToMimeType(it) } ?: "*/*"
+
+        val launcher = activity.activityResultRegistry.register(key, ActivityResultContracts.CreateDocument(mimeType)) { uri ->
+            val path = uri?.toString()
+            if (uri != null) {
+                try {
+                    activity.contentResolver.takePersistableUriPermission(
+                        uri,
+                        android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                    )
+                } catch (_: SecurityException) {
+                    // Best-effort
+                }
+            }
+            cont.resume(path)
+        }
+
+        cont.invokeOnCancellation { launcher.unregister() }
+        launcher.launch(defaultName)
+    }
+
+    private fun extensionToMimeType(ext: String): String = when (ext.lowercase()) {
+        "kdbx" -> "application/x-keepass-database"
+        "kdb" -> "application/x-keepass-database"
+        "xml" -> "text/xml"
+        "csv" -> "text/csv"
+        "html", "htm" -> "text/html"
+        "json" -> "application/json"
+        "key" -> "application/octet-stream"
+        else -> "application/octet-stream"
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/PlatformFileSystem.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/PlatformFileSystem.android.kt
@@ -1,7 +1,46 @@
 package org.github.keepasscompose.core.common
 
+import android.net.Uri
+
 actual class PlatformFileSystem actual constructor() : BaseFileSystem() {
     override fun getDefaultDatabaseDirectory(): String = AndroidContextHolder.applicationContext.filesDir
         .resolve("databases")
         .absolutePath
+
+    override fun readFile(path: String): ByteArray {
+        if (path.startsWith("content://")) {
+            val uri = Uri.parse(path)
+            return AndroidContextHolder.applicationContext.contentResolver
+                .openInputStream(uri)
+                ?.use { it.readBytes() }
+                ?: throw IllegalStateException("Cannot open content URI: $path")
+        }
+        return super.readFile(path)
+    }
+
+    override fun writeFile(path: String, data: ByteArray) {
+        if (path.startsWith("content://")) {
+            val uri = Uri.parse(path)
+            AndroidContextHolder.applicationContext.contentResolver
+                .openOutputStream(uri, "wt")
+                ?.use { it.write(data) }
+                ?: throw IllegalStateException("Cannot write to content URI: $path")
+            return
+        }
+        super.writeFile(path, data)
+    }
+
+    override fun fileExists(path: String): Boolean {
+        if (path.startsWith("content://")) {
+            return try {
+                AndroidContextHolder.applicationContext.contentResolver
+                    .openInputStream(Uri.parse(path))
+                    ?.close()
+                true
+            } catch (_: Exception) {
+                false
+            }
+        }
+        return super.fileExists(path)
+    }
 }


### PR DESCRIPTION
## Summary
- **FilePicker.android.kt**: Replace TODO stubs with working implementation using `ActivityResultContracts.OpenDocument` and `CreateDocument`
- Uses `suspendCancellableCoroutine` to bridge the callback-based Activity Result API with coroutines
- Takes persistable URI permissions so files remain accessible across app restarts
- Maps file extensions to MIME types for the system file picker
- **AndroidContextHolder**: Store weak reference to `ComponentActivity` for `activityResultRegistry` access
- **PlatformFileSystem.android.kt**: Override `readFile`, `writeFile`, `fileExists` to handle `content://` URIs via `ContentResolver` (Android returns content URIs, not file paths)

Closes #305

## Test plan
- [ ] Verify JVM build compiles ✅
- [ ] Click "Open Database" on Android — file picker dialog appears
- [ ] Select a .kdbx file — navigates to unlock screen
- [ ] Cancel file picker — returns to previous screen without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)