### PR TITLE
Fix exporter tests broken by secure default change

### DIFF
--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/CsvExporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/CsvExporterTest.kt
@@ -28,7 +28,8 @@ class CsvExporterTest {
                 name = "Root",
                 entries = listOf(entry("GitHub", "john", "pass123", "https://github.com", "Dev")),
             )
-        val csv = CsvExporter.export(root)
+        val config = CsvExporter.Config(includePassword = true)
+        val csv = CsvExporter.export(root, config)
         val lines = csv.trim().lines()
         assertEquals("Title,Username,Password,URL,Notes", lines[0])
         assertEquals("GitHub,john,pass123,https://github.com,Dev", lines[1])
@@ -176,7 +177,8 @@ class CsvExporterTest {
                     entry("Gmail", "john@gmail.com", "secret456", "https://gmail.com", ""),
                 ),
             )
-        val csv = CsvExporter.export(root)
+        val config = CsvExporter.Config(includePassword = true)
+        val csv = CsvExporter.export(root, config)
         val imported = CsvImporter.parse(csv)
         assertEquals(2, imported.entries.size)
         assertEquals("GitHub", imported.entries[0].title)

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/XmlExporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/database/XmlExporterTest.kt
@@ -64,17 +64,17 @@ class XmlExporterTest {
     }
 
     @Test
-    fun export_passwordsIncludedByDefault() {
+    fun export_passwordsExcludedByDefault() {
         val xml = XmlExporter.export(root)
-        assertTrue(xml.contains("secret"))
-        assertTrue(xml.contains("Protected=\"True\""))
+        assertFalse(xml.contains("secret"))
+        assertFalse(xml.contains("mailpass"))
     }
 
     @Test
-    fun export_passwordsExcludedWhenConfigured() {
-        val xml = XmlExporter.export(root, XmlExporter.Config(includePasswords = false))
-        assertFalse(xml.contains("secret"))
-        assertFalse(xml.contains("mailpass"))
+    fun export_passwordsIncludedWhenConfigured() {
+        val xml = XmlExporter.export(root, XmlExporter.Config(includePasswords = true))
+        assertTrue(xml.contains("secret"))
+        assertTrue(xml.contains("Protected=\"True\""))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Update `CsvExporterTest` to explicitly pass `includePassword = true` in tests that verify password export behavior
- Update `XmlExporterTest` to test that passwords are **excluded** by default (matching the new secure default), and **included** when explicitly configured

Closes #325

## Test plan
- [x] `./gradlew :composeApp:jvmTest` — all 630 tests pass
- [x] `./gradlew spotlessApply` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)