### PR TITLE
Fix Android compilation error: use stateSaver instead of saver

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -52,7 +52,7 @@ fun AppNavigator() {
     val filePicker = remember { FilePicker() }
     val scope = rememberCoroutineScope()
 
-    var currentScreen: AppScreen by rememberSaveable(saver = AppScreenSaver) { mutableStateOf(AppScreen.Welcome) }
+    var currentScreen: AppScreen by rememberSaveable(stateSaver = AppScreenSaver) { mutableStateOf(AppScreen.Welcome) }
     val unlockState by unlockViewModel.state.collectAsState()
 
     // React to successful unlock


### PR DESCRIPTION
## Summary
- Fix `rememberSaveable` parameter name from `saver` to `stateSaver` in `AppNavigator.kt`
- The `saver` overload returns `T` directly, but `by` property delegation requires the `stateSaver` overload that returns `MutableState<T>`

Closes #323

## Test plan
- [x] `./gradlew :composeApp:compileAndroidMain` passes
- [x] `./gradlew spotlessApply` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)