### PR TITLE
[#361] Wire New Entry FAB to EntryEditorScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -19,11 +19,14 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.github.keepasscompose.core.common.AppSettings
 import org.github.keepasscompose.core.common.FilePicker
+import org.github.keepasscompose.core.database.RecycleBinManager
+import org.github.keepasscompose.ui.screens.EntryEditorScreen
 import org.github.keepasscompose.ui.screens.MainScreen
 import org.github.keepasscompose.ui.screens.RecentDatabase
 import org.github.keepasscompose.ui.screens.UnlockScreen
 import org.github.keepasscompose.ui.screens.WelcomeScreen
 import org.github.keepasscompose.viewmodel.DatabaseViewModel
+import org.github.keepasscompose.viewmodel.EntryEditorViewModel
 import org.github.keepasscompose.viewmodel.GroupNavigationViewModel
 import org.github.keepasscompose.viewmodel.UnlockState
 import org.github.keepasscompose.viewmodel.UnlockViewModel
@@ -93,6 +96,7 @@ fun AppNavigator() {
     val unlockViewModel: UnlockViewModel = koinInject()
     val databaseViewModel: DatabaseViewModel = koinInject()
     val groupNavViewModel: GroupNavigationViewModel = koinInject()
+    val entryEditorViewModel: EntryEditorViewModel = koinInject()
     val appSettings: AppSettings = koinInject()
     val filePicker = remember { FilePicker() }
     val scope = rememberCoroutineScope()
@@ -185,11 +189,54 @@ fun AppNavigator() {
                         }
                     }
                 },
+                onNewEntry = {
+                    entryEditorViewModel.startCreating()
+                    currentScreen = AppScreen.EntryEditor(isEditMode = false, entryUuid = null)
+                },
             )
         }
 
         is AppScreen.EntryEditor -> {
-            PlaceholderScreen("Entry Editor") { currentScreen = AppScreen.Main }
+            val screen = currentScreen as AppScreen.EntryEditor
+            val database by databaseViewModel.database.collectAsState()
+            val existingEntry = if (screen.isEditMode && screen.entryUuid != null) {
+                database?.rootGroup?.let { RecycleBinManager.findEntry(it, screen.entryUuid) }
+            } else {
+                null
+            }
+
+            EntryEditorScreen(
+                initialTitle = existingEntry?.title ?: "",
+                initialUserName = existingEntry?.userName ?: "",
+                initialPassword = existingEntry?.password ?: "",
+                initialUrl = existingEntry?.url ?: "",
+                initialNotes = existingEntry?.notes ?: "",
+                initialIconIndex = existingEntry?.icon?.standardIndex ?: 0,
+                initialTags = existingEntry?.tags ?: emptyList(),
+                isEditMode = screen.isEditMode,
+                onSave = { result ->
+                    val saved = entryEditorViewModel.save(result)
+                    if (saved != null) {
+                        val selectedGroup = groupNavViewModel.selectedGroup.value
+                        val parentUuid = selectedGroup?.uuid ?: database?.rootGroup?.uuid ?: return@EntryEditorScreen
+                        if (screen.isEditMode) {
+                            databaseViewModel.updateEntry(saved)
+                        } else {
+                            databaseViewModel.addEntry(parentUuid, saved)
+                        }
+                        // Refresh group navigation with updated root
+                        databaseViewModel.database.value?.rootGroup?.let {
+                            groupNavViewModel.setRootGroup(it)
+                        }
+                        entryEditorViewModel.resetState()
+                        currentScreen = AppScreen.Main
+                    }
+                },
+                onCancel = {
+                    entryEditorViewModel.resetState()
+                    currentScreen = AppScreen.Main
+                },
+            )
         }
 
         is AppScreen.CreateDatabase -> {


### PR DESCRIPTION
## Summary
- Connect MainScreen "New Entry" FAB to `EntryEditorScreen` in create mode
- Inject `EntryEditorViewModel` in AppNavigator
- On save: create entry via `EntryEditorViewModel.save()`, add to database via `DatabaseViewModel.addEntry()`, refresh group tree
- Cancel returns to Main without changes
- EntryEditor branch also handles edit mode (pre-fills existing entry data) for #362

Closes #361

## Test plan
- [x] Build compiles successfully
- [x] All tests pass
- [ ] Clicking FAB opens entry editor
- [ ] Filling fields and saving creates entry visible in group tree
- [ ] Cancel returns to main without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)