### PR TITLE
Fix WelcomeScreen and UnlockScreen not following system dark theme

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        android:theme="@android:style/Theme.Material.DayNight.NoActionBar">
         <activity
             android:exported="true"
             android:name="org.github.keepasscompose.MainActivity">

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/UnlockScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/UnlockScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,113 +49,115 @@ fun UnlockScreen(
     var password by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Icon(
-            Icons.Filled.Lock,
-            contentDescription = null,
-            modifier = Modifier.size(48.dp),
-            tint = MaterialTheme.colorScheme.primary,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Unlock Database",
-            style = MaterialTheme.typography.headlineSmall,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = databasePath,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth(0.8f),
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        OutlinedTextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Master Password") },
-            singleLine = true,
-            enabled = !isLoading,
-            visualTransformation = if (passwordVisible) {
-                VisualTransformation.None
-            } else {
-                PasswordVisualTransformation()
-            },
-            trailingIcon = {
-                IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                    Icon(
-                        if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
-                        contentDescription = if (passwordVisible) "Hide password" else "Show password",
-                    )
-                }
-            },
-            modifier = Modifier.fillMaxWidth(0.8f),
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // Key file selector
-        Row(
-            modifier = Modifier.fillMaxWidth(0.8f),
-            verticalAlignment = Alignment.CenterVertically,
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
+            Icon(
+                Icons.Filled.Lock,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Unlock Database",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = databasePath,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(0.8f),
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
             OutlinedTextField(
-                value = keyFilePath,
-                onValueChange = {},
-                label = { Text("Key File (optional)") },
-                readOnly = true,
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Master Password") },
                 singleLine = true,
                 enabled = !isLoading,
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            OutlinedButton(
-                onClick = if (keyFilePath.isEmpty()) onSelectKeyFile else onClearKeyFile,
-                enabled = !isLoading,
-            ) {
-                if (keyFilePath.isEmpty()) {
-                    Icon(Icons.Filled.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text("Browse")
+                visualTransformation = if (passwordVisible) {
+                    VisualTransformation.None
                 } else {
-                    Text("Clear")
-                }
-            }
-        }
-
-        if (errorMessage != null) {
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = errorMessage,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
+                    PasswordVisualTransformation()
+                },
+                trailingIcon = {
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(
+                            if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                            contentDescription = if (passwordVisible) "Hide password" else "Show password",
+                        )
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(0.8f),
             )
-        }
 
-        Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
-        Button(
-            onClick = { onPasswordSubmit(password) },
-            enabled = password.isNotEmpty() && !isLoading,
-            modifier = Modifier.fillMaxWidth(0.8f),
-        ) {
-            if (isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(18.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.onPrimary,
+            // Key file selector
+            Row(
+                modifier = Modifier.fillMaxWidth(0.8f),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = keyFilePath,
+                    onValueChange = {},
+                    label = { Text("Key File (optional)") },
+                    readOnly = true,
+                    singleLine = true,
+                    enabled = !isLoading,
+                    modifier = Modifier.weight(1f),
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text("Unlocking...")
-            } else {
-                Text("Unlock")
+                OutlinedButton(
+                    onClick = if (keyFilePath.isEmpty()) onSelectKeyFile else onClearKeyFile,
+                    enabled = !isLoading,
+                ) {
+                    if (keyFilePath.isEmpty()) {
+                        Icon(Icons.Filled.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Browse")
+                    } else {
+                        Text("Clear")
+                    }
+                }
+            }
+
+            if (errorMessage != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = errorMessage,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = { onPasswordSubmit(password) },
+                enabled = password.isNotEmpty() && !isLoading,
+                modifier = Modifier.fillMaxWidth(0.8f),
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Unlocking...")
+                } else {
+                    Text("Unlock")
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/WelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/WelcomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -42,62 +43,64 @@ fun WelcomeScreen(
     onRecentDatabaseSelected: (RecentDatabase) -> Unit = {},
     onRemoveRecentDatabase: (RecentDatabase) -> Unit = {},
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Spacer(modifier = Modifier.height(48.dp))
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(48.dp))
 
-        Icon(
-            Icons.Filled.Lock,
-            contentDescription = null,
-            modifier = Modifier.size(64.dp),
-            tint = MaterialTheme.colorScheme.primary,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "KeePass Compose",
-            style = MaterialTheme.typography.headlineMedium,
-        )
-        Text(
-            text = "Secure password manager",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Button(onClick = onOpenDatabase) {
-                Icon(Icons.Filled.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Open Database")
-            }
-            OutlinedButton(onClick = onNewDatabase) {
-                Icon(Icons.AutoMirrored.Filled.NoteAdd, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("New Database")
-            }
-        }
-
-        if (recentDatabases.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(32.dp))
-            Text(
-                text = "Recent Databases",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.fillMaxWidth(),
+            Icon(
+                Icons.Filled.Lock,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.primary,
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                items(recentDatabases) { db ->
-                    RecentDatabaseItem(
-                        database = db,
-                        onClick = { onRecentDatabaseSelected(db) },
-                        onRemove = { onRemoveRecentDatabase(db) },
-                    )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "KeePass Compose",
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            Text(
+                text = "Secure password manager",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = onOpenDatabase) {
+                    Icon(Icons.Filled.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Open Database")
+                }
+                OutlinedButton(onClick = onNewDatabase) {
+                    Icon(Icons.AutoMirrored.Filled.NoteAdd, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("New Database")
+                }
+            }
+
+            if (recentDatabases.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = "Recent Databases",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    items(recentDatabases) { db ->
+                        RecentDatabaseItem(
+                            database = db,
+                            onClick = { onRecentDatabaseSelected(db) },
+                            onRemove = { onRemoveRecentDatabase(db) },
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Wrap `WelcomeScreen` and `UnlockScreen` root content in `Surface(Modifier.fillMaxSize())` to apply themed background color
- Change Activity theme from `Theme.Material.Light.NoActionBar` to `Theme.Material.DayNight.NoActionBar` so the window background follows system dark/light mode

**Root cause:** MainScreen uses `Scaffold`/`Surface` which paint the themed background, but WelcomeScreen and UnlockScreen used a plain `Column` with no background — so the hardcoded light window theme showed through.

Closes #329

## Test plan
- [x] `./gradlew :composeApp:compileAndroidMain` passes
- [x] `./gradlew :composeApp:jvmTest` — all 630 tests pass
- [ ] Manual: toggle system dark mode, verify WelcomeScreen follows theme
- [ ] Manual: verify UnlockScreen follows theme
- [ ] Manual: verify MainScreen still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)