### PR TITLE
Fix rotation losing navigation state back to Welcome screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
 import org.github.keepasscompose.core.common.FilePicker
@@ -25,6 +27,23 @@ private sealed interface AppScreen {
     data object Main : AppScreen
 }
 
+private val AppScreenSaver = Saver<AppScreen, List<String>>(
+    save = { screen ->
+        when (screen) {
+            is AppScreen.Welcome -> listOf("welcome")
+            is AppScreen.Unlock -> listOf("unlock", screen.databasePath)
+            is AppScreen.Main -> listOf("main")
+        }
+    },
+    restore = { list ->
+        when (list[0]) {
+            "unlock" -> AppScreen.Unlock(list[1])
+            "main" -> AppScreen.Main
+            else -> AppScreen.Welcome
+        }
+    },
+)
+
 @Composable
 fun AppNavigator() {
     val unlockViewModel: UnlockViewModel = koinInject()
@@ -33,7 +52,7 @@ fun AppNavigator() {
     val filePicker = remember { FilePicker() }
     val scope = rememberCoroutineScope()
 
-    var currentScreen: AppScreen by remember { mutableStateOf(AppScreen.Welcome) }
+    var currentScreen: AppScreen by rememberSaveable(saver = AppScreenSaver) { mutableStateOf(AppScreen.Welcome) }
     val unlockState by unlockViewModel.state.collectAsState()
 
     // React to successful unlock


### PR DESCRIPTION
## Summary
- `currentScreen` used `remember {}` which resets on configuration change (rotation), sending the user back to the Welcome screen
- Replaced with `rememberSaveable` and a custom `Saver` for the `AppScreen` sealed class
- ViewModels are Koin singletons so database state is already preserved in memory — only the screen selection was being lost

Fixes #321

## Test plan
- [ ] Open database, rotate tablet — should stay on Main screen
- [ ] Be on Unlock screen, rotate — should stay on Unlock screen with path preserved
- [ ] Be on Welcome screen, rotate — should stay on Welcome screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)