### PR TITLE
[#355] Replace left panel with expandable tree view

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupTree.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupTree.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
@@ -26,44 +27,71 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.core.model.KdbxGroup
 
 @Composable
-fun GroupTree(rootGroup: KdbxGroup, selectedGroupUuid: String? = null, onGroupSelected: (KdbxGroup) -> Unit = {}, modifier: Modifier = Modifier) {
+fun GroupTree(
+    rootGroup: KdbxGroup,
+    selectedEntryUuid: String? = null,
+    onEntrySelected: (KdbxEntry) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
     val expandedGroups = remember { mutableStateListOf(rootGroup.uuid) }
     val flattenedItems = remember(rootGroup, expandedGroups.toList()) {
-        buildFlatGroupList(rootGroup, expandedGroups.toSet(), depth = 0)
+        buildFlatTreeList(rootGroup, expandedGroups.toSet(), depth = 0)
     }
 
     LazyColumn(modifier = modifier) {
-        items(flattenedItems, key = { it.group.uuid }) { item ->
-            GroupTreeItem(
-                group = item.group,
-                depth = item.depth,
-                isExpanded = item.group.uuid in expandedGroups,
-                isSelected = item.group.uuid == selectedGroupUuid,
-                hasChildren = item.group.groups.isNotEmpty(),
-                entryCount = item.group.entries.size,
-                onToggleExpand = {
-                    if (item.group.uuid in expandedGroups) {
-                        expandedGroups.remove(item.group.uuid)
-                    } else {
-                        expandedGroups.add(item.group.uuid)
-                    }
-                },
-                onSelect = { onGroupSelected(item.group) },
-            )
+        items(flattenedItems, key = { it.key }) { item ->
+            when (item) {
+                is TreeItem.Group -> GroupTreeItem(
+                    group = item.group,
+                    depth = item.depth,
+                    isExpanded = item.group.uuid in expandedGroups,
+                    hasChildren = item.group.groups.isNotEmpty() || item.group.entries.isNotEmpty(),
+                    entryCount = item.group.entries.size,
+                    onToggleExpand = {
+                        if (item.group.uuid in expandedGroups) {
+                            expandedGroups.remove(item.group.uuid)
+                        } else {
+                            expandedGroups.add(item.group.uuid)
+                        }
+                    },
+                )
+
+                is TreeItem.Entry -> EntryTreeItem(
+                    entry = item.entry,
+                    depth = item.depth,
+                    isSelected = item.entry.uuid == selectedEntryUuid,
+                    onSelect = { onEntrySelected(item.entry) },
+                )
+            }
         }
     }
 }
 
-private data class FlatGroupItem(val group: KdbxGroup, val depth: Int)
+private sealed class TreeItem {
+    abstract val key: String
+    abstract val depth: Int
 
-private fun buildFlatGroupList(group: KdbxGroup, expandedIds: Set<String>, depth: Int): List<FlatGroupItem> = buildList {
-    add(FlatGroupItem(group, depth))
+    data class Group(val group: KdbxGroup, override val depth: Int) : TreeItem() {
+        override val key: String get() = "g_${group.uuid}"
+    }
+
+    data class Entry(val entry: KdbxEntry, override val depth: Int) : TreeItem() {
+        override val key: String get() = "e_${entry.uuid}"
+    }
+}
+
+private fun buildFlatTreeList(group: KdbxGroup, expandedIds: Set<String>, depth: Int): List<TreeItem> = buildList {
+    add(TreeItem.Group(group, depth))
     if (group.uuid in expandedIds) {
         for (child in group.groups) {
-            addAll(buildFlatGroupList(child, expandedIds, depth + 1))
+            addAll(buildFlatTreeList(child, expandedIds, depth + 1))
+        }
+        for (entry in group.entries) {
+            add(TreeItem.Entry(entry, depth + 1))
         }
     }
 }
@@ -73,10 +101,64 @@ private fun GroupTreeItem(
     group: KdbxGroup,
     depth: Int,
     isExpanded: Boolean,
-    isSelected: Boolean,
     hasChildren: Boolean,
     entryCount: Int,
     onToggleExpand: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggleExpand)
+            .padding(start = (16 + depth * 20).dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+    ) {
+        if (hasChildren) {
+            IconButton(onClick = onToggleExpand, modifier = Modifier.size(24.dp)) {
+                Icon(
+                    @Suppress("DEPRECATION")
+                    if (isExpanded) Icons.Filled.KeyboardArrowDown else Icons.Filled.KeyboardArrowRight,
+                    contentDescription = if (isExpanded) "Collapse" else "Expand",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        } else {
+            Spacer(modifier = Modifier.size(24.dp))
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        Icon(
+            if (isExpanded && hasChildren) Icons.Filled.FolderOpen else Icons.Filled.Folder,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp),
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(
+            text = group.name,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+
+        if (entryCount > 0) {
+            Text(
+                text = "$entryCount",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EntryTreeItem(
+    entry: KdbxEntry,
+    depth: Int,
+    isSelected: Boolean,
     onSelect: () -> Unit,
 ) {
     val backgroundColor = if (isSelected) {
@@ -96,50 +178,30 @@ private fun GroupTreeItem(
             .fillMaxWidth()
             .background(backgroundColor)
             .clickable(onClick = onSelect)
-            .padding(start = (16 + depth * 20).dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+            .padding(start = (16 + depth * 20 + 28).dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
     ) {
-        // Expand/collapse arrow
-        if (hasChildren) {
-            IconButton(onClick = onToggleExpand, modifier = Modifier.size(24.dp)) {
-                Icon(
-                    @Suppress("DEPRECATION")
-                    if (isExpanded) Icons.Filled.KeyboardArrowDown else Icons.Filled.KeyboardArrowRight,
-                    contentDescription = if (isExpanded) "Collapse" else "Expand",
-                    tint = contentColor,
-                    modifier = Modifier.size(18.dp),
-                )
-            }
-        } else {
-            Spacer(modifier = Modifier.size(24.dp))
-        }
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        // Folder icon
         Icon(
-            if (isExpanded && hasChildren) Icons.Filled.FolderOpen else Icons.Filled.Folder,
+            Icons.Filled.Key,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(20.dp),
+            tint = if (isSelected) contentColor else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(18.dp),
         )
 
         Spacer(modifier = Modifier.width(8.dp))
 
-        // Group name
-        Text(
-            text = group.name,
-            style = MaterialTheme.typography.bodyMedium,
-            color = contentColor,
-            modifier = Modifier.weight(1f),
-        )
-
-        // Entry count badge
-        if (entryCount > 0) {
+        Column {
             Text(
-                text = "$entryCount",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = entry.title.ifEmpty { "Untitled" },
+                style = MaterialTheme.typography.bodySmall,
+                color = contentColor,
             )
+            if (entry.userName.isNotEmpty()) {
+                Text(
+                    text = entry.userName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (isSelected) contentColor.copy(alpha = 0.7f) else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -126,15 +126,10 @@ fun AppNavigator() {
 
         is AppScreen.Main -> {
             val database by databaseViewModel.database.collectAsState()
-            val selectedGroup by groupNavViewModel.selectedGroup.collectAsState()
-            val breadcrumb by groupNavViewModel.breadcrumb.collectAsState()
 
             MainScreen(
                 databaseName = database?.meta?.databaseName ?: "Database",
-                selectedGroup = selectedGroup,
-                hasParentGroup = breadcrumb.size > 1,
-                onGroupSelected = { group -> groupNavViewModel.navigateTo(group) },
-                onNavigateUp = { groupNavViewModel.navigateToParent() },
+                rootGroup = database?.rootGroup,
                 onLockDatabase = {
                     databaseViewModel.lock()
                     unlockViewModel.resetState()

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -1,24 +1,15 @@
 package org.github.keepasscompose.ui.screens
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.FolderOpen
-import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -47,15 +38,13 @@ import kotlinx.coroutines.launch
 import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.core.model.KdbxGroup
 import org.github.keepasscompose.ui.common.BackHandler
+import org.github.keepasscompose.ui.components.GroupTree
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
     databaseName: String = "",
-    selectedGroup: KdbxGroup? = null,
-    hasParentGroup: Boolean = false,
-    onGroupSelected: (KdbxGroup) -> Unit = {},
-    onNavigateUp: () -> Unit = {},
+    rootGroup: KdbxGroup? = null,
     onCopyField: (String) -> Unit = {},
     onLockDatabase: () -> Unit = {},
     onOpenDatabase: () -> Unit = {},
@@ -64,10 +53,7 @@ fun MainScreen(
 ) {
     val navigator = rememberListDetailPaneScaffoldNavigator<String>()
     val scope = rememberCoroutineScope()
-    val entries = selectedGroup?.entries ?: emptyList()
-    val subGroups = selectedGroup?.groups ?: emptyList()
-    val entryCount = entries.size
-    val selectedEntry = entries.find { it.uuid == navigator.currentDestination?.contentKey }
+    val selectedEntry = rootGroup?.let { findEntry(it, navigator.currentDestination?.contentKey) }
 
     val isListHidden = navigator.scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Hidden
     val isDetailHidden = navigator.scaffoldValue[ListDetailPaneScaffoldRole.Detail] == PaneAdaptedValue.Hidden
@@ -85,14 +71,7 @@ fun MainScreen(
                     topBar = {
                         Column {
                             TopAppBar(
-                                title = { Text(selectedGroup?.name ?: databaseName.ifEmpty { "KeePass Compose" }) },
-                                navigationIcon = {
-                                    if (hasParentGroup) {
-                                        IconButton(onClick = onNavigateUp) {
-                                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate up")
-                                        }
-                                    }
-                                },
+                                title = { Text(databaseName.ifEmpty { "KeePass Compose" }) },
                                 actions = {
                                     IconButton(onClick = onSearch) {
                                         Icon(Icons.Filled.Search, contentDescription = "Search")
@@ -107,7 +86,7 @@ fun MainScreen(
                                 ),
                             )
                             if (!isDetailHidden) {
-                                StatusBar(databaseName = databaseName, entryCount = entryCount)
+                                StatusBar(databaseName = databaseName, entryCount = rootGroup?.let { countEntries(it) } ?: 0)
                             }
                         }
                     },
@@ -120,22 +99,22 @@ fun MainScreen(
                     },
                     bottomBar = {
                         if (isDetailHidden) {
-                            StatusBar(databaseName = databaseName, entryCount = entryCount)
+                            StatusBar(databaseName = databaseName, entryCount = rootGroup?.let { countEntries(it) } ?: 0)
                         }
                     },
                 ) { padding ->
-                    GroupEntryListPane(
-                        subGroups = subGroups,
-                        entries = entries,
-                        selectedEntryUuid = navigator.currentDestination?.contentKey,
-                        onGroupSelected = onGroupSelected,
-                        onEntrySelected = { entry ->
-                            scope.launch {
-                                navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, entry.uuid)
-                            }
-                        },
-                        modifier = Modifier.fillMaxSize().padding(padding),
-                    )
+                    if (rootGroup != null) {
+                        GroupTree(
+                            rootGroup = rootGroup,
+                            selectedEntryUuid = navigator.currentDestination?.contentKey,
+                            onEntrySelected = { entry ->
+                                scope.launch {
+                                    navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, entry.uuid)
+                                }
+                            },
+                            modifier = Modifier.fillMaxSize().padding(padding),
+                        )
+                    }
                 }
             }
         },
@@ -181,97 +160,24 @@ fun MainScreen(
 }
 
 // ---------------------------------------------------------------------------
-// Shared components
+// Helpers
 // ---------------------------------------------------------------------------
 
-@Composable
-private fun GroupEntryListPane(
-    subGroups: List<KdbxGroup>,
-    entries: List<KdbxEntry>,
-    selectedEntryUuid: String? = null,
-    onGroupSelected: (KdbxGroup) -> Unit = {},
-    onEntrySelected: (KdbxEntry) -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    if (subGroups.isEmpty() && entries.isEmpty()) {
-        Box(modifier = modifier, contentAlignment = Alignment.Center) {
-            Text(
-                text = "No entries",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    } else {
-        LazyColumn(modifier = modifier) {
-            items(subGroups, key = { it.uuid }) { group ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onGroupSelected(group) }
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                ) {
-                    Icon(
-                        Icons.Filled.FolderOpen,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(24.dp),
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column {
-                        Text(
-                            text = group.name,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        val itemCount = group.groups.size + group.entries.size
-                        if (itemCount > 0) {
-                            Text(
-                                text = "$itemCount items",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-                HorizontalDivider()
-            }
-            items(entries, key = { it.uuid }) { entry ->
-                val isSelected = entry.uuid == selectedEntryUuid
-                val bg = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
-                val contentColor = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(bg)
-                        .clickable { onEntrySelected(entry) }
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                ) {
-                    Icon(
-                        Icons.Filled.Key,
-                        contentDescription = null,
-                        tint = if (isSelected) contentColor else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(24.dp),
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column {
-                        Text(text = entry.title.ifEmpty { "Untitled" }, style = MaterialTheme.typography.bodyLarge, color = contentColor)
-                        if (entry.userName.isNotEmpty()) {
-                            Text(
-                                text = entry.userName,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = if (isSelected) contentColor.copy(alpha = 0.7f) else MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-                HorizontalDivider()
-            }
-        }
+private fun findEntry(group: KdbxGroup, uuid: String?): KdbxEntry? {
+    if (uuid == null) return null
+    group.entries.find { it.uuid == uuid }?.let { return it }
+    for (child in group.groups) {
+        findEntry(child, uuid)?.let { return it }
     }
+    return null
 }
+
+private fun countEntries(group: KdbxGroup): Int =
+    group.entries.size + group.groups.sumOf { countEntries(it) }
+
+// ---------------------------------------------------------------------------
+// Shared components
+// ---------------------------------------------------------------------------
 
 @Composable
 private fun StatusBar(databaseName: String, entryCount: Int) {


### PR DESCRIPTION
## Summary
- Replaced the flat group list in the left panel with an expandable tree view showing groups as collapsible folder nodes and entries as leaves
- Removed drill-in navigation (click group → navigate back) in favor of expand/collapse tree interaction
- Simplified `MainScreen` and `AppNavigator` by removing group navigation callbacks

Closes #355

## Test plan
- [ ] Open a database with nested groups and verify the tree view renders correctly
- [ ] Expand/collapse groups by clicking on them
- [ ] Click an entry leaf to view its details in the right pane
- [ ] Verify the status bar shows the total entry count across all groups
- [ ] Test on both phone (single pane) and tablet/desktop (dual pane) layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)