### PR TITLE
Wire up recent databases list on welcome screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
@@ -6,7 +6,11 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -16,7 +20,12 @@ class AppSettings(private val dataStore: DataStore<Preferences>) {
         val AUTO_LOCK_TIMEOUT_SECONDS = intPreferencesKey("auto_lock_timeout_seconds")
         val THEME_PREFERENCE = stringPreferencesKey("theme_preference")
         val CLIPBOARD_CLEAR_TIMEOUT_SECONDS = intPreferencesKey("clipboard_clear_timeout_seconds")
+        val RECENT_DATABASES = stringPreferencesKey("recent_databases")
+        const val MAX_RECENT_DATABASES = 10
     }
+
+    @Serializable
+    data class RecentDatabaseEntry(val path: String, val name: String, val lastOpened: String)
 
     object Defaults {
         const val AUTO_LOCK_TIMEOUT_SECONDS = 300 // 5 minutes
@@ -66,5 +75,32 @@ class AppSettings(private val dataStore: DataStore<Preferences>) {
 
     suspend fun setClipboardClearTimeoutSeconds(seconds: Int) {
         dataStore.edit { it[CLIPBOARD_CLEAR_TIMEOUT_SECONDS] = seconds }
+    }
+
+    val recentDatabases: Flow<List<RecentDatabaseEntry>>
+        get() = dataStore.data.map { prefs ->
+            prefs[RECENT_DATABASES]?.let { json ->
+                try {
+                    Json.decodeFromString<List<RecentDatabaseEntry>>(json)
+                } catch (_: Exception) {
+                    emptyList()
+                }
+            } ?: emptyList()
+        }
+
+    suspend fun addRecentDatabase(path: String, name: String, timestamp: String) {
+        val current = recentDatabases.first().toMutableList()
+        current.removeAll { it.path == path }
+        current.add(0, RecentDatabaseEntry(path = path, name = name, lastOpened = timestamp))
+        if (current.size > MAX_RECENT_DATABASES) {
+            current.subList(MAX_RECENT_DATABASES, current.size).clear()
+        }
+        dataStore.edit { it[RECENT_DATABASES] = Json.encodeToString(current.toList()) }
+    }
+
+    suspend fun removeRecentDatabase(path: String) {
+        val current = recentDatabases.first().toMutableList()
+        current.removeAll { it.path == path }
+        dataStore.edit { it[RECENT_DATABASES] = Json.encodeToString(current.toList()) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -10,9 +10,13 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.github.keepasscompose.core.common.AppSettings
 import org.github.keepasscompose.core.common.FilePicker
 import org.github.keepasscompose.core.model.KdbxGroup
 import org.github.keepasscompose.ui.screens.MainScreen
+import org.github.keepasscompose.ui.screens.RecentDatabase
 import org.github.keepasscompose.ui.screens.UnlockScreen
 import org.github.keepasscompose.ui.screens.WelcomeScreen
 import org.github.keepasscompose.viewmodel.DatabaseViewModel
@@ -49,20 +53,31 @@ fun AppNavigator() {
     val unlockViewModel: UnlockViewModel = koinInject()
     val databaseViewModel: DatabaseViewModel = koinInject()
     val groupNavViewModel: GroupNavigationViewModel = koinInject()
+    val appSettings: AppSettings = koinInject()
     val filePicker = remember { FilePicker() }
     val scope = rememberCoroutineScope()
 
     var currentScreen: AppScreen by rememberSaveable(stateSaver = AppScreenSaver) { mutableStateOf(AppScreen.Welcome) }
     val unlockState by unlockViewModel.state.collectAsState()
+    val recentEntries by appSettings.recentDatabases.collectAsState(initial = emptyList())
 
     // React to successful unlock
     when (val state = unlockState) {
         is UnlockState.Success -> {
             val path = (currentScreen as? AppScreen.Unlock)?.databasePath ?: ""
+            val dbName = state.database.meta.databaseName.ifBlank {
+                path.substringAfterLast('/').substringBeforeLast('.')
+            }
             databaseViewModel.setDatabase(state.database, path)
             groupNavViewModel.setRootGroup(state.database.rootGroup)
             unlockViewModel.resetState()
             currentScreen = AppScreen.Main
+            scope.launch {
+                val now = kotlin.time.Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+                val timestamp = "${now.year}-${now.monthNumber.toString().padStart(2, '0')}-${now.dayOfMonth.toString().padStart(2, '0')} " +
+                    "${now.hour.toString().padStart(2, '0')}:${now.minute.toString().padStart(2, '0')}"
+                appSettings.addRecentDatabase(path, dbName, timestamp)
+            }
         }
 
         else -> {}
@@ -71,6 +86,7 @@ fun AppNavigator() {
     when (currentScreen) {
         is AppScreen.Welcome -> {
             WelcomeScreen(
+                recentDatabases = recentEntries.map { RecentDatabase(it.name, it.path, it.lastOpened) },
                 onOpenDatabase = {
                     scope.launch {
                         val path = filePicker.pickFile(listOf("kdbx"))
@@ -80,6 +96,12 @@ fun AppNavigator() {
                     }
                 },
                 onNewDatabase = {},
+                onRecentDatabaseSelected = { db ->
+                    currentScreen = AppScreen.Unlock(db.path)
+                },
+                onRemoveRecentDatabase = { db ->
+                    scope.launch { appSettings.removeRecentDatabase(db.path) }
+                },
             )
         }
 


### PR DESCRIPTION
## Summary
- Add recent databases persistence to `AppSettings` using JSON-serialized DataStore preference (stores path, name, timestamp; max 10 entries)
- Wire `AppNavigator` to collect recent databases and pass them to `WelcomeScreen`
- On successful unlock, save database to recent list with name and timestamp
- Clicking a recent entry navigates to the unlock screen with that database path
- Remove button deletes the entry from the persisted list

Closes #327

## Test plan
- [x] `./gradlew :composeApp:compileAndroidMain` passes
- [x] `./gradlew :composeApp:compileKotlinJvm` passes
- [x] `./gradlew :composeApp:jvmTest` — all 630 tests pass
- [ ] Manual: open a database, lock, verify it appears in recent list on welcome screen
- [ ] Manual: click recent entry, verify it navigates to unlock
- [ ] Manual: remove recent entry, verify it disappears
- [ ] Manual: relaunch app, verify recent list persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)