### PR TITLE
[#130] Implement Android Autofill Service skeleton

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -44,6 +44,18 @@
                 <data android:pathPattern=".*\\.KDBX" />
             </intent-filter>
         </activity>
+        <service
+            android:name="org.github.keepasscompose.KeePassAutofillService"
+            android:exported="true"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.autofill"
+                android:resource="@xml/autofill_service" />
+        </service>
     </application>
 
 </manifest>

--- a/androidApp/src/main/kotlin/org/github/keepasscompose/KeePassAutofillService.kt
+++ b/androidApp/src/main/kotlin/org/github/keepasscompose/KeePassAutofillService.kt
@@ -1,0 +1,39 @@
+package org.github.keepasscompose
+
+import android.os.CancellationSignal
+import android.service.autofill.AutofillService
+import android.service.autofill.FillCallback
+import android.service.autofill.FillRequest
+import android.service.autofill.SaveCallback
+import android.service.autofill.SaveRequest
+import io.github.aakira.napier.Napier
+
+/**
+ * Android Autofill Service that provides KeePass credential suggestions
+ * to autofill-enabled apps and browsers.
+ *
+ * Users must enable this service in Settings > Passwords & accounts > Autofill service.
+ */
+class KeePassAutofillService : AutofillService() {
+
+    override fun onFillRequest(request: FillRequest, cancellationSignal: CancellationSignal, callback: FillCallback) {
+        // TODO: Parse the AssistStructure from request.fillContexts to identify
+        //  autofill-eligible fields (username, password, etc.)
+        // TODO: Look up matching credentials from the unlocked KeePass database
+        // TODO: Build Dataset objects with RemoteViews for the autofill dropdown
+        // TODO: Return a FillResponse via callback.onSuccess()
+        Napier.d(tag = TAG) { "onFillRequest received" }
+        callback.onSuccess(null)
+    }
+
+    override fun onSaveRequest(request: SaveRequest, callback: SaveCallback) {
+        // TODO: Extract filled field values from request.fillContexts
+        // TODO: Prompt the user to save new or updated credentials to the KeePass database
+        Napier.d(tag = TAG) { "onSaveRequest received" }
+        callback.onSuccess()
+    }
+
+    companion object {
+        private const val TAG = "KeePassAutofillService"
+    }
+}

--- a/androidApp/src/main/res/xml/autofill_service.xml
+++ b/androidApp/src/main/res/xml/autofill_service.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<autofill-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.github.keepasscompose.MainActivity" />


### PR DESCRIPTION
## Summary
- Add `KeePassAutofillService` extending `AutofillService` with skeleton `onFillRequest` and `onSaveRequest` implementations
- Register the service in `AndroidManifest.xml` with `BIND_AUTOFILL_SERVICE` permission and proper intent filter
- Add `autofill_service.xml` meta-data resource pointing to MainActivity as settings activity

Closes #130

## Test plan
- [ ] Verify the app compiles for Android target
- [ ] Verify the autofill service appears in Android Settings > Autofill service list
- [ ] Verify selecting KeePass Compose as autofill provider does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)