### PR TITLE
[#110] Implement credential matching

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/browser/CredentialMatcher.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/browser/CredentialMatcher.kt
@@ -1,0 +1,251 @@
+package org.github.keepasscompose.core.browser
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxGroup
+import kotlin.time.ExperimentalTime
+
+/**
+ * Matches database entries against URLs for browser credential autofill.
+ *
+ * Supports multiple matching strategies:
+ * - **Exact**: URL must match the entry URL exactly
+ * - **Domain**: Domain (including subdomains) must match
+ * - **Host**: Hostname must match exactly (no subdomain flexibility)
+ * - **StartsWith**: Entry URL must be a prefix of the request URL
+ *
+ * The default strategy is [MatchStrategy.DOMAIN] which provides a good
+ * balance between security and usability — matching `login.example.com`
+ * against an entry stored for `example.com`.
+ */
+class CredentialMatcher(private val strategy: MatchStrategy = MatchStrategy.DOMAIN) {
+
+    enum class MatchStrategy {
+        EXACT,
+        DOMAIN,
+        HOST,
+        STARTS_WITH,
+    }
+
+    /**
+     * A matched credential with relevance score for sorting.
+     */
+    data class MatchResult(val entry: KdbxEntry, val groupPath: List<String>, val score: Int) : Comparable<MatchResult> {
+        override fun compareTo(other: MatchResult): Int = other.score.compareTo(score)
+    }
+
+    /**
+     * Find all entries matching the given URL, sorted by relevance.
+     *
+     * @param rootGroup The root group to search recursively.
+     * @param url The URL to match against entry URLs.
+     * @param includeExpired Whether to include expired entries.
+     * @return Sorted list of matching entries (best match first).
+     */
+    fun findMatches(rootGroup: KdbxGroup, url: String, includeExpired: Boolean = false): List<MatchResult> {
+        val parsed = parseUrl(url) ?: return emptyList()
+        val results = mutableListOf<MatchResult>()
+        findMatchesInGroup(rootGroup, parsed, includeExpired, emptyList(), results)
+        return results.sorted()
+    }
+
+    /**
+     * Convert matched entries to browser protocol format.
+     */
+    fun toBrowserEntries(matches: List<MatchResult>): List<BrowserEntry> = matches.map { match ->
+        BrowserEntry(
+            login = match.entry.userName,
+            password = match.entry.password,
+            name = match.entry.title,
+            uuid = match.entry.uuid,
+            group = match.groupPath.lastOrNull(),
+            expired = if (match.entry.expires) isExpired(match.entry) else null,
+            stringFields = match.entry.fields
+                .filter { it.key !in STANDARD_FIELDS && !it.isProtected }
+                .map { BrowserStringField(key = it.key, value = it.value) }
+                .ifEmpty { null },
+        )
+    }
+
+    private fun findMatchesInGroup(
+        group: KdbxGroup,
+        targetUrl: ParsedUrl,
+        includeExpired: Boolean,
+        path: List<String>,
+        results: MutableList<MatchResult>,
+    ) {
+        val currentPath = path + group.name
+        for (entry in group.entries) {
+            if (!includeExpired && entry.expires && isExpired(entry)) continue
+
+            val entryUrl = entry.url
+            if (entryUrl.isBlank()) continue
+
+            val score = calculateMatchScore(entryUrl, targetUrl)
+            if (score > 0) {
+                results.add(MatchResult(entry, currentPath, score))
+            }
+        }
+        for (subgroup in group.groups) {
+            findMatchesInGroup(subgroup, targetUrl, includeExpired, currentPath, results)
+        }
+    }
+
+    internal fun calculateMatchScore(entryUrl: String, targetUrl: ParsedUrl): Int {
+        val entryParsed = parseUrl(entryUrl) ?: return 0
+
+        return when (strategy) {
+            MatchStrategy.EXACT -> {
+                if (normalizeUrl(entryUrl) == normalizeUrl(targetUrl.original)) SCORE_EXACT else 0
+            }
+
+            MatchStrategy.HOST -> {
+                if (entryParsed.host.equals(targetUrl.host, ignoreCase = true)) {
+                    scoreByPathMatch(entryParsed, targetUrl)
+                } else {
+                    0
+                }
+            }
+
+            MatchStrategy.DOMAIN -> {
+                val entryDomain = extractDomain(entryParsed.host)
+                val targetDomain = extractDomain(targetUrl.host)
+                if (entryDomain.equals(targetDomain, ignoreCase = true)) {
+                    scoreByPathMatch(entryParsed, targetUrl)
+                } else {
+                    0
+                }
+            }
+
+            MatchStrategy.STARTS_WITH -> {
+                val normalizedEntry = normalizeUrl(entryUrl)
+                val normalizedTarget = normalizeUrl(targetUrl.original)
+                if (normalizedTarget.startsWith(normalizedEntry)) {
+                    SCORE_STARTS_WITH + normalizedEntry.length
+                } else {
+                    0
+                }
+            }
+        }
+    }
+
+    private fun scoreByPathMatch(entryParsed: ParsedUrl, targetUrl: ParsedUrl): Int {
+        var score = SCORE_DOMAIN
+
+        // Exact host match is better than domain-only match
+        if (entryParsed.host.equals(targetUrl.host, ignoreCase = true)) {
+            score += SCORE_HOST_BONUS
+        }
+
+        // Scheme match bonus
+        if (entryParsed.scheme.equals(targetUrl.scheme, ignoreCase = true)) {
+            score += SCORE_SCHEME_BONUS
+        }
+
+        // Port match bonus
+        if (entryParsed.port == targetUrl.port) {
+            score += SCORE_PORT_BONUS
+        }
+
+        // Path prefix match bonus
+        if (entryParsed.path.isNotEmpty() && entryParsed.path != "/") {
+            if (targetUrl.path.startsWith(entryParsed.path, ignoreCase = true)) {
+                score += SCORE_PATH_BONUS + entryParsed.path.length
+            }
+        }
+
+        return score
+    }
+
+    companion object {
+        private const val SCORE_EXACT = 1000
+        private const val SCORE_DOMAIN = 100
+        private const val SCORE_HOST_BONUS = 50
+        private const val SCORE_SCHEME_BONUS = 10
+        private const val SCORE_PORT_BONUS = 5
+        private const val SCORE_PATH_BONUS = 20
+        private const val SCORE_STARTS_WITH = 80
+
+        private val STANDARD_FIELDS = setOf("Title", "UserName", "Password", "URL", "Notes")
+    }
+
+    /**
+     * Parsed URL components.
+     */
+    internal data class ParsedUrl(val original: String, val scheme: String, val host: String, val port: Int?, val path: String)
+
+    internal fun parseUrl(url: String): ParsedUrl? {
+        val trimmed = url.trim()
+        if (trimmed.isBlank()) return null
+
+        // Handle URLs without scheme
+        val withScheme = if (!trimmed.contains("://")) "https://$trimmed" else trimmed
+
+        return try {
+            val schemeEnd = withScheme.indexOf("://")
+            val scheme = withScheme.substring(0, schemeEnd)
+            val rest = withScheme.substring(schemeEnd + 3)
+
+            val pathStart = rest.indexOf('/')
+            val hostPort = if (pathStart >= 0) rest.substring(0, pathStart) else rest
+            val path = if (pathStart >= 0) rest.substring(pathStart) else "/"
+
+            // Strip query string and fragment from path
+            val cleanPath = path.substringBefore('?').substringBefore('#')
+
+            val portSep = hostPort.lastIndexOf(':')
+            val host: String
+            val port: Int?
+            if (portSep > 0 && portSep < hostPort.length - 1) {
+                host = hostPort.substring(0, portSep)
+                port = hostPort.substring(portSep + 1).toIntOrNull()
+            } else {
+                host = hostPort
+                port = null
+            }
+
+            if (host.isBlank()) return null
+
+            ParsedUrl(
+                original = trimmed,
+                scheme = scheme,
+                host = host.lowercase(),
+                port = port,
+                path = cleanPath,
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    internal fun extractDomain(host: String): String {
+        val parts = host.lowercase().split('.')
+        if (parts.size <= 2) return host.lowercase()
+
+        // Handle common TLDs with second-level domains (e.g., co.uk, com.au)
+        val lastTwo = "${parts[parts.size - 2]}.${parts.last()}"
+        return if (lastTwo in COMPOUND_TLDS) {
+            if (parts.size >= 3) "${parts[parts.size - 3]}.$lastTwo" else host.lowercase()
+        } else {
+            "${parts[parts.size - 2]}.${parts.last()}"
+        }
+    }
+
+    private fun normalizeUrl(url: String): String = url.trim().lowercase().removeSuffix("/")
+
+    @OptIn(ExperimentalTime::class)
+    private fun isExpired(entry: KdbxEntry): Boolean {
+        if (!entry.expires || entry.expiryTime == null) return false
+        return entry.expiryTime < kotlin.time.Clock.System.now()
+    }
+}
+
+/**
+ * Common compound TLDs where the "domain" needs an extra level.
+ */
+private val COMPOUND_TLDS = setOf(
+    "co.uk", "co.jp", "co.kr", "co.in", "co.nz", "co.za",
+    "com.au", "com.br", "com.cn", "com.mx", "com.tw", "com.sg",
+    "org.uk", "org.au",
+    "net.au", "net.uk",
+    "ac.uk", "gov.uk",
+)

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/browser/CredentialMatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/browser/CredentialMatcherTest.kt
@@ -1,0 +1,398 @@
+package org.github.keepasscompose.core.browser
+
+import org.github.keepasscompose.core.model.KdbxEntry
+import org.github.keepasscompose.core.model.KdbxEntryField
+import org.github.keepasscompose.core.model.KdbxGroup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+
+class CredentialMatcherTest {
+    private fun entry(title: String, url: String, userName: String = "user", password: String = "pass", uuid: String = title): KdbxEntry = KdbxEntry(
+        uuid = uuid,
+        fields = listOf(
+            KdbxEntryField("Title", title),
+            KdbxEntryField("UserName", userName),
+            KdbxEntryField("Password", password, isProtected = true),
+            KdbxEntryField("URL", url),
+            KdbxEntryField("Notes", ""),
+        ),
+    )
+
+    private fun group(name: String, entries: List<KdbxEntry> = emptyList(), groups: List<KdbxGroup> = emptyList()): KdbxGroup =
+        KdbxGroup(uuid = name, name = name, entries = entries, groups = groups)
+
+    // --- URL Parsing ---
+
+    @Test
+    fun parseUrlWithFullUrl() {
+        val matcher = CredentialMatcher()
+        val parsed = matcher.parseUrl("https://example.com/path?q=1#frag")
+        assertNotNull(parsed)
+        assertEquals("https", parsed.scheme)
+        assertEquals("example.com", parsed.host)
+        assertNull(parsed.port)
+        assertEquals("/path", parsed.path)
+    }
+
+    @Test
+    fun parseUrlWithPort() {
+        val matcher = CredentialMatcher()
+        val parsed = matcher.parseUrl("http://localhost:8080/api")
+        assertNotNull(parsed)
+        assertEquals("localhost", parsed.host)
+        assertEquals(8080, parsed.port)
+        assertEquals("/api", parsed.path)
+    }
+
+    @Test
+    fun parseUrlWithoutScheme() {
+        val matcher = CredentialMatcher()
+        val parsed = matcher.parseUrl("example.com")
+        assertNotNull(parsed)
+        assertEquals("https", parsed.scheme)
+        assertEquals("example.com", parsed.host)
+    }
+
+    @Test
+    fun parseUrlWithBlankReturnsNull() {
+        val matcher = CredentialMatcher()
+        assertNull(matcher.parseUrl(""))
+        assertNull(matcher.parseUrl("   "))
+    }
+
+    // --- Domain Extraction ---
+
+    @Test
+    fun extractDomainSimple() {
+        val matcher = CredentialMatcher()
+        assertEquals("example.com", matcher.extractDomain("example.com"))
+    }
+
+    @Test
+    fun extractDomainWithSubdomain() {
+        val matcher = CredentialMatcher()
+        assertEquals("example.com", matcher.extractDomain("login.example.com"))
+        assertEquals("example.com", matcher.extractDomain("www.login.example.com"))
+    }
+
+    @Test
+    fun extractDomainCompoundTld() {
+        val matcher = CredentialMatcher()
+        assertEquals("example.co.uk", matcher.extractDomain("www.example.co.uk"))
+        assertEquals("example.com.au", matcher.extractDomain("login.example.com.au"))
+    }
+
+    // --- Domain Strategy Matching ---
+
+    @Test
+    fun domainStrategyMatchesSameDomain() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.DOMAIN)
+        val root = group(
+            "Root",
+            entries = listOf(entry("GitHub", "https://github.com/login")),
+        )
+
+        val results = matcher.findMatches(root, "https://github.com")
+        assertEquals(1, results.size)
+        assertEquals("GitHub", results[0].entry.title)
+    }
+
+    @Test
+    fun domainStrategyMatchesSubdomain() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.DOMAIN)
+        val root = group(
+            "Root",
+            entries = listOf(entry("GitLab", "https://gitlab.com")),
+        )
+
+        val results = matcher.findMatches(root, "https://projects.gitlab.com")
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun domainStrategyDoesNotMatchDifferentDomain() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.DOMAIN)
+        val root = group(
+            "Root",
+            entries = listOf(entry("GitHub", "https://github.com")),
+        )
+
+        val results = matcher.findMatches(root, "https://gitlab.com")
+        assertEquals(0, results.size)
+    }
+
+    // --- Exact Strategy ---
+
+    @Test
+    fun exactStrategyMatchesExactUrl() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.EXACT)
+        val root = group(
+            "Root",
+            entries = listOf(entry("Test", "https://example.com/path")),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/path")
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun exactStrategyDoesNotMatchDifferentPath() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.EXACT)
+        val root = group(
+            "Root",
+            entries = listOf(entry("Test", "https://example.com/path1")),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/path2")
+        assertEquals(0, results.size)
+    }
+
+    // --- Host Strategy ---
+
+    @Test
+    fun hostStrategyMatchesExactHost() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.HOST)
+        val root = group(
+            "Root",
+            entries = listOf(entry("Test", "https://login.example.com")),
+        )
+
+        val results = matcher.findMatches(root, "https://login.example.com/auth")
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun hostStrategyDoesNotMatchDifferentSubdomain() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.HOST)
+        val root = group(
+            "Root",
+            entries = listOf(entry("Test", "https://www.example.com")),
+        )
+
+        val results = matcher.findMatches(root, "https://login.example.com")
+        assertEquals(0, results.size)
+    }
+
+    // --- StartsWith Strategy ---
+
+    @Test
+    fun startsWithStrategyMatchesPrefix() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.STARTS_WITH)
+        val root = group(
+            "Root",
+            entries = listOf(entry("Test", "https://example.com/app")),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/app/dashboard")
+        assertEquals(1, results.size)
+    }
+
+    @Test
+    fun startsWithStrategyDoesNotMatchDifferentPrefix() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.STARTS_WITH)
+        val root = group(
+            "Root",
+            entries = listOf(entry("Test", "https://example.com/api")),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/app")
+        assertEquals(0, results.size)
+    }
+
+    // --- Scoring ---
+
+    @Test
+    fun exactHostScoresHigherThanSubdomainMatch() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.DOMAIN)
+        val root = group(
+            "Root",
+            entries = listOf(
+                entry("Subdomain", "https://login.example.com"),
+                entry("Exact", "https://example.com"),
+            ),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/login")
+        assertEquals(2, results.size)
+        // Exact host match should score higher
+        assertEquals("Exact", results[0].entry.title)
+    }
+
+    @Test
+    fun pathMatchScoresHigher() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.DOMAIN)
+        val root = group(
+            "Root",
+            entries = listOf(
+                entry("No Path", "https://example.com"),
+                entry("With Path", "https://example.com/app"),
+            ),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/app/page")
+        assertEquals(2, results.size)
+        assertEquals("With Path", results[0].entry.title)
+    }
+
+    // --- Recursive Search ---
+
+    @Test
+    fun searchesNestedGroups() {
+        val matcher = CredentialMatcher()
+        val root = group(
+            "Root",
+            groups = listOf(
+                group(
+                    "Social",
+                    groups = listOf(
+                        group("Coding", entries = listOf(entry("GitHub", "https://github.com"))),
+                    ),
+                ),
+            ),
+        )
+
+        val results = matcher.findMatches(root, "https://github.com")
+        assertEquals(1, results.size)
+        assertEquals(listOf("Root", "Social", "Coding"), results[0].groupPath)
+    }
+
+    // --- Entries with blank URLs ---
+
+    @Test
+    fun skipsEntriesWithBlankUrl() {
+        val matcher = CredentialMatcher()
+        val root = group(
+            "Root",
+            entries = listOf(
+                entry("No URL", ""),
+                entry("Has URL", "https://example.com"),
+            ),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com")
+        assertEquals(1, results.size)
+        assertEquals("Has URL", results[0].entry.title)
+    }
+
+    // --- Expired entries ---
+
+    @Test
+    fun excludesExpiredByDefault() {
+        val matcher = CredentialMatcher()
+        val expired = KdbxEntry(
+            uuid = "expired",
+            fields = listOf(
+                KdbxEntryField("Title", "Expired"),
+                KdbxEntryField("URL", "https://example.com"),
+                KdbxEntryField("UserName", "user"),
+                KdbxEntryField("Password", "pass", isProtected = true),
+            ),
+            expires = true,
+            expiryTime = kotlin.time.Clock.System.now() - 1.hours,
+        )
+        val root = group("Root", entries = listOf(expired))
+
+        val results = matcher.findMatches(root, "https://example.com")
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    fun includesExpiredWhenRequested() {
+        val matcher = CredentialMatcher()
+        val expired = KdbxEntry(
+            uuid = "expired",
+            fields = listOf(
+                KdbxEntryField("Title", "Expired"),
+                KdbxEntryField("URL", "https://example.com"),
+                KdbxEntryField("UserName", "user"),
+                KdbxEntryField("Password", "pass", isProtected = true),
+            ),
+            expires = true,
+            expiryTime = kotlin.time.Clock.System.now() - 1.hours,
+        )
+        val root = group("Root", entries = listOf(expired))
+
+        val results = matcher.findMatches(root, "https://example.com", includeExpired = true)
+        assertEquals(1, results.size)
+    }
+
+    // --- toBrowserEntries ---
+
+    @Test
+    fun convertsMatchesToBrowserEntries() {
+        val matcher = CredentialMatcher()
+        val testEntry = entry("Test", "https://example.com", "admin", "secret")
+        val root = group("Root", entries = listOf(testEntry))
+
+        val matches = matcher.findMatches(root, "https://example.com")
+        val browserEntries = matcher.toBrowserEntries(matches)
+
+        assertEquals(1, browserEntries.size)
+        assertEquals("admin", browserEntries[0].login)
+        assertEquals("secret", browserEntries[0].password)
+        assertEquals("Test", browserEntries[0].name)
+    }
+
+    @Test
+    fun customFieldsIncludedInBrowserEntries() {
+        val matcher = CredentialMatcher()
+        val testEntry = KdbxEntry(
+            uuid = "custom",
+            fields = listOf(
+                KdbxEntryField("Title", "Custom"),
+                KdbxEntryField("URL", "https://example.com"),
+                KdbxEntryField("UserName", "user"),
+                KdbxEntryField("Password", "pass", isProtected = true),
+                KdbxEntryField("Notes", ""),
+                KdbxEntryField("CustomField", "custom-value"),
+            ),
+        )
+        val root = group("Root", entries = listOf(testEntry))
+
+        val matches = matcher.findMatches(root, "https://example.com")
+        val browserEntries = matcher.toBrowserEntries(matches)
+
+        assertEquals(1, browserEntries.size)
+        assertEquals(1, browserEntries[0].stringFields?.size)
+        assertEquals("CustomField", browserEntries[0].stringFields?.first()?.key)
+    }
+
+    // --- Case insensitivity ---
+
+    @Test
+    fun matchingIsCaseInsensitive() {
+        val matcher = CredentialMatcher()
+        val root = group(
+            "Root",
+            entries = listOf(entry("GitHub", "HTTPS://GITHUB.COM")),
+        )
+
+        val results = matcher.findMatches(root, "https://github.com")
+        assertEquals(1, results.size)
+    }
+
+    // --- Multiple matches sorted by score ---
+
+    @Test
+    fun multipleMatchesSortedByScore() {
+        val matcher = CredentialMatcher(CredentialMatcher.MatchStrategy.DOMAIN)
+        val root = group(
+            "Root",
+            entries = listOf(
+                entry("Generic", "example.com"),
+                entry("Specific", "https://example.com/app/login"),
+                entry("Medium", "https://example.com/app"),
+            ),
+        )
+
+        val results = matcher.findMatches(root, "https://example.com/app/login")
+        assertEquals(3, results.size)
+        // Most specific path match should be first
+        assertEquals("Specific", results[0].entry.title)
+        assertTrue(results[0].score > results[1].score)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CredentialMatcher` with URL-based credential matching for browser autofill
- Support 4 matching strategies: Exact, Domain (default), Host, StartsWith
- Relevance-based scoring: exact host > subdomain, path prefix > no path
- Domain extraction with compound TLD support (co.uk, com.au, etc.)
- Expired entry filtering with opt-in inclusion

## Test plan
- [x] 25 unit tests covering all strategies and edge cases
- [x] URL parsing with/without scheme, ports, query strings
- [x] Domain extraction including compound TLDs
- [x] Scoring ranking verified (host match > subdomain, path > no path)
- [x] Recursive group traversal tested
- [x] Expired entry handling tested

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)