### PR TITLE
Fix Android file picker: unable to select .kdbx files

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/FilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/FilePicker.android.kt
@@ -70,13 +70,18 @@ actual class FilePicker actual constructor() {
     }
 
     private fun extensionToMimeType(ext: String): String = when (ext.lowercase()) {
-        "kdbx" -> "application/x-keepass-database"
-        "kdb" -> "application/x-keepass-database"
+        // kdbx/kdb have no standard MIME type registered on Android;
+        // using application/octet-stream so the picker allows selecting them.
+        "kdbx", "kdb", "keyx", "key" -> "application/octet-stream"
+
         "xml" -> "text/xml"
+
         "csv" -> "text/csv"
+
         "html", "htm" -> "text/html"
+
         "json" -> "application/json"
-        "key" -> "application/octet-stream"
+
         else -> "application/octet-stream"
     }
 }


### PR DESCRIPTION
## Summary
Change MIME type for kdbx/kdb/keyx/key files from `application/x-keepass-database` to `application/octet-stream` in the Android FilePicker. The custom MIME type is not recognized by Android's document provider, causing files to appear greyed out.

## Ticket
Fixes #309

## Test plan
- [ ] Android: "Open Database" → file picker → .kdbx files are selectable (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)