### PR TITLE
[#112] Implement keyboard simulation (expect/actual)

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.android.kt
@@ -1,0 +1,33 @@
+package org.github.keepasscompose.core.autotype
+
+/**
+ * Android keyboard simulation stub.
+ *
+ * Full auto-type on Android requires an AccessibilityService, which
+ * is implemented separately in the Android autofill infrastructure.
+ * This stub returns [isAvailable] = false to indicate that direct
+ * keyboard simulation is not supported in the shared layer.
+ */
+actual class KeyboardSimulator actual constructor() {
+    actual fun isAvailable(): Boolean = false
+
+    actual suspend fun typeText(text: String, interKeyDelayMs: Long) {
+        // Not available on Android — use AccessibilityService instead
+    }
+
+    actual suspend fun pressKey(keyCode: Int) {
+        // Not available on Android
+    }
+
+    actual suspend fun pressKeyCombo(modifiers: List<Int>, keyCode: Int) {
+        // Not available on Android
+    }
+
+    actual suspend fun pressTab() {
+        // Not available on Android
+    }
+
+    actual suspend fun pressEnter() {
+        // Not available on Android
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.kt
@@ -1,0 +1,77 @@
+package org.github.keepasscompose.core.autotype
+
+/**
+ * Platform-abstracted keyboard simulation for auto-type.
+ *
+ * Simulates key presses, releases, and typed text as if the user were
+ * physically typing on the keyboard. Each platform provides its own
+ * implementation:
+ * - **Desktop (JVM)**: Uses `java.awt.Robot` for native key simulation
+ * - **Android**: Uses `AccessibilityService` for input injection
+ * - **iOS**: Stub (auto-type not supported on iOS)
+ */
+expect class KeyboardSimulator() {
+    /**
+     * Whether keyboard simulation is available on this platform.
+     */
+    fun isAvailable(): Boolean
+
+    /**
+     * Type a string of characters, simulating individual key presses.
+     * Each character is typed with a configurable inter-key delay.
+     *
+     * @param text The text to type.
+     * @param interKeyDelayMs Delay between key presses in milliseconds.
+     */
+    suspend fun typeText(text: String, interKeyDelayMs: Long = 10)
+
+    /**
+     * Press and release a single key by its virtual key code.
+     *
+     * @param keyCode Platform-specific virtual key code.
+     */
+    suspend fun pressKey(keyCode: Int)
+
+    /**
+     * Press and release a key combination (e.g., Ctrl+A).
+     *
+     * @param modifiers List of modifier key codes (e.g., Ctrl, Alt, Shift).
+     * @param keyCode The main key code.
+     */
+    suspend fun pressKeyCombo(modifiers: List<Int>, keyCode: Int)
+
+    /**
+     * Simulate pressing the Tab key.
+     */
+    suspend fun pressTab()
+
+    /**
+     * Simulate pressing the Enter/Return key.
+     */
+    suspend fun pressEnter()
+}
+
+/**
+ * Platform-independent virtual key codes for common auto-type actions.
+ * Platform implementations map these to native key codes.
+ */
+object AutoTypeKey {
+    const val TAB = 1
+    const val ENTER = 2
+    const val UP = 3
+    const val DOWN = 4
+    const val LEFT = 5
+    const val RIGHT = 6
+    const val HOME = 7
+    const val END = 8
+    const val DELETE = 9
+    const val BACKSPACE = 10
+    const val ESCAPE = 11
+    const val SPACE = 12
+
+    // Modifiers
+    const val SHIFT = 100
+    const val CTRL = 101
+    const val ALT = 102
+    const val META = 103 // Windows/Command key
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.ios.kt
@@ -1,0 +1,31 @@
+package org.github.keepasscompose.core.autotype
+
+/**
+ * iOS keyboard simulation stub.
+ *
+ * iOS does not support programmatic keyboard simulation from
+ * regular apps. Auto-type is not available on this platform.
+ */
+actual class KeyboardSimulator actual constructor() {
+    actual fun isAvailable(): Boolean = false
+
+    actual suspend fun typeText(text: String, interKeyDelayMs: Long) {
+        // Not available on iOS
+    }
+
+    actual suspend fun pressKey(keyCode: Int) {
+        // Not available on iOS
+    }
+
+    actual suspend fun pressKeyCombo(modifiers: List<Int>, keyCode: Int) {
+        // Not available on iOS
+    }
+
+    actual suspend fun pressTab() {
+        // Not available on iOS
+    }
+
+    actual suspend fun pressEnter() {
+        // Not available on iOS
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulator.jvm.kt
@@ -1,0 +1,91 @@
+package org.github.keepasscompose.core.autotype
+
+import kotlinx.coroutines.delay
+import java.awt.Robot
+import java.awt.event.KeyEvent
+
+actual class KeyboardSimulator actual constructor() {
+    private val robot: Robot? = try {
+        Robot().also { it.autoDelay = 0 }
+    } catch (_: Exception) {
+        null
+    }
+
+    actual fun isAvailable(): Boolean = robot != null
+
+    actual suspend fun typeText(text: String, interKeyDelayMs: Long) {
+        val r = robot ?: return
+        for (char in text) {
+            typeChar(r, char)
+            if (interKeyDelayMs > 0) delay(interKeyDelayMs)
+        }
+    }
+
+    actual suspend fun pressKey(keyCode: Int) {
+        val r = robot ?: return
+        val nativeCode = mapToNativeKeyCode(keyCode)
+        r.keyPress(nativeCode)
+        r.keyRelease(nativeCode)
+    }
+
+    actual suspend fun pressKeyCombo(modifiers: List<Int>, keyCode: Int) {
+        val r = robot ?: return
+        val nativeMods = modifiers.map { mapToNativeKeyCode(it) }
+        val nativeKey = mapToNativeKeyCode(keyCode)
+
+        nativeMods.forEach { r.keyPress(it) }
+        r.keyPress(nativeKey)
+        r.keyRelease(nativeKey)
+        nativeMods.reversed().forEach { r.keyRelease(it) }
+    }
+
+    actual suspend fun pressTab() {
+        val r = robot ?: return
+        r.keyPress(KeyEvent.VK_TAB)
+        r.keyRelease(KeyEvent.VK_TAB)
+    }
+
+    actual suspend fun pressEnter() {
+        val r = robot ?: return
+        r.keyPress(KeyEvent.VK_ENTER)
+        r.keyRelease(KeyEvent.VK_ENTER)
+    }
+
+    private fun typeChar(robot: Robot, char: Char) {
+        val keyCode = KeyEvent.getExtendedKeyCodeForChar(char.code)
+        if (keyCode == KeyEvent.VK_UNDEFINED) return
+
+        val needsShift = char.isUpperCase() || char in SHIFT_CHARS
+        if (needsShift) robot.keyPress(KeyEvent.VK_SHIFT)
+        robot.keyPress(keyCode)
+        robot.keyRelease(keyCode)
+        if (needsShift) robot.keyRelease(KeyEvent.VK_SHIFT)
+    }
+
+    private fun mapToNativeKeyCode(autoTypeKey: Int): Int = when (autoTypeKey) {
+        AutoTypeKey.TAB -> KeyEvent.VK_TAB
+        AutoTypeKey.ENTER -> KeyEvent.VK_ENTER
+        AutoTypeKey.UP -> KeyEvent.VK_UP
+        AutoTypeKey.DOWN -> KeyEvent.VK_DOWN
+        AutoTypeKey.LEFT -> KeyEvent.VK_LEFT
+        AutoTypeKey.RIGHT -> KeyEvent.VK_RIGHT
+        AutoTypeKey.HOME -> KeyEvent.VK_HOME
+        AutoTypeKey.END -> KeyEvent.VK_END
+        AutoTypeKey.DELETE -> KeyEvent.VK_DELETE
+        AutoTypeKey.BACKSPACE -> KeyEvent.VK_BACK_SPACE
+        AutoTypeKey.ESCAPE -> KeyEvent.VK_ESCAPE
+        AutoTypeKey.SPACE -> KeyEvent.VK_SPACE
+        AutoTypeKey.SHIFT -> KeyEvent.VK_SHIFT
+        AutoTypeKey.CTRL -> KeyEvent.VK_CONTROL
+        AutoTypeKey.ALT -> KeyEvent.VK_ALT
+        AutoTypeKey.META -> KeyEvent.VK_META
+        else -> autoTypeKey // Pass through native key codes
+    }
+
+    companion object {
+        private val SHIFT_CHARS = setOf(
+            '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+            '_', '+', '{', '}', '|', ':', '"', '<', '>', '?', '~',
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulatorTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/github/keepasscompose/core/autotype/KeyboardSimulatorTest.kt
@@ -1,0 +1,46 @@
+package org.github.keepasscompose.core.autotype
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class KeyboardSimulatorTest {
+    @Test
+    fun autoTypeKeysHaveDistinctValues() {
+        val keys = listOf(
+            AutoTypeKey.TAB, AutoTypeKey.ENTER, AutoTypeKey.UP, AutoTypeKey.DOWN,
+            AutoTypeKey.LEFT, AutoTypeKey.RIGHT, AutoTypeKey.HOME, AutoTypeKey.END,
+            AutoTypeKey.DELETE, AutoTypeKey.BACKSPACE, AutoTypeKey.ESCAPE, AutoTypeKey.SPACE,
+        )
+        assertEquals(keys.size, keys.toSet().size, "All key codes should be unique")
+    }
+
+    @Test
+    fun modifierKeysHaveDistinctValues() {
+        val mods = listOf(AutoTypeKey.SHIFT, AutoTypeKey.CTRL, AutoTypeKey.ALT, AutoTypeKey.META)
+        assertEquals(mods.size, mods.toSet().size, "All modifier codes should be unique")
+    }
+
+    @Test
+    fun modifierKeysDoNotOverlapWithActionKeys() {
+        val actionKeys = setOf(
+            AutoTypeKey.TAB, AutoTypeKey.ENTER, AutoTypeKey.UP, AutoTypeKey.DOWN,
+            AutoTypeKey.LEFT, AutoTypeKey.RIGHT, AutoTypeKey.HOME, AutoTypeKey.END,
+            AutoTypeKey.DELETE, AutoTypeKey.BACKSPACE, AutoTypeKey.ESCAPE, AutoTypeKey.SPACE,
+        )
+        val modifiers = setOf(AutoTypeKey.SHIFT, AutoTypeKey.CTRL, AutoTypeKey.ALT, AutoTypeKey.META)
+        val overlap = actionKeys.intersect(modifiers)
+        assertEquals(0, overlap.size, "Modifiers and action keys should not overlap")
+    }
+
+    @Test
+    fun keyboardSimulatorCanBeInstantiated() {
+        val sim = KeyboardSimulator()
+        // On CI/headless environments isAvailable may be false, that's OK
+        // Just verify it doesn't throw
+        val available = sim.isAvailable()
+        // Can be true or false depending on environment — just verify no exception
+        @Suppress("SENSELESS_COMPARISON")
+        assertEquals(true, available == true || available == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `KeyboardSimulator` expect/actual class for platform-abstracted keyboard simulation
- JVM: `java.awt.Robot`-based implementation with shift-char handling
- Android/iOS: Stub implementations (auto-type via platform-specific mechanisms)
- `AutoTypeKey` constants for platform-independent key references

## Test plan
- [x] Key code uniqueness tests (action keys and modifiers)
- [x] No overlap between modifier and action key codes
- [x] Instantiation test (headless-safe)
- [x] Build compiles on all platforms

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)