### PR TITLE
Fix tablet crash: ClassNotFoundException for KeePassApplication

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:name=".KeePassApplication"
+        android:name="org.github.keepasscompose.KeePassApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
## Summary
- Fixed `ClassNotFoundException` crash on tablet launch caused by AndroidManifest using relative class name `.KeePassApplication` which resolved against the namespace `org.github.keepasscompose.app` instead of the actual package `org.github.keepasscompose`
- Changed to fully qualified class name `org.github.keepasscompose.KeePassApplication`

Fixes #317

## Test plan
- [ ] Launch app on tablet and verify no crash
- [ ] Launch app on phone and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)