### PR TITLE
[#363] Wire entry deletion with confirmation dialog

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -200,6 +200,11 @@ fun AppNavigator() {
                         currentScreen = AppScreen.EntryEditor(isEditMode = true, entryUuid = uuid)
                     }
                 },
+                onDeleteEntry = { uuid ->
+                    databaseViewModel.deleteEntry(uuid)
+                    database?.rootGroup?.let { groupNavViewModel.setRootGroup(it) }
+                },
+                hasRecycleBin = database?.meta?.recycleBinEnabled == true,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryDetailScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Visibility
@@ -45,6 +46,7 @@ fun EntryDetailScreen(
     onCopyField: (String) -> Unit = {},
     onBack: () -> Unit = {},
     onEditEntry: (String) -> Unit = {},
+    onDeleteEntry: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
@@ -74,6 +76,9 @@ fun EntryDetailScreen(
             )
             IconButton(onClick = { onEditEntry(entry.uuid) }) {
                 Icon(Icons.Filled.Edit, contentDescription = "Edit entry")
+            }
+            IconButton(onClick = { onDeleteEntry(entry.uuid) }) {
+                Icon(Icons.Filled.Delete, contentDescription = "Delete entry", tint = MaterialTheme.colorScheme.error)
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.launch
 import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.core.model.KdbxGroup
 import org.github.keepasscompose.ui.common.BackHandler
+import org.github.keepasscompose.ui.components.DeleteEntryDialog
 import org.github.keepasscompose.ui.components.GroupTree
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalMaterial3Api::class)
@@ -64,10 +65,26 @@ fun MainScreen(
     onOpenReports: () -> Unit = {},
     onChangePassword: () -> Unit = {},
     onChangeKeyFile: () -> Unit = {},
+    onDeleteEntry: (String) -> Unit = {},
+    hasRecycleBin: Boolean = false,
 ) {
     val navigator = rememberListDetailPaneScaffoldNavigator<String>()
     val scope = rememberCoroutineScope()
     val selectedEntry = rootGroup?.let { findEntry(it, navigator.currentDestination?.contentKey) }
+    var entryPendingDelete by remember { mutableStateOf<KdbxEntry?>(null) }
+
+    entryPendingDelete?.let { entry ->
+        DeleteEntryDialog(
+            entries = listOf(entry),
+            hasRecycleBin = hasRecycleBin,
+            onDismiss = { entryPendingDelete = null },
+            onConfirm = {
+                onDeleteEntry(entry.uuid)
+                entryPendingDelete = null
+                scope.launch { navigator.navigateBack() }
+            },
+        )
+    }
 
     val isListHidden = navigator.scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Hidden
     val isDetailHidden = navigator.scaffoldValue[ListDetailPaneScaffoldRole.Detail] == PaneAdaptedValue.Hidden
@@ -172,6 +189,7 @@ fun MainScreen(
                                 entry = entry,
                                 onCopyField = onCopyField,
                                 onEditEntry = onEditEntry,
+                                onDeleteEntry = { _ -> entryPendingDelete = entry },
                                 modifier = Modifier.padding(padding),
                             )
                         }


### PR DESCRIPTION
## Summary
- Add delete button (red trash icon) to `EntryDetailScreen` header
- Add `DeleteEntryDialog` confirmation to `MainScreen` with recycle bin awareness
- Wire `onDeleteEntry` in `AppNavigator` to call `DatabaseViewModel.deleteEntry()` + refresh group tree

Closes #363

## Test plan
- [x] Build compiles, all tests pass
- [ ] Delete button visible on entry detail
- [ ] Clicking delete shows confirmation dialog
- [ ] Dialog shows correct text based on recycle bin setting
- [ ] Confirming removes entry from tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)