### PR TITLE
Fix DataStore singleton crash on Android quick relaunch

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".KeePassApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/androidApp/src/main/kotlin/org/github/keepasscompose/KeePassApplication.kt
+++ b/androidApp/src/main/kotlin/org/github/keepasscompose/KeePassApplication.kt
@@ -1,0 +1,13 @@
+package org.github.keepasscompose
+
+import android.app.Application
+import org.github.keepasscompose.core.common.AndroidContextHolder
+import org.github.keepasscompose.di.initKoin
+
+class KeePassApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AndroidContextHolder.init(this)
+        initKoin()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/App.kt
@@ -5,26 +5,19 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
 import org.github.keepasscompose.core.common.AppSettings
-import org.github.keepasscompose.di.appModule
-import org.github.keepasscompose.di.platformModule
 import org.github.keepasscompose.ui.navigation.AppNavigator
 import org.github.keepasscompose.ui.theme.KeePassTheme
 import org.github.keepasscompose.ui.theme.resolveIsDarkTheme
-import org.koin.compose.KoinApplication
 import org.koin.compose.koinInject
 
 @Composable
 @Preview
 fun App() {
-    KoinApplication(application = {
-        modules(appModule, platformModule())
-    }) {
-        val appSettings: AppSettings = koinInject()
-        val themePreference by appSettings.themePreference.collectAsState(
-            initial = AppSettings.Defaults.THEME_PREFERENCE,
-        )
-        KeePassTheme(darkTheme = resolveIsDarkTheme(themePreference)) {
-            AppNavigator()
-        }
+    val appSettings: AppSettings = koinInject()
+    val themePreference by appSettings.themePreference.collectAsState(
+        initial = AppSettings.Defaults.THEME_PREFERENCE,
+    )
+    KeePassTheme(darkTheme = resolveIsDarkTheme(themePreference)) {
+        AppNavigator()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/InitKoin.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/InitKoin.kt
@@ -1,0 +1,11 @@
+package org.github.keepasscompose.di
+
+import org.koin.core.KoinApplication
+import org.koin.core.context.startKoin
+
+fun initKoin(appDeclaration: (KoinApplication.() -> Unit)? = null) {
+    startKoin {
+        appDeclaration?.invoke(this)
+        modules(appModule, platformModule())
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/MainViewController.kt
@@ -1,6 +1,11 @@
 package org.github.keepasscompose
 
 import androidx.compose.ui.window.ComposeUIViewController
+import org.github.keepasscompose.di.initKoin
+import platform.UIKit.UIViewController
 
 @Suppress("ktlint:standard:function-naming")
-fun MainViewController() = ComposeUIViewController { App() }
+fun MainViewController(): UIViewController {
+    initKoin()
+    return ComposeUIViewController { App() }
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/Main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/Main.kt
@@ -3,13 +3,17 @@ package org.github.keepasscompose
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import org.github.keepasscompose.di.initKoin
 
-fun main() = application {
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = "KeePass Compose",
-        icon = painterResource("icon.png"),
-    ) {
-        App()
+fun main() {
+    initKoin()
+    application {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "KeePass Compose",
+            icon = painterResource("icon.png"),
+        ) {
+            App()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Move Koin initialization from `@Composable App()` to platform entry points (`Application.onCreate` on Android, `main()` on Desktop, `MainViewController()` on iOS)
- Create `KeePassApplication` Android Application class to host Koin startup
- Add shared `initKoin()` function in commonMain for all platforms
- `App()` now reads from the global Koin instance instead of creating a new one per recomposition

## Root Cause
`KoinApplication` inside `@Composable App()` created a fresh DI container on every recomposition. On quick Android relaunch, the previous DataStore instance hadn't been torn down yet, causing `IllegalStateException: There are multiple DataStores active for the same file`.

## Test plan
- [x] JVM compilation passes
- [x] Android assembleDebug passes
- [ ] Quick relaunch on Android no longer crashes
- [ ] Desktop app starts normally

Fixes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)