### PR TITLE
[#362] Add Edit button to EntryDetailScreen and wire editing

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -193,6 +193,13 @@ fun AppNavigator() {
                     entryEditorViewModel.startCreating()
                     currentScreen = AppScreen.EntryEditor(isEditMode = false, entryUuid = null)
                 },
+                onEditEntry = { uuid ->
+                    val entry = database?.rootGroup?.let { RecycleBinManager.findEntry(it, uuid) }
+                    if (entry != null) {
+                        entryEditorViewModel.startEditing(entry)
+                        currentScreen = AppScreen.EntryEditor(isEditMode = true, entryUuid = uuid)
+                    }
+                },
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -39,7 +40,13 @@ import org.github.keepasscompose.ui.components.TotpDisplay
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun EntryDetailScreen(entry: KdbxEntry, onCopyField: (String) -> Unit = {}, onBack: () -> Unit = {}, modifier: Modifier = Modifier) {
+fun EntryDetailScreen(
+    entry: KdbxEntry,
+    onCopyField: (String) -> Unit = {},
+    onBack: () -> Unit = {},
+    onEditEntry: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
     var passwordVisible by remember { mutableStateOf(false) }
 
     Column(
@@ -49,7 +56,10 @@ fun EntryDetailScreen(entry: KdbxEntry, onCopyField: (String) -> Unit = {}, onBa
             .padding(16.dp),
     ) {
         // Header
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Icon(
                 Icons.Filled.Key,
                 contentDescription = null,
@@ -60,7 +70,11 @@ fun EntryDetailScreen(entry: KdbxEntry, onCopyField: (String) -> Unit = {}, onBa
             Text(
                 text = entry.title.ifEmpty { "Untitled" },
                 style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.weight(1f),
             )
+            IconButton(onClick = { onEditEntry(entry.uuid) }) {
+                Icon(Icons.Filled.Edit, contentDescription = "Edit entry")
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -56,6 +56,7 @@ fun MainScreen(
     onLockDatabase: () -> Unit = {},
     onOpenDatabase: () -> Unit = {},
     onNewEntry: () -> Unit = {},
+    onEditEntry: (String) -> Unit = {},
     onSearch: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
     onOpenDatabaseSettings: () -> Unit = {},
@@ -170,6 +171,7 @@ fun MainScreen(
                             EntryDetailScreen(
                                 entry = entry,
                                 onCopyField = onCopyField,
+                                onEditEntry = onEditEntry,
                                 modifier = Modifier.padding(padding),
                             )
                         }


### PR DESCRIPTION
## Summary
- Add edit icon button to `EntryDetailScreen` header row
- Add `onEditEntry: (String) -> Unit` callback to `EntryDetailScreen` and `MainScreen`
- Wire in `AppNavigator`: clicking Edit finds entry, calls `startEditing()`, navigates to EntryEditor in edit mode

Closes #362

## Test plan
- [x] Build compiles, all tests pass
- [ ] Edit button visible on entry detail view
- [ ] Clicking Edit opens editor pre-filled with current values
- [ ] Saving updates the entry and returns to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)