### PR TITLE
[#119] Implement secure key storage for biometric unlock

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.android.kt
@@ -1,0 +1,135 @@
+package org.github.keepasscompose.core.biometric
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import org.github.keepasscompose.core.common.AndroidContextHolder
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Android biometric key storage using Android KeyStore.
+ *
+ * Generates an AES-256-GCM key protected by biometric authentication and
+ * uses it to encrypt/decrypt composite key data. Encrypted data (IV + ciphertext)
+ * is stored in SharedPreferences.
+ */
+actual class BiometricKeyStorage actual constructor() {
+    private companion object {
+        const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+        const val KEY_ALIAS_PREFIX = "keepass_biometric_"
+        const val PREFS_NAME = "biometric_key_storage"
+        const val AES_GCM_TAG_LENGTH = 128
+        const val GCM_IV_LENGTH = 12
+    }
+
+    actual fun isKeyStored(databasePath: String): Boolean {
+        val prefs = getPreferences() ?: return false
+        return prefs.contains(storageKey(databasePath))
+    }
+
+    actual fun storeKey(databasePath: String, compositeKeyData: ByteArray) {
+        val prefs = getPreferences() ?: return
+        val secretKey = getOrCreateKey(databasePath)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+
+        val iv = cipher.iv
+        val encrypted = cipher.doFinal(compositeKeyData)
+
+        // Store IV + encrypted data as a single Base64-encoded blob
+        val combined = ByteArray(GCM_IV_LENGTH + encrypted.size)
+        iv.copyInto(combined, 0, 0, GCM_IV_LENGTH)
+        encrypted.copyInto(combined, GCM_IV_LENGTH)
+
+        prefs.edit()
+            .putString(storageKey(databasePath), android.util.Base64.encodeToString(combined, android.util.Base64.NO_WRAP))
+            .apply()
+    }
+
+    actual fun retrieveKey(databasePath: String): ByteArray? {
+        val prefs = getPreferences() ?: return null
+        val encoded = prefs.getString(storageKey(databasePath), null) ?: return null
+
+        val combined = android.util.Base64.decode(encoded, android.util.Base64.NO_WRAP)
+        if (combined.size <= GCM_IV_LENGTH) return null
+
+        val iv = combined.copyOfRange(0, GCM_IV_LENGTH)
+        val encrypted = combined.copyOfRange(GCM_IV_LENGTH, combined.size)
+
+        val secretKey = loadKey(databasePath) ?: return null
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(AES_GCM_TAG_LENGTH, iv))
+        return cipher.doFinal(encrypted)
+    }
+
+    actual fun deleteKey(databasePath: String) {
+        // Remove from SharedPreferences
+        getPreferences()?.edit()?.remove(storageKey(databasePath))?.apply()
+        // Remove from KeyStore
+        try {
+            val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+            keyStore.load(null)
+            keyStore.deleteEntry(keyAlias(databasePath))
+        } catch (_: Exception) {
+            // Ignore errors during cleanup
+        }
+    }
+
+    actual fun deleteAllKeys() {
+        // Clear all preferences
+        getPreferences()?.edit()?.clear()?.apply()
+        // Remove all biometric keys from KeyStore
+        try {
+            val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+            keyStore.load(null)
+            keyStore.aliases().toList()
+                .filter { it.startsWith(KEY_ALIAS_PREFIX) }
+                .forEach { keyStore.deleteEntry(it) }
+        } catch (_: Exception) {
+            // Ignore errors during cleanup
+        }
+    }
+
+    private fun getPreferences(): android.content.SharedPreferences? {
+        val context = AndroidContextHolder.applicationContext ?: return null
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    private fun storageKey(databasePath: String): String = "encrypted_key_${databasePath.hashCode()}"
+
+    private fun keyAlias(databasePath: String): String = "$KEY_ALIAS_PREFIX${databasePath.hashCode()}"
+
+    private fun getOrCreateKey(databasePath: String): SecretKey {
+        loadKey(databasePath)?.let { return it }
+
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            KEYSTORE_PROVIDER,
+        )
+        val spec = KeyGenParameterSpec.Builder(
+            keyAlias(databasePath),
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .setUserAuthenticationRequired(true)
+            .build()
+
+        keyGenerator.init(spec)
+        return keyGenerator.generateKey()
+    }
+
+    private fun loadKey(databasePath: String): SecretKey? {
+        val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER)
+        keyStore.load(null)
+        val entry = keyStore.getEntry(keyAlias(databasePath), null) as? KeyStore.SecretKeyEntry
+        return entry?.secretKey
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.kt
@@ -1,0 +1,49 @@
+package org.github.keepasscompose.core.biometric
+
+/**
+ * Platform-abstracted secure key storage for biometric unlock.
+ *
+ * Stores the composite key encrypted with a biometric-protected key so that
+ * the database can be unlocked using biometric authentication alone.
+ *
+ * - **Android**: Uses Android KeyStore for AES key generation with biometric
+ *   authentication binding, and SharedPreferences for encrypted data storage.
+ * - **iOS**: Stub (real implementation would use Keychain with biometric ACL).
+ * - **Desktop (JVM)**: Stub (biometric key storage is not available).
+ */
+expect class BiometricKeyStorage() {
+    /**
+     * Returns `true` if a biometric-protected key is stored for the given database.
+     *
+     * @param databasePath Path identifying the database.
+     */
+    fun isKeyStored(databasePath: String): Boolean
+
+    /**
+     * Stores the composite key data encrypted with a biometric-protected key.
+     *
+     * @param databasePath Path identifying the database.
+     * @param compositeKeyData The raw composite key bytes to encrypt and store.
+     */
+    fun storeKey(databasePath: String, compositeKeyData: ByteArray)
+
+    /**
+     * Retrieves and decrypts the stored composite key data.
+     *
+     * @param databasePath Path identifying the database.
+     * @return The decrypted composite key bytes, or `null` if no key is stored.
+     */
+    fun retrieveKey(databasePath: String): ByteArray?
+
+    /**
+     * Deletes the stored key for the given database.
+     *
+     * @param databasePath Path identifying the database.
+     */
+    fun deleteKey(databasePath: String)
+
+    /**
+     * Deletes all stored biometric keys for all databases.
+     */
+    fun deleteAllKeys()
+}

--- a/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorageTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorageTest.kt
@@ -1,0 +1,68 @@
+package org.github.keepasscompose.core.biometric
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class BiometricKeyStorageTest {
+    @Test
+    fun isKeyStoredReturnsFalseByDefault() {
+        val storage = BiometricKeyStorage()
+        assertFalse(storage.isKeyStored("/path/to/database.kdbx"))
+    }
+
+    @Test
+    fun isKeyStoredReturnsFalseForDifferentPaths() {
+        val storage = BiometricKeyStorage()
+        assertFalse(storage.isKeyStored("/path/to/db1.kdbx"))
+        assertFalse(storage.isKeyStored("/path/to/db2.kdbx"))
+        assertFalse(storage.isKeyStored(""))
+    }
+
+    @Test
+    fun retrieveKeyReturnsNullWhenNoKeyStored() {
+        val storage = BiometricKeyStorage()
+        assertNull(storage.retrieveKey("/path/to/database.kdbx"))
+    }
+
+    @Test
+    fun retrieveKeyReturnsNullForDifferentPaths() {
+        val storage = BiometricKeyStorage()
+        assertNull(storage.retrieveKey("/path/to/db1.kdbx"))
+        assertNull(storage.retrieveKey("/path/to/db2.kdbx"))
+    }
+
+    @Test
+    fun deleteKeyDoesNotThrow() {
+        val storage = BiometricKeyStorage()
+        // Should not throw even when no key is stored
+        storage.deleteKey("/path/to/database.kdbx")
+    }
+
+    @Test
+    fun deleteAllKeysDoesNotThrow() {
+        val storage = BiometricKeyStorage()
+        // Should not throw even when no keys are stored
+        storage.deleteAllKeys()
+    }
+
+    @Test
+    fun storeKeyDoesNotThrowOnJvm() {
+        val storage = BiometricKeyStorage()
+        // On JVM/iOS stubs, storeKey is a no-op but should not throw
+        storage.storeKey("/path/to/database.kdbx", byteArrayOf(1, 2, 3, 4))
+    }
+
+    @Test
+    fun multipleOperationsDoNotThrow() {
+        val storage = BiometricKeyStorage()
+        val path = "/path/to/test.kdbx"
+
+        // Sequence of operations should not throw
+        storage.storeKey(path, byteArrayOf(10, 20, 30))
+        storage.isKeyStored(path)
+        storage.retrieveKey(path)
+        storage.deleteKey(path)
+        storage.deleteAllKeys()
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.ios.kt
@@ -1,0 +1,27 @@
+package org.github.keepasscompose.core.biometric
+
+/**
+ * iOS biometric key storage stub.
+ *
+ * A full implementation would use the iOS Keychain with a biometric
+ * access control (kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
+ * + SecAccessControlCreateFlags.biometryCurrentSet) to store and
+ * retrieve composite keys protected by Face ID or Touch ID.
+ */
+actual class BiometricKeyStorage actual constructor() {
+    actual fun isKeyStored(databasePath: String): Boolean = false
+
+    actual fun storeKey(databasePath: String, compositeKeyData: ByteArray) {
+        // Stub: real implementation would use Keychain with biometric ACL
+    }
+
+    actual fun retrieveKey(databasePath: String): ByteArray? = null
+
+    actual fun deleteKey(databasePath: String) {
+        // Stub
+    }
+
+    actual fun deleteAllKeys() {
+        // Stub
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/github/keepasscompose/core/biometric/BiometricKeyStorage.jvm.kt
@@ -1,0 +1,24 @@
+package org.github.keepasscompose.core.biometric
+
+/**
+ * Desktop (JVM) biometric key storage stub.
+ *
+ * Biometric key storage is not available on standard desktop platforms.
+ */
+actual class BiometricKeyStorage actual constructor() {
+    actual fun isKeyStored(databasePath: String): Boolean = false
+
+    actual fun storeKey(databasePath: String, compositeKeyData: ByteArray) {
+        // Stub: biometric key storage not available on desktop
+    }
+
+    actual fun retrieveKey(databasePath: String): ByteArray? = null
+
+    actual fun deleteKey(databasePath: String) {
+        // Stub
+    }
+
+    actual fun deleteAllKeys() {
+        // Stub
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BiometricKeyStorage` expect/actual class for securely storing composite keys encrypted with biometric-protected keys
- Android actual uses Android KeyStore (AES-256-GCM) with biometric auth binding + SharedPreferences for encrypted data
- iOS and JVM actuals are stubs (iOS returns false for isKeyStored, JVM returns false)
- Add commonTest covering the API contract (isKeyStored, retrieveKey, deleteKey, deleteAllKeys, storeKey)

## Test plan
- [x] `./gradlew composeApp:compileKotlinJvm` passes
- [x] Common tests verify stub behavior on JVM (no-op operations don't throw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)