### PR TITLE
[#131] Add cross-platform AutofillProvider with iOS stub

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.android.kt
@@ -1,0 +1,13 @@
+package org.github.keepasscompose.core.common
+
+/**
+ * Android autofill credential provider stub.
+ *
+ * Credential filling on Android is handled by [KeePassAutofillService];
+ * this class exists only to satisfy the expect/actual contract.
+ */
+actual class AutofillProvider actual constructor() {
+    actual fun isAvailable(): Boolean = false
+
+    actual fun provideCredentials(serviceIdentifier: String): List<AutofillCredential> = emptyList()
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.kt
@@ -1,0 +1,18 @@
+package org.github.keepasscompose.core.common
+
+/** A credential returned by the platform autofill provider. */
+data class AutofillCredential(val username: String, val password: String, val serviceIdentifier: String)
+
+/**
+ * Platform-specific autofill provider abstraction.
+ *
+ * Each platform implements the ability to query whether autofill is available
+ * and to supply credentials for a given service identifier (URL / app package).
+ */
+expect class AutofillProvider() {
+    /** Returns `true` when the platform autofill integration is available. */
+    fun isAvailable(): Boolean
+
+    /** Returns matching credentials for the given [serviceIdentifier]. */
+    fun provideCredentials(serviceIdentifier: String): List<AutofillCredential>
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.ios.kt
@@ -1,0 +1,13 @@
+package org.github.keepasscompose.core.common
+
+/**
+ * iOS autofill credential provider stub.
+ *
+ * A full implementation would integrate with ASCredentialProviderViewController
+ * to surface KeePass entries in the iOS AutoFill QuickType bar.
+ */
+actual class AutofillProvider actual constructor() {
+    actual fun isAvailable(): Boolean = false
+
+    actual fun provideCredentials(serviceIdentifier: String): List<AutofillCredential> = emptyList()
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/common/AutofillProvider.jvm.kt
@@ -1,0 +1,13 @@
+package org.github.keepasscompose.core.common
+
+/**
+ * Desktop (JVM) autofill credential provider stub.
+ *
+ * Desktop platforms do not have a native autofill framework;
+ * this class exists only to satisfy the expect/actual contract.
+ */
+actual class AutofillProvider actual constructor() {
+    actual fun isAvailable(): Boolean = false
+
+    actual fun provideCredentials(serviceIdentifier: String): List<AutofillCredential> = emptyList()
+}


### PR DESCRIPTION
## Summary
- Add `AutofillProvider` expect class in commonMain with `isAvailable()` and `provideCredentials()` methods
- Add `AutofillCredential` data class to represent credentials returned by the provider
- Implement `IosAutofillProvider` actual in iosMain as a stub for future ASCredentialProviderViewController integration
- Add Android and JVM actual stubs to satisfy the expect/actual contract

Closes #131

## Test plan
- [ ] Verify JVM compilation succeeds
- [ ] Verify all expect/actual declarations are matched across platforms
- [ ] Verify iOS stub returns `false` for `isAvailable()` and empty list for `provideCredentials()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)