### PR TITLE
[#358] Register missing ViewModels in Koin DI

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/di/AppModule.kt
@@ -9,7 +9,9 @@ import org.github.keepasscompose.core.crypto.PlatformCryptoProvider
 import org.github.keepasscompose.core.database.KdbxReader
 import org.github.keepasscompose.core.database.KdbxWriter
 import org.github.keepasscompose.viewmodel.DatabaseViewModel
+import org.github.keepasscompose.viewmodel.EntryEditorViewModel
 import org.github.keepasscompose.viewmodel.GroupNavigationViewModel
+import org.github.keepasscompose.viewmodel.MultiDatabaseViewModel
 import org.github.keepasscompose.viewmodel.UnlockViewModel
 import org.koin.dsl.module
 
@@ -28,4 +30,6 @@ val appModule =
         single { UnlockViewModel(get(), get()) }
         single { DatabaseViewModel(get(), get()) }
         single { GroupNavigationViewModel() }
+        single { EntryEditorViewModel() }
+        single { MultiDatabaseViewModel(get(), get()) }
     }


### PR DESCRIPTION
## Summary
- Register `EntryEditorViewModel` and `MultiDatabaseViewModel` in `AppModule.kt`
- Both ViewModels already existed but were never registered in the DI container

Closes #358

## Test plan
- [x] Build compiles successfully
- [ ] Existing DI injections still work (app starts without crashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)