### PR TITLE
[#331] Replace drawer with inline group folders

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -14,7 +14,6 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.github.keepasscompose.core.common.AppSettings
 import org.github.keepasscompose.core.common.FilePicker
-import org.github.keepasscompose.core.model.KdbxGroup
 import org.github.keepasscompose.ui.screens.MainScreen
 import org.github.keepasscompose.ui.screens.RecentDatabase
 import org.github.keepasscompose.ui.screens.UnlockScreen
@@ -128,16 +127,14 @@ fun AppNavigator() {
         is AppScreen.Main -> {
             val database by databaseViewModel.database.collectAsState()
             val selectedGroup by groupNavViewModel.selectedGroup.collectAsState()
+            val breadcrumb by groupNavViewModel.breadcrumb.collectAsState()
 
             MainScreen(
                 databaseName = database?.meta?.databaseName ?: "Database",
-                entryCount = selectedGroup?.entries?.size ?: 0,
-                groups = buildGroupNames(database?.rootGroup),
-                entries = selectedGroup?.entries ?: emptyList(),
-                onGroupSelected = { groupName ->
-                    val root = database?.rootGroup ?: return@MainScreen
-                    findGroup(root, groupName)?.let { groupNavViewModel.navigateTo(it) }
-                },
+                selectedGroup = selectedGroup,
+                hasParentGroup = breadcrumb.size > 1,
+                onGroupSelected = { group -> groupNavViewModel.navigateTo(group) },
+                onNavigateUp = { groupNavViewModel.navigateToParent() },
                 onLockDatabase = {
                     databaseViewModel.lock()
                     unlockViewModel.resetState()
@@ -157,24 +154,3 @@ fun AppNavigator() {
     }
 }
 
-private fun buildGroupNames(root: KdbxGroup?): List<String> {
-    if (root == null) return emptyList()
-    val names = mutableListOf<String>()
-    collectGroupNames(root, names)
-    return names
-}
-
-private fun collectGroupNames(group: KdbxGroup, names: MutableList<String>) {
-    names.add(group.name)
-    for (child in group.groups) {
-        collectGroupNames(child, names)
-    }
-}
-
-private fun findGroup(group: KdbxGroup, name: String): KdbxGroup? {
-    if (group.name == name) return group
-    for (child in group.groups) {
-        findGroup(child, name)?.let { return it }
-    }
-    return null
-}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -6,26 +6,27 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -37,28 +38,24 @@ import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
 import org.github.keepasscompose.ui.common.BackHandler
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
     databaseName: String = "",
-    entryCount: Int = 0,
-    groups: List<String> = emptyList(),
-    entries: List<KdbxEntry> = emptyList(),
-    onGroupSelected: (String) -> Unit = {},
+    selectedGroup: KdbxGroup? = null,
+    hasParentGroup: Boolean = false,
+    onGroupSelected: (KdbxGroup) -> Unit = {},
+    onNavigateUp: () -> Unit = {},
     onCopyField: (String) -> Unit = {},
     onLockDatabase: () -> Unit = {},
     onOpenDatabase: () -> Unit = {},
@@ -67,8 +64,9 @@ fun MainScreen(
 ) {
     val navigator = rememberListDetailPaneScaffoldNavigator<String>()
     val scope = rememberCoroutineScope()
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
-    var selectedGroup by remember { mutableStateOf("Root") }
+    val entries = selectedGroup?.entries ?: emptyList()
+    val subGroups = selectedGroup?.groups ?: emptyList()
+    val entryCount = entries.size
     val selectedEntry = entries.find { it.uuid == navigator.currentDestination?.contentKey }
 
     val isListHidden = navigator.scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Hidden
@@ -78,139 +76,108 @@ fun MainScreen(
         scope.launch { navigator.navigateBack() }
     }
 
-    ModalNavigationDrawer(
-        gesturesEnabled = !isListHidden,
-        drawerState = drawerState,
-        drawerContent = {
-            ModalDrawerSheet {
-                Text(
-                    text = "Groups",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(16.dp),
-                )
-                HorizontalDivider()
-                GroupTreeSidebar(
-                    groups = groups,
-                    modifier = Modifier.fillMaxWidth(),
-                    onGroupSelected = { group ->
-                        selectedGroup = group
-                        onGroupSelected(group)
-                        scope.launch { drawerState.close() }
-                    },
-                )
-            }
-        },
-    ) {
-        ListDetailPaneScaffold(
-            directive = navigator.scaffoldDirective,
-            value = navigator.scaffoldValue,
-            listPane = {
-                AnimatedPane {
-                    Scaffold(
-                        topBar = {
-                            Column {
-                                TopAppBar(
-                                    title = { Text(databaseName.ifEmpty { "KeePass Compose" }) },
-                                    navigationIcon = {
-                                        IconButton(onClick = { scope.launch { drawerState.open() } }) {
-                                            Icon(Icons.Filled.Menu, contentDescription = "Open drawer")
+    ListDetailPaneScaffold(
+        directive = navigator.scaffoldDirective,
+        value = navigator.scaffoldValue,
+        listPane = {
+            AnimatedPane {
+                Scaffold(
+                    topBar = {
+                        Column {
+                            TopAppBar(
+                                title = { Text(selectedGroup?.name ?: databaseName.ifEmpty { "KeePass Compose" }) },
+                                navigationIcon = {
+                                    if (hasParentGroup) {
+                                        IconButton(onClick = onNavigateUp) {
+                                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate up")
                                         }
-                                    },
-                                    actions = {
-                                        IconButton(onClick = onSearch) {
-                                            Icon(Icons.Filled.Search, contentDescription = "Search")
-                                        }
-                                        IconButton(onClick = onLockDatabase) {
-                                            Icon(Icons.Filled.Lock, contentDescription = "Lock Database")
-                                        }
-                                    },
-                                    colors = TopAppBarDefaults.topAppBarColors(
-                                        containerColor = MaterialTheme.colorScheme.surface,
-                                        titleContentColor = MaterialTheme.colorScheme.onSurface,
-                                    ),
-                                )
-                                if (!isDetailHidden) {
-                                    StatusBar(databaseName = databaseName, entryCount = entryCount)
-                                }
-                            }
-                        },
-                        floatingActionButton = {
-                            if (isDetailHidden) {
-                                FloatingActionButton(onClick = onNewEntry) {
-                                    Icon(Icons.Filled.Add, contentDescription = "New Entry")
-                                }
-                            }
-                        },
-                        bottomBar = {
-                            if (isDetailHidden) {
-                                StatusBar(databaseName = databaseName, entryCount = entryCount)
-                            }
-                        },
-                    ) { padding ->
-                        EntryListPane(
-                            entries = entries,
-                            selectedEntryUuid = navigator.currentDestination?.contentKey,
-                            onEntrySelected = { entry ->
-                                scope.launch {
-                                    navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, entry.uuid)
-                                }
-                            },
-                            modifier = Modifier.fillMaxSize().padding(padding),
-                        )
-                    }
-                }
-            },
-            detailPane = {
-                AnimatedPane {
-                    Surface(modifier = Modifier.fillMaxSize()) {
-                        val entry = selectedEntry
-                        if (entry != null) {
-                            Scaffold(
-                                topBar = {
-                                    if (isListHidden) {
-                                        TopAppBar(
-                                            title = { Text(entry.title.ifEmpty { "Entry" }) },
-                                            navigationIcon = {
-                                                IconButton(
-                                                    onClick = { scope.launch { navigator.navigateBack() } },
-                                                ) {
-                                                    Icon(
-                                                        Icons.AutoMirrored.Filled.ArrowBack,
-                                                        contentDescription = "Back",
-                                                    )
-                                                }
-                                            },
-                                            colors = TopAppBarDefaults.topAppBarColors(
-                                                containerColor = MaterialTheme.colorScheme.surface,
-                                                titleContentColor = MaterialTheme.colorScheme.onSurface,
-                                            ),
-                                        )
                                     }
                                 },
-                            ) { padding ->
-                                EntryDetailScreen(
-                                    entry = entry,
-                                    onCopyField = onCopyField,
-                                    modifier = Modifier.padding(padding),
-                                )
+                                actions = {
+                                    IconButton(onClick = onSearch) {
+                                        Icon(Icons.Filled.Search, contentDescription = "Search")
+                                    }
+                                    IconButton(onClick = onLockDatabase) {
+                                        Icon(Icons.Filled.Lock, contentDescription = "Lock Database")
+                                    }
+                                },
+                                colors = TopAppBarDefaults.topAppBarColors(
+                                    containerColor = MaterialTheme.colorScheme.surface,
+                                    titleContentColor = MaterialTheme.colorScheme.onSurface,
+                                ),
+                            )
+                            if (!isDetailHidden) {
+                                StatusBar(databaseName = databaseName, entryCount = entryCount)
                             }
-                        } else {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Text(
-                                    text = "Select an entry",
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                        }
+                    },
+                    floatingActionButton = {
+                        if (isDetailHidden) {
+                            FloatingActionButton(onClick = onNewEntry) {
+                                Icon(Icons.Filled.Add, contentDescription = "New Entry")
                             }
+                        }
+                    },
+                    bottomBar = {
+                        if (isDetailHidden) {
+                            StatusBar(databaseName = databaseName, entryCount = entryCount)
+                        }
+                    },
+                ) { padding ->
+                    GroupEntryListPane(
+                        subGroups = subGroups,
+                        entries = entries,
+                        selectedEntryUuid = navigator.currentDestination?.contentKey,
+                        onGroupSelected = onGroupSelected,
+                        onEntrySelected = { entry ->
+                            scope.launch {
+                                navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, entry.uuid)
+                            }
+                        },
+                        modifier = Modifier.fillMaxSize().padding(padding),
+                    )
+                }
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    val entry = selectedEntry
+                    if (entry != null) {
+                        Scaffold(
+                            topBar = {
+                                if (isListHidden) {
+                                    TopAppBar(
+                                        title = { Text(entry.title.ifEmpty { "Entry" }) },
+                                        navigationIcon = {
+                                            IconButton(
+                                                onClick = { scope.launch { navigator.navigateBack() } },
+                                            ) {
+                                                Icon(
+                                                    Icons.AutoMirrored.Filled.ArrowBack,
+                                                    contentDescription = "Back",
+                                                )
+                                            }
+                                        },
+                                        colors = TopAppBarDefaults.topAppBarColors(
+                                            containerColor = MaterialTheme.colorScheme.surface,
+                                            titleContentColor = MaterialTheme.colorScheme.onSurface,
+                                        ),
+                                    )
+                                }
+                            },
+                        ) { padding ->
+                            EntryDetailScreen(
+                                entry = entry,
+                                onCopyField = onCopyField,
+                                modifier = Modifier.padding(padding),
+                            )
                         }
                     }
                 }
-            },
-        )
-    }
+            }
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -218,29 +185,15 @@ fun MainScreen(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun GroupTreeSidebar(groups: List<String>, modifier: Modifier = Modifier, onGroupSelected: (String) -> Unit = {}) {
-    LazyColumn(modifier = modifier.background(MaterialTheme.colorScheme.surfaceContainerLow)) {
-        items(groups) { group ->
-            Text(
-                text = group,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onGroupSelected(group) }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-            )
-        }
-    }
-}
-
-@Composable
-private fun EntryListPane(
+private fun GroupEntryListPane(
+    subGroups: List<KdbxGroup>,
     entries: List<KdbxEntry>,
     selectedEntryUuid: String? = null,
+    onGroupSelected: (KdbxGroup) -> Unit = {},
     onEntrySelected: (KdbxEntry) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    if (entries.isEmpty()) {
+    if (subGroups.isEmpty() && entries.isEmpty()) {
         Box(modifier = modifier, contentAlignment = Alignment.Center) {
             Text(
                 text = "No entries",
@@ -250,25 +203,68 @@ private fun EntryListPane(
         }
     } else {
         LazyColumn(modifier = modifier) {
-            items(entries) { entry ->
+            items(subGroups, key = { it.uuid }) { group ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onGroupSelected(group) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                ) {
+                    Icon(
+                        Icons.Filled.FolderOpen,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = group.name,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        val itemCount = group.groups.size + group.entries.size
+                        if (itemCount > 0) {
+                            Text(
+                                text = "$itemCount items",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+                HorizontalDivider()
+            }
+            items(entries, key = { it.uuid }) { entry ->
                 val isSelected = entry.uuid == selectedEntryUuid
                 val bg = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
                 val contentColor = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
 
-                Column(
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(bg)
                         .clickable { onEntrySelected(entry) }
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                 ) {
-                    Text(text = entry.title.ifEmpty { "Untitled" }, style = MaterialTheme.typography.bodyLarge, color = contentColor)
-                    if (entry.userName.isNotEmpty()) {
-                        Text(
-                            text = entry.userName,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (isSelected) contentColor.copy(alpha = 0.7f) else MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                    Icon(
+                        Icons.Filled.Key,
+                        contentDescription = null,
+                        tint = if (isSelected) contentColor else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(text = entry.title.ifEmpty { "Untitled" }, style = MaterialTheme.typography.bodyLarge, color = contentColor)
+                        if (entry.userName.isNotEmpty()) {
+                            Text(
+                                text = entry.userName,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (isSelected) contentColor.copy(alpha = 0.7f) else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
                 HorizontalDivider()


### PR DESCRIPTION
## Summary
- Removed `ModalNavigationDrawer` from MainScreen and replaced it with inline group/entry display in the list pane
- Subgroups are shown as folder rows with `FolderOpen` icon; entries shown with `Key` icon
- Clicking a folder navigates into that group; back arrow in top bar navigates to parent
- Simplified AppNavigator by passing `KdbxGroup` directly instead of flattened group name strings

## Test plan
- [ ] Open a database with nested groups
- [ ] Verify groups appear as folder rows with opened folder icon
- [ ] Verify entries appear below groups with key icon
- [ ] Tap a group folder and verify it navigates into the subgroup
- [ ] Verify back arrow appears and navigates up to parent group
- [ ] Verify no drawer gesture or menu button remains
- [ ] Test on both compact (phone) and expanded (tablet/desktop) layouts

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)