### PR TITLE
[#396] Add Scaffold with TopAppBar and back button to all secondary screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -324,6 +324,7 @@ fun AppNavigator() {
             SearchResultsScreen(
                 results = results,
                 query = searchQuery,
+                onBack = { currentScreen = AppScreen.Main },
                 onResultClick = { result ->
                     currentScreen = AppScreen.Main
                 },
@@ -458,6 +459,7 @@ fun AppNavigator() {
                     onReusedPasswords = { /* navigate to reused passwords sub-screen */ },
                     onExpiredEntries = { /* navigate to expired entries sub-screen */ },
                     onHibpReport = { /* navigate to HIBP sub-screen */ },
+                    onBack = { currentScreen = AppScreen.Main },
                 )
             } else {
                 PlaceholderScreen("Reports") { currentScreen = AppScreen.Main }
@@ -489,6 +491,7 @@ fun AppNavigator() {
             if (entry != null) {
                 EntryHistoryScreen(
                     entry = entry,
+                    onBack = { currentScreen = AppScreen.Main },
                     onRestoreVersion = { historicalEntry ->
                         databaseViewModel.updateEntry(historicalEntry)
                         database?.rootGroup?.let { groupNavViewModel.setRootGroup(it) }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/AppSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/AppSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
@@ -25,14 +26,17 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -61,6 +65,7 @@ data class AppSettingsData(
     val browserInstalledBrowsers: List<BrowserInstallStatus> = emptyList(),
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppSettingsScreen(
     settings: AppSettingsData = AppSettingsData(),
@@ -84,83 +89,94 @@ fun AppSettingsScreen(
     var browserSortByTitle by remember { mutableStateOf(settings.browserSortByTitle) }
     var browserMinimizeOnAutofill by remember { mutableStateOf(settings.browserMinimizeOnAutofill) }
 
-    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Text("App Settings", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(16.dp))
-
-        PrimaryTabRow(selectedTabIndex = selectedTab) {
-            tabs.forEachIndexed { index, title ->
-                Tab(selected = selectedTab == index, onClick = { selectedTab = index }, text = { Text(title) })
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("App Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+            PrimaryTabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(selected = selectedTab == index, onClick = { selectedTab = index }, text = { Text(title) })
+                }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
-            when (selectedTab) {
-                0 -> GeneralSettingsTab(
-                    startAtLogin = startAtLogin,
-                    minimizeToTray = minimizeToTray,
-                    onStartAtLoginChange = { startAtLogin = it },
-                    onMinimizeToTrayChange = { minimizeToTray = it },
-                )
-
-                1 -> SecuritySettingsTab(
-                    autoLockTimeout = autoLockTimeout,
-                    lockOnMinimize = lockOnMinimize,
-                    clipboardClearTimeout = clipboardClearTimeout,
-                    onAutoLockChange = { autoLockTimeout = it },
-                    onLockOnMinimizeChange = { lockOnMinimize = it },
-                    onClipboardClearChange = { clipboardClearTimeout = it },
-                )
-
-                2 -> AppearanceSettingsTab(
-                    theme = theme,
-                    fontSize = fontSize,
-                    onThemeChange = { theme = it },
-                    onFontSizeChange = { fontSize = it },
-                )
-
-                3 -> BrowserSettingsTab(
-                    enabled = browserEnabled,
-                    onEnabledChange = { browserEnabled = it },
-                    matchStrategy = browserMatchStrategy,
-                    onMatchStrategyChange = { browserMatchStrategy = it },
-                    showNotifications = browserShowNotifications,
-                    onShowNotificationsChange = { browserShowNotifications = it },
-                    sortByTitle = browserSortByTitle,
-                    onSortByTitleChange = { browserSortByTitle = it },
-                    minimizeOnAutofill = browserMinimizeOnAutofill,
-                    onMinimizeOnAutofillChange = { browserMinimizeOnAutofill = it },
-                    installedBrowsers = settings.browserInstalledBrowsers,
-                    onInstallBrowserSupport = {},
-                )
-            }
-        }
-
-        HorizontalDivider()
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            TextButton(onClick = onCancel) { Text("Cancel") }
-            Spacer(modifier = Modifier.width(8.dp))
-            Button(onClick = {
-                onSave(
-                    AppSettingsData(
+            Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+                when (selectedTab) {
+                    0 -> GeneralSettingsTab(
                         startAtLogin = startAtLogin,
                         minimizeToTray = minimizeToTray,
-                        autoLockTimeout = autoLockTimeout.toIntOrNull() ?: 300,
+                        onStartAtLoginChange = { startAtLogin = it },
+                        onMinimizeToTrayChange = { minimizeToTray = it },
+                    )
+
+                    1 -> SecuritySettingsTab(
+                        autoLockTimeout = autoLockTimeout,
                         lockOnMinimize = lockOnMinimize,
-                        clipboardClearTimeout = clipboardClearTimeout.toIntOrNull() ?: 30,
+                        clipboardClearTimeout = clipboardClearTimeout,
+                        onAutoLockChange = { autoLockTimeout = it },
+                        onLockOnMinimizeChange = { lockOnMinimize = it },
+                        onClipboardClearChange = { clipboardClearTimeout = it },
+                    )
+
+                    2 -> AppearanceSettingsTab(
                         theme = theme,
                         fontSize = fontSize,
-                        browserIntegrationEnabled = browserEnabled,
-                        browserMatchStrategy = browserMatchStrategy,
-                        browserShowNotifications = browserShowNotifications,
-                        browserSortByTitle = browserSortByTitle,
-                        browserMinimizeOnAutofill = browserMinimizeOnAutofill,
-                    ),
-                )
-            }) { Text("Save") }
+                        onThemeChange = { theme = it },
+                        onFontSizeChange = { fontSize = it },
+                    )
+
+                    3 -> BrowserSettingsTab(
+                        enabled = browserEnabled,
+                        onEnabledChange = { browserEnabled = it },
+                        matchStrategy = browserMatchStrategy,
+                        onMatchStrategyChange = { browserMatchStrategy = it },
+                        showNotifications = browserShowNotifications,
+                        onShowNotificationsChange = { browserShowNotifications = it },
+                        sortByTitle = browserSortByTitle,
+                        onSortByTitleChange = { browserSortByTitle = it },
+                        minimizeOnAutofill = browserMinimizeOnAutofill,
+                        onMinimizeOnAutofillChange = { browserMinimizeOnAutofill = it },
+                        installedBrowsers = settings.browserInstalledBrowsers,
+                        onInstallBrowserSupport = {},
+                    )
+                }
+            }
+
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onCancel) { Text("Cancel") }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = {
+                    onSave(
+                        AppSettingsData(
+                            startAtLogin = startAtLogin,
+                            minimizeToTray = minimizeToTray,
+                            autoLockTimeout = autoLockTimeout.toIntOrNull() ?: 300,
+                            lockOnMinimize = lockOnMinimize,
+                            clipboardClearTimeout = clipboardClearTimeout.toIntOrNull() ?: 30,
+                            theme = theme,
+                            fontSize = fontSize,
+                            browserIntegrationEnabled = browserEnabled,
+                            browserMatchStrategy = browserMatchStrategy,
+                            browserShowNotifications = browserShowNotifications,
+                            browserSortByTitle = browserSortByTitle,
+                            browserMinimizeOnAutofill = browserMinimizeOnAutofill,
+                        ),
+                    )
+                }) { Text("Save") }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ChangeKeyFileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ChangeKeyFileScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FolderOpen
@@ -18,16 +19,21 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChangeKeyFileScreen(
     currentKeyFilePath: String? = null,
@@ -40,102 +46,115 @@ fun ChangeKeyFileScreen(
     onCancel: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
-        Text("Change Key File", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "A key file provides an additional layer of security alongside your master password.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Change Key File") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(16.dp)) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "A key file provides an additional layer of security alongside your master password.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
 
-        Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-        // Current key file status
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            ),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Row(
-                modifier = Modifier.padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
+            // Current key file status
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                ),
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                Icon(
-                    Icons.Filled.Key,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp),
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Current Key File", style = MaterialTheme.typography.labelMedium)
-                    Text(
-                        text = currentKeyFilePath ?: "None",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = if (currentKeyFilePath != null) {
-                            MaterialTheme.colorScheme.onSurface
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Filled.Key,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
                     )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Current Key File", style = MaterialTheme.typography.labelMedium)
+                        Text(
+                            text = currentKeyFilePath ?: "None",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = if (currentKeyFilePath != null) {
+                                MaterialTheme.colorScheme.onSurface
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
+                    }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-        // Actions
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            OutlinedButton(
-                onClick = onSelectKeyFile,
-                enabled = !isProcessing,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(Icons.Filled.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Select Existing Key File")
-            }
-            OutlinedButton(
-                onClick = onGenerateKeyFile,
-                enabled = !isProcessing,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Generate New Key File")
-            }
-            if (currentKeyFilePath != null) {
+            // Actions
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedButton(
-                    onClick = onRemoveKeyFile,
+                    onClick = onSelectKeyFile,
                     enabled = !isProcessing,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Icon(Icons.Filled.Close, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Icon(Icons.Filled.FolderOpen, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text("Remove Key File")
+                    Text("Select Existing Key File")
+                }
+                OutlinedButton(
+                    onClick = onGenerateKeyFile,
+                    enabled = !isProcessing,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Generate New Key File")
+                }
+                if (currentKeyFilePath != null) {
+                    OutlinedButton(
+                        onClick = onRemoveKeyFile,
+                        enabled = !isProcessing,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(Icons.Filled.Close, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Remove Key File")
+                    }
                 }
             }
-        }
 
-        if (errorMessage != null) {
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(errorMessage, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-        }
+            if (errorMessage != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(errorMessage, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
 
-        Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            TextButton(onClick = onCancel, enabled = !isProcessing) { Text("Cancel") }
-            Spacer(modifier = Modifier.width(8.dp))
-            Button(onClick = onApply, enabled = !isProcessing) {
-                if (isProcessing) {
-                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Re-encrypting...")
-                } else {
-                    Text("Apply")
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onCancel, enabled = !isProcessing) { Text("Cancel") }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = onApply, enabled = !isProcessing) {
+                    if (isProcessing) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Re-encrypting...")
+                    } else {
+                        Text("Apply")
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ChangePasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ChangePasswordScreen.kt
@@ -10,17 +10,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,6 +35,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChangePasswordScreen(
     isProcessing: Boolean = false,
@@ -47,87 +52,100 @@ fun ChangePasswordScreen(
     val passwordsMatch = newPassword == confirmPassword
     val canSubmit = currentPassword.isNotEmpty() && newPassword.isNotEmpty() && passwordsMatch && !isProcessing
 
-    Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
-        Text("Change Master Password", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(24.dp))
-
-        OutlinedTextField(
-            value = currentPassword,
-            onValueChange = { currentPassword = it },
-            label = { Text("Current Password") },
-            singleLine = true,
-            enabled = !isProcessing,
-            visualTransformation = if (showPasswords) VisualTransformation.None else PasswordVisualTransformation(),
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = newPassword,
-            onValueChange = { newPassword = it },
-            label = { Text("New Password") },
-            singleLine = true,
-            enabled = !isProcessing,
-            visualTransformation = if (showPasswords) VisualTransformation.None else PasswordVisualTransformation(),
-            trailingIcon = {
-                IconButton(onClick = { showPasswords = !showPasswords }) {
-                    Icon(
-                        if (showPasswords) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
-                        contentDescription = null,
-                    )
-                }
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        // Strength indicator
-        if (newPassword.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(8.dp))
-            val strength = computeStrength(newPassword)
-            LinearProgressIndicator(
-                progress = { strength.first },
-                modifier = Modifier.fillMaxWidth(),
-                color = strength.third,
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Change Password") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
             )
-            Text(strength.second, style = MaterialTheme.typography.labelSmall, color = strength.third)
-        }
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(16.dp)) {
+            Spacer(modifier = Modifier.height(24.dp))
 
-        Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = currentPassword,
+                onValueChange = { currentPassword = it },
+                label = { Text("Current Password") },
+                singleLine = true,
+                enabled = !isProcessing,
+                visualTransformation = if (showPasswords) VisualTransformation.None else PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth(),
+            )
 
-        OutlinedTextField(
-            value = confirmPassword,
-            onValueChange = { confirmPassword = it },
-            label = { Text("Confirm New Password") },
-            singleLine = true,
-            enabled = !isProcessing,
-            visualTransformation = if (showPasswords) VisualTransformation.None else PasswordVisualTransformation(),
-            isError = confirmPassword.isNotEmpty() && !passwordsMatch,
-            supportingText = if (confirmPassword.isNotEmpty() && !passwordsMatch) {
-                { Text("Passwords do not match") }
-            } else {
-                null
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
+            Spacer(modifier = Modifier.height(16.dp))
 
-        if (errorMessage != null) {
+            OutlinedTextField(
+                value = newPassword,
+                onValueChange = { newPassword = it },
+                label = { Text("New Password") },
+                singleLine = true,
+                enabled = !isProcessing,
+                visualTransformation = if (showPasswords) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    IconButton(onClick = { showPasswords = !showPasswords }) {
+                        Icon(
+                            if (showPasswords) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                            contentDescription = null,
+                        )
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // Strength indicator
+            if (newPassword.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                val strength = computeStrength(newPassword)
+                LinearProgressIndicator(
+                    progress = { strength.first },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = strength.third,
+                )
+                Text(strength.second, style = MaterialTheme.typography.labelSmall, color = strength.third)
+            }
+
             Spacer(modifier = Modifier.height(12.dp))
-            Text(errorMessage, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-        }
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            TextButton(onClick = onCancel, enabled = !isProcessing) { Text("Cancel") }
-            Spacer(modifier = Modifier.width(8.dp))
-            Button(onClick = { onChangePassword(currentPassword, newPassword) }, enabled = canSubmit) {
-                if (isProcessing) {
-                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Re-encrypting...")
+            OutlinedTextField(
+                value = confirmPassword,
+                onValueChange = { confirmPassword = it },
+                label = { Text("Confirm New Password") },
+                singleLine = true,
+                enabled = !isProcessing,
+                visualTransformation = if (showPasswords) VisualTransformation.None else PasswordVisualTransformation(),
+                isError = confirmPassword.isNotEmpty() && !passwordsMatch,
+                supportingText = if (confirmPassword.isNotEmpty() && !passwordsMatch) {
+                    { Text("Passwords do not match") }
                 } else {
-                    Text("Change Password")
+                    null
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (errorMessage != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(errorMessage, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onCancel, enabled = !isProcessing) { Text("Cancel") }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = { onChangePassword(currentPassword, newPassword) }, enabled = canSubmit) {
+                    if (isProcessing) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Re-encrypting...")
+                    } else {
+                        Text("Change Password")
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/CreateDatabaseScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/CreateDatabaseScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -28,8 +29,10 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -42,12 +45,14 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateDatabaseScreen(
     onSelectLocation: () -> Unit = {},
     onSelectKeyFile: () -> Unit = {},
     onCreate: (CreateDatabaseConfig) -> Unit = {},
     onCancel: () -> Unit = {},
+    modifier: Modifier = Modifier,
 ) {
     var currentStep by remember { mutableIntStateOf(0) }
 
@@ -68,114 +73,125 @@ fun CreateDatabaseScreen(
     var kdfAlgorithm by remember { mutableStateOf("Argon2d") }
     var kdfIterations by remember { mutableStateOf("10") }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp)
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = "Create New Database",
-            style = MaterialTheme.typography.headlineSmall,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = "Step ${currentStep + 1} of 5",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        LinearProgressIndicator(
-            progress = { (currentStep + 1) / 5f },
-            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        when (currentStep) {
-            0 -> StepLocation(
-                databaseName = databaseName,
-                databasePath = databasePath,
-                onNameChange = { databaseName = it },
-                onSelectLocation = onSelectLocation,
-                onPathChange = { databasePath = it },
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Create Database") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
             )
-
-            1 -> StepPassword(
-                password = password,
-                confirmPassword = confirmPassword,
-                passwordVisible = passwordVisible,
-                onPasswordChange = { password = it },
-                onConfirmPasswordChange = { confirmPassword = it },
-                onToggleVisibility = { passwordVisible = !passwordVisible },
-            )
-
-            2 -> StepKeyFile(
-                keyFilePath = keyFilePath,
-                onSelectKeyFile = onSelectKeyFile,
-                onClearKeyFile = { keyFilePath = "" },
-                onKeyFilePathChange = { keyFilePath = it },
-            )
-
-            3 -> StepSettings(
-                encryptionAlgorithm = encryptionAlgorithm,
-                kdfAlgorithm = kdfAlgorithm,
-                kdfIterations = kdfIterations,
-                onEncryptionChange = { encryptionAlgorithm = it },
-                onKdfChange = { kdfAlgorithm = it },
-                onIterationsChange = { kdfIterations = it },
-            )
-
-            4 -> StepConfirmation(
-                databaseName = databaseName,
-                databasePath = databasePath,
-                hasKeyFile = keyFilePath.isNotEmpty(),
-                encryption = encryptionAlgorithm,
-                kdf = kdfAlgorithm,
-            )
-        }
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        // Navigation buttons
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            if (currentStep > 0) {
-                OutlinedButton(onClick = { currentStep-- }) {
-                    Text("Back")
-                }
-            } else {
-                TextButton(onClick = onCancel) {
-                    Text("Cancel")
-                }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Step ${currentStep + 1} of 5",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            LinearProgressIndicator(
+                progress = { (currentStep + 1) / 5f },
+                modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            when (currentStep) {
+                0 -> StepLocation(
+                    databaseName = databaseName,
+                    databasePath = databasePath,
+                    onNameChange = { databaseName = it },
+                    onSelectLocation = onSelectLocation,
+                    onPathChange = { databasePath = it },
+                )
+
+                1 -> StepPassword(
+                    password = password,
+                    confirmPassword = confirmPassword,
+                    passwordVisible = passwordVisible,
+                    onPasswordChange = { password = it },
+                    onConfirmPasswordChange = { confirmPassword = it },
+                    onToggleVisibility = { passwordVisible = !passwordVisible },
+                )
+
+                2 -> StepKeyFile(
+                    keyFilePath = keyFilePath,
+                    onSelectKeyFile = onSelectKeyFile,
+                    onClearKeyFile = { keyFilePath = "" },
+                    onKeyFilePathChange = { keyFilePath = it },
+                )
+
+                3 -> StepSettings(
+                    encryptionAlgorithm = encryptionAlgorithm,
+                    kdfAlgorithm = kdfAlgorithm,
+                    kdfIterations = kdfIterations,
+                    onEncryptionChange = { encryptionAlgorithm = it },
+                    onKdfChange = { kdfAlgorithm = it },
+                    onIterationsChange = { kdfIterations = it },
+                )
+
+                4 -> StepConfirmation(
+                    databaseName = databaseName,
+                    databasePath = databasePath,
+                    hasKeyFile = keyFilePath.isNotEmpty(),
+                    encryption = encryptionAlgorithm,
+                    kdf = kdfAlgorithm,
+                )
             }
 
-            if (currentStep < 4) {
-                val canProceed = when (currentStep) {
-                    0 -> databaseName.isNotBlank() && databasePath.isNotBlank()
-                    1 -> password.isNotEmpty() && password == confirmPassword
-                    else -> true
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Navigation buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                if (currentStep > 0) {
+                    OutlinedButton(onClick = { currentStep-- }) {
+                        Text("Back")
+                    }
+                } else {
+                    TextButton(onClick = onCancel) {
+                        Text("Cancel")
+                    }
                 }
-                Button(onClick = { currentStep++ }, enabled = canProceed) {
-                    Text("Next")
-                }
-            } else {
-                Button(onClick = {
-                    onCreate(
-                        CreateDatabaseConfig(
-                            name = databaseName,
-                            path = databasePath,
-                            password = password,
-                            keyFilePath = keyFilePath.ifEmpty { null },
-                            encryptionAlgorithm = encryptionAlgorithm,
-                            kdfAlgorithm = kdfAlgorithm,
-                            kdfIterations = kdfIterations.toIntOrNull() ?: 10,
-                        ),
-                    )
-                }) {
-                    Text("Create")
+
+                if (currentStep < 4) {
+                    val canProceed = when (currentStep) {
+                        0 -> databaseName.isNotBlank() && databasePath.isNotBlank()
+                        1 -> password.isNotEmpty() && password == confirmPassword
+                        else -> true
+                    }
+                    Button(onClick = { currentStep++ }, enabled = canProceed) {
+                        Text("Next")
+                    }
+                } else {
+                    Button(onClick = {
+                        onCreate(
+                            CreateDatabaseConfig(
+                                name = databaseName,
+                                path = databasePath,
+                                password = password,
+                                keyFilePath = keyFilePath.ifEmpty { null },
+                                encryptionAlgorithm = encryptionAlgorithm,
+                                kdfAlgorithm = kdfAlgorithm,
+                                kdfIterations = kdfIterations.toIntOrNull() ?: 10,
+                            ),
+                        )
+                    }) {
+                        Text("Create")
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/DatabaseSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/DatabaseSettingsScreen.kt
@@ -8,14 +8,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -36,6 +43,7 @@ data class DatabaseSettingsResult(
     val historyMaxSize: Long,
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatabaseSettingsScreen(
     meta: KdbxMeta,
@@ -56,72 +64,83 @@ fun DatabaseSettingsScreen(
     var historyMaxItems by remember { mutableStateOf(meta.historyMaxItems.toString()) }
     var historyMaxSize by remember { mutableStateOf((meta.historyMaxSize / (1024 * 1024)).toString()) }
 
-    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Text("Database Settings", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(16.dp))
-
-        PrimaryTabRow(selectedTabIndex = selectedTab) {
-            tabs.forEachIndexed { index, title ->
-                Tab(
-                    selected = selectedTab == index,
-                    onClick = { selectedTab = index },
-                    text = { Text(title) },
-                )
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Database Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+            PrimaryTabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(title) },
+                    )
+                }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Column(
-            modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()),
-        ) {
-            when (selectedTab) {
-                0 -> GeneralTab(
-                    databaseName = databaseName,
-                    description = description,
-                    defaultUserName = defaultUserName,
-                    onNameChange = { databaseName = it },
-                    onDescriptionChange = { description = it },
-                    onDefaultUserNameChange = { defaultUserName = it },
-                )
-
-                1 -> SecurityTab(
-                    encryption = encryption,
-                    kdf = kdf,
-                    onEncryptionChange = { encryption = it },
-                    onKdfChange = { kdf = it },
-                )
-
-                2 -> MaintenanceTab(
-                    historyMaxItems = historyMaxItems,
-                    historyMaxSize = historyMaxSize,
-                    onMaxItemsChange = { historyMaxItems = it },
-                    onMaxSizeChange = { historyMaxSize = it },
-                )
-            }
-        }
-
-        HorizontalDivider()
-        Spacer(modifier = Modifier.height(8.dp))
-        androidx.compose.foundation.layout.Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
-        ) {
-            TextButton(onClick = onCancel) { Text("Cancel") }
-            Spacer(modifier = Modifier.padding(horizontal = 4.dp))
-            Button(onClick = {
-                onSave(
-                    DatabaseSettingsResult(
+            Column(
+                modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()),
+            ) {
+                when (selectedTab) {
+                    0 -> GeneralTab(
                         databaseName = databaseName,
                         description = description,
                         defaultUserName = defaultUserName,
-                        encryptionAlgorithm = encryption,
-                        kdfAlgorithm = kdf,
-                        historyMaxItems = historyMaxItems.toIntOrNull() ?: KdbxMeta.DEFAULT_HISTORY_MAX_ITEMS,
-                        historyMaxSize = (historyMaxSize.toLongOrNull() ?: 6) * 1024 * 1024,
-                    ),
-                )
-            }) { Text("Save") }
+                        onNameChange = { databaseName = it },
+                        onDescriptionChange = { description = it },
+                        onDefaultUserNameChange = { defaultUserName = it },
+                    )
+
+                    1 -> SecurityTab(
+                        encryption = encryption,
+                        kdf = kdf,
+                        onEncryptionChange = { encryption = it },
+                        onKdfChange = { kdf = it },
+                    )
+
+                    2 -> MaintenanceTab(
+                        historyMaxItems = historyMaxItems,
+                        historyMaxSize = historyMaxSize,
+                        onMaxItemsChange = { historyMaxItems = it },
+                        onMaxSizeChange = { historyMaxSize = it },
+                    )
+                }
+            }
+
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+            androidx.compose.foundation.layout.Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
+            ) {
+                TextButton(onClick = onCancel) { Text("Cancel") }
+                Spacer(modifier = Modifier.padding(horizontal = 4.dp))
+                Button(onClick = {
+                    onSave(
+                        DatabaseSettingsResult(
+                            databaseName = databaseName,
+                            description = description,
+                            defaultUserName = defaultUserName,
+                            encryptionAlgorithm = encryption,
+                            kdfAlgorithm = kdf,
+                            historyMaxItems = historyMaxItems.toIntOrNull() ?: KdbxMeta.DEFAULT_HISTORY_MAX_ITEMS,
+                            historyMaxSize = (historyMaxSize.toLongOrNull() ?: 6) * 1024 * 1024,
+                        ),
+                    )
+                }) { Text("Save") }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryEditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryEditorScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Close
@@ -31,9 +32,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -81,6 +84,7 @@ fun EntryEditorScreen(
     onCancel: () -> Unit = {},
     onCopyToClipboard: (String) -> Unit = {},
     onRevert: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
 ) {
     var title by remember { mutableStateOf(initialTitle) }
     var userName by remember { mutableStateOf(initialUserName) }
@@ -124,228 +128,238 @@ fun EntryEditorScreen(
     val hasAnyModification =
         isTitleModified || isUserNameModified || isPasswordModified || isUrlModified || isNotesModified
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-    ) {
-        Text(
-            text = if (isEditMode) "Edit Entry" else "Create Entry",
-            style = MaterialTheme.typography.headlineSmall,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Icon + Title
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                Icons.Filled.Key,
-                contentDescription = "Icon $iconIndex",
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(32.dp).clickable { /* icon picker wired later */ },
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            OutlinedTextField(
-                value = title,
-                onValueChange = { title = it },
-                label = { Text("Title") },
-                singleLine = true,
-                modifier = Modifier.weight(1f),
-            )
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-        OutlinedTextField(
-            value = userName,
-            onValueChange = { userName = it },
-            label = { Text("Username") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-        // Password with generate and show/hide
-        OutlinedTextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Password") },
-            singleLine = true,
-            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-            trailingIcon = {
-                Row {
-                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                        Icon(
-                            if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
-                            contentDescription = null,
-                        )
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(if (isEditMode) "Edit Entry" else "Create Entry") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
-                    IconButton(onClick = { showGeneratorDialog = true }) {
-                        Icon(Icons.Filled.AutoAwesome, contentDescription = "Generate password")
-                    }
-                }
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Spacer(modifier = Modifier.height(12.dp))
-        OutlinedTextField(
-            value = url,
-            onValueChange = { url = it },
-            label = { Text("URL") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
+            // Icon + Title
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Key,
+                    contentDescription = "Icon $iconIndex",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(32.dp).clickable { /* icon picker wired later */ },
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    label = { Text("Title") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+            }
 
-        Spacer(modifier = Modifier.height(12.dp))
-        OutlinedTextField(
-            value = notes,
-            onValueChange = { notes = it },
-            label = { Text("Notes") },
-            minLines = 3,
-            maxLines = 6,
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        // Expiration
-        Spacer(modifier = Modifier.height(12.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(checked = expires, onCheckedChange = { expires = it })
-            Text("Expires", style = MaterialTheme.typography.bodyMedium)
-        }
-        if (expires) {
+            Spacer(modifier = Modifier.height(12.dp))
             OutlinedTextField(
-                value = expiryDate,
-                onValueChange = { expiryDate = it },
-                label = { Text("Expiry Date (YYYY-MM-DD)") },
+                value = userName,
+                onValueChange = { userName = it },
+                label = { Text("Username") },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
-        }
 
-        // Tags
-        Spacer(modifier = Modifier.height(12.dp))
-        OutlinedTextField(
-            value = tagInput,
-            onValueChange = { tagInput = it },
-            label = { Text("Tags (comma-separated)") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
+            Spacer(modifier = Modifier.height(12.dp))
+            // Password with generate and show/hide
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                singleLine = true,
+                visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    Row {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                                contentDescription = null,
+                            )
+                        }
+                        IconButton(onClick = { showGeneratorDialog = true }) {
+                            Icon(Icons.Filled.AutoAwesome, contentDescription = "Generate password")
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
 
-        // Custom fields
-        Spacer(modifier = Modifier.height(16.dp))
-        HorizontalDivider()
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text("Custom Fields", style = MaterialTheme.typography.titleSmall)
-            IconButton(onClick = { customFields.add(EntryEditorField("", "")) }) {
-                Icon(Icons.Filled.Add, contentDescription = "Add field")
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = url,
+                onValueChange = { url = it },
+                label = { Text("URL") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = notes,
+                onValueChange = { notes = it },
+                label = { Text("Notes") },
+                minLines = 3,
+                maxLines = 6,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // Expiration
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = expires, onCheckedChange = { expires = it })
+                Text("Expires", style = MaterialTheme.typography.bodyMedium)
             }
-        }
-        customFields.forEachIndexed { index, field ->
+            if (expires) {
+                OutlinedTextField(
+                    value = expiryDate,
+                    onValueChange = { expiryDate = it },
+                    label = { Text("Expiry Date (YYYY-MM-DD)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            // Tags
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = tagInput,
+                onValueChange = { tagInput = it },
+                label = { Text("Tags (comma-separated)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            // Custom fields
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
             Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                OutlinedTextField(
-                    value = field.key,
-                    onValueChange = { customFields[index] = field.copy(key = it) },
-                    label = { Text("Key") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                OutlinedTextField(
-                    value = field.value,
-                    onValueChange = { customFields[index] = field.copy(value = it) },
-                    label = { Text("Value") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                IconButton(onClick = { customFields.removeAt(index) }) {
-                    Icon(Icons.Filled.Close, contentDescription = "Remove", modifier = Modifier.size(18.dp))
+                Text("Custom Fields", style = MaterialTheme.typography.titleSmall)
+                IconButton(onClick = { customFields.add(EntryEditorField("", "")) }) {
+                    Icon(Icons.Filled.Add, contentDescription = "Add field")
                 }
             }
-        }
-
-        // TOTP setup
-        Spacer(modifier = Modifier.height(16.dp))
-        HorizontalDivider()
-        Spacer(modifier = Modifier.height(8.dp))
-        var showTotpSetup by remember { mutableStateOf(false) }
-        val hasTotpField = customFields.any { it.key == "otp" || it.key.startsWith("TimeOtp-") }
-        OutlinedButton(
-            onClick = { showTotpSetup = true },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Icon(Icons.Filled.Timer, contentDescription = null, modifier = Modifier.size(18.dp))
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(if (hasTotpField) "Edit TOTP" else "Set up TOTP")
-        }
-        if (showTotpSetup) {
-            TotpSetupDialog(
-                onConfirm = { params ->
-                    // Remove old TOTP fields
-                    customFields.removeAll { it.key == "otp" || it.key.startsWith("TimeOtp-") }
-                    // Add otpauth:// URI as the "otp" custom field
-                    val uri = buildOtpauthUri(params)
-                    customFields.add(EntryEditorField(key = "otp", value = uri))
-                    showTotpSetup = false
-                },
-                onDismiss = { showTotpSetup = false },
-            )
-        }
-
-        // Action buttons
-        Spacer(modifier = Modifier.height(24.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (isEditMode && hasAnyModification) {
-                Text(
-                    text = "Modified",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.tertiary,
-                    modifier = Modifier.padding(end = 8.dp),
-                )
-            }
-            if (onRevert != null && isEditMode && hasAnyModification) {
-                OutlinedButton(onClick = onRevert) {
-                    Text("Revert")
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-            }
-            TextButton(onClick = onCancel) {
-                Text("Cancel")
-            }
-            Spacer(modifier = Modifier.width(8.dp))
-            Button(
-                onClick = {
-                    onSave(
-                        EntryEditorResult(
-                            title = title,
-                            userName = userName,
-                            password = password,
-                            url = url,
-                            notes = notes,
-                            iconIndex = iconIndex,
-                            tags = tagInput.split(",").map { it.trim() }.filter { it.isNotEmpty() },
-                            customFields = customFields.toList(),
-                            expires = expires,
-                            expiryDate = expiryDate,
-                        ),
+            customFields.forEachIndexed { index, field ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedTextField(
+                        value = field.key,
+                        onValueChange = { customFields[index] = field.copy(key = it) },
+                        label = { Text("Key") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
                     )
-                },
-                enabled = title.isNotBlank(),
+                    Spacer(modifier = Modifier.width(8.dp))
+                    OutlinedTextField(
+                        value = field.value,
+                        onValueChange = { customFields[index] = field.copy(value = it) },
+                        label = { Text("Value") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = { customFields.removeAt(index) }) {
+                        Icon(Icons.Filled.Close, contentDescription = "Remove", modifier = Modifier.size(18.dp))
+                    }
+                }
+            }
+
+            // TOTP setup
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+            var showTotpSetup by remember { mutableStateOf(false) }
+            val hasTotpField = customFields.any { it.key == "otp" || it.key.startsWith("TimeOtp-") }
+            OutlinedButton(
+                onClick = { showTotpSetup = true },
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(if (isEditMode) "Save" else "Create")
+                Icon(Icons.Filled.Timer, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(if (hasTotpField) "Edit TOTP" else "Set up TOTP")
+            }
+            if (showTotpSetup) {
+                TotpSetupDialog(
+                    onConfirm = { params ->
+                        // Remove old TOTP fields
+                        customFields.removeAll { it.key == "otp" || it.key.startsWith("TimeOtp-") }
+                        // Add otpauth:// URI as the "otp" custom field
+                        val uri = buildOtpauthUri(params)
+                        customFields.add(EntryEditorField(key = "otp", value = uri))
+                        showTotpSetup = false
+                    },
+                    onDismiss = { showTotpSetup = false },
+                )
+            }
+
+            // Action buttons
+            Spacer(modifier = Modifier.height(24.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (isEditMode && hasAnyModification) {
+                    Text(
+                        text = "Modified",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
+                }
+                if (onRevert != null && isEditMode && hasAnyModification) {
+                    OutlinedButton(onClick = onRevert) {
+                        Text("Revert")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                TextButton(onClick = onCancel) {
+                    Text("Cancel")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = {
+                        onSave(
+                            EntryEditorResult(
+                                title = title,
+                                userName = userName,
+                                password = password,
+                                url = url,
+                                notes = notes,
+                                iconIndex = iconIndex,
+                                tags = tagInput.split(",").map { it.trim() }.filter { it.isNotEmpty() },
+                                customFields = customFields.toList(),
+                                expires = expires,
+                                expiryDate = expiryDate,
+                            ),
+                        )
+                    },
+                    enabled = title.isNotBlank(),
+                ) {
+                    Text(if (isEditMode) "Save" else "Create")
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryHistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/EntryHistoryScreen.kt
@@ -12,62 +12,82 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.model.KdbxEntry
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EntryHistoryScreen(
     entry: KdbxEntry,
     onViewVersion: (KdbxEntry) -> Unit = {},
     onRestoreVersion: (KdbxEntry) -> Unit = {},
     onDeleteVersion: (Int) -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Text(
-            text = "History: ${entry.title}",
-            style = MaterialTheme.typography.headlineSmall,
-        )
-        Text(
-            text = "${entry.history.size} version${if (entry.history.size != 1) "s" else ""}",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        if (entry.history.isEmpty()) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Entry History") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
             Text(
-                text = "No history available",
-                style = MaterialTheme.typography.bodyLarge,
+                text = "History: ${entry.title}",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Text(
+                text = "${entry.history.size} version${if (entry.history.size != 1) "s" else ""}",
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        } else {
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                itemsIndexed(
-                    entry.history.reversed(),
-                    key = { index, _ -> index },
-                ) { index, version ->
-                    val actualIndex = entry.history.lastIndex - index
-                    HistoryVersionCard(
-                        version = version,
-                        versionNumber = actualIndex + 1,
-                        onView = { onViewVersion(version) },
-                        onRestore = { onRestoreVersion(version) },
-                        onDelete = { onDeleteVersion(actualIndex) },
-                    )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (entry.history.isEmpty()) {
+                Text(
+                    text = "No history available",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    itemsIndexed(
+                        entry.history.reversed(),
+                        key = { index, _ -> index },
+                    ) { index, version ->
+                        val actualIndex = entry.history.lastIndex - index
+                        HistoryVersionCard(
+                            version = version,
+                            versionNumber = actualIndex + 1,
+                            onView = { onViewVersion(version) },
+                            onRestore = { onRestoreVersion(version) },
+                            onDelete = { onDeleteVersion(actualIndex) },
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ExpiredEntriesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ExpiredEntriesScreen.kt
@@ -14,14 +14,19 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,73 +34,88 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.common.PasswordHealthAnalyzer
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExpiredEntriesScreen(
     expiredEntries: List<PasswordHealthAnalyzer.EntryHealth>,
     expiringSoonEntries: List<PasswordHealthAnalyzer.EntryHealth>,
     onEntryClick: (PasswordHealthAnalyzer.EntryHealth) -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val total = expiredEntries.size + expiringSoonEntries.size
 
-    Column(modifier = modifier.fillMaxWidth().padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
-        Text("Expired Entries", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = "${expiredEntries.size} expired, ${expiringSoonEntries.size} expiring soon",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Expired Entries") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "${expiredEntries.size} expired, ${expiringSoonEntries.size} expiring soon",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
 
-        if (total == 0) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        Icons.Filled.CheckCircle,
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        "No expired entries!",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+            if (total == 0) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            Icons.Filled.CheckCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            "No expired entries!",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
-            }
-            return
-        }
-
-        LazyColumn {
-            if (expiredEntries.isNotEmpty()) {
-                item(key = "expired_header") {
-                    Text(
-                        text = "Expired (${expiredEntries.size})",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.padding(bottom = 4.dp),
-                    )
-                }
-                items(expiredEntries, key = { "expired_${it.entry.uuid}" }) { entryHealth ->
-                    ExpiredEntryRow(entryHealth = entryHealth, isExpired = true, onClick = { onEntryClick(entryHealth) })
-                    HorizontalDivider()
-                }
+                return@Scaffold
             }
 
-            if (expiringSoonEntries.isNotEmpty()) {
-                item(key = "expiring_header") {
-                    Text(
-                        text = "Expiring Soon (${expiringSoonEntries.size})",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.tertiary,
-                        modifier = Modifier.padding(top = if (expiredEntries.isNotEmpty()) 16.dp else 0.dp, bottom = 4.dp),
-                    )
+            LazyColumn {
+                if (expiredEntries.isNotEmpty()) {
+                    item(key = "expired_header") {
+                        Text(
+                            text = "Expired (${expiredEntries.size})",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                    }
+                    items(expiredEntries, key = { "expired_${it.entry.uuid}" }) { entryHealth ->
+                        ExpiredEntryRow(entryHealth = entryHealth, isExpired = true, onClick = { onEntryClick(entryHealth) })
+                        HorizontalDivider()
+                    }
                 }
-                items(expiringSoonEntries, key = { "expiring_${it.entry.uuid}" }) { entryHealth ->
-                    ExpiredEntryRow(entryHealth = entryHealth, isExpired = false, onClick = { onEntryClick(entryHealth) })
-                    HorizontalDivider()
+
+                if (expiringSoonEntries.isNotEmpty()) {
+                    item(key = "expiring_header") {
+                        Text(
+                            text = "Expiring Soon (${expiringSoonEntries.size})",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.padding(top = if (expiredEntries.isNotEmpty()) 16.dp else 0.dp, bottom = 4.dp),
+                        )
+                    }
+                    items(expiringSoonEntries, key = { "expiring_${it.entry.uuid}" }) { entryHealth ->
+                        ExpiredEntryRow(entryHealth = entryHealth, isExpired = false, onClick = { onEntryClick(entryHealth) })
+                        HorizontalDivider()
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/HibpReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/HibpReportScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Shield
@@ -22,11 +23,15 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.common.HibpChecker
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HibpReportScreen(
     results: List<HibpChecker.EntryBreachResult>?,
@@ -41,124 +47,137 @@ fun HibpReportScreen(
     progress: Float,
     onCheckAll: () -> Unit = {},
     onEntryClick: (HibpChecker.EntryBreachResult) -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth().padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
-        Text("HIBP Breach Check", style = MaterialTheme.typography.headlineSmall)
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Privacy warning
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-            ),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Row(
-                modifier = Modifier.padding(12.dp),
-                verticalAlignment = Alignment.Top,
-            ) {
-                Icon(
-                    Icons.Filled.Warning,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
-                    modifier = Modifier.size(20.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "This check sends the first 5 characters of each password's SHA-1 hash to the " +
-                        "Have I Been Pwned API. Your full passwords are never transmitted.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer,
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // Check All button
-        Button(
-            onClick = onCheckAll,
-            enabled = !isChecking,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Icon(Icons.Filled.Shield, contentDescription = null, modifier = Modifier.size(18.dp))
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(if (isChecking) "Checking..." else "Check All Passwords")
-        }
-
-        // Progress bar
-        if (isChecking) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("HIBP Breach Check") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
             Spacer(modifier = Modifier.height(8.dp))
-            LinearProgressIndicator(
-                progress = { progress },
+
+            // Privacy warning
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                ),
                 modifier = Modifier.fillMaxWidth(),
-            )
-            Text(
-                text = "${(progress * 100).toInt()}%",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Results
-        if (results == null) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(
-                    "Click \"Check All Passwords\" to scan for breached passwords",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            return
-        }
-
-        val breached = results.filter { it.result.isBreached }
-
-        if (breached.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            ) {
+                Row(
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.Top,
+                ) {
                     Icon(
-                        Icons.Filled.CheckCircle,
+                        Icons.Filled.Warning,
                         contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                        modifier = Modifier.size(20.dp),
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        "No breached passwords found!",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        "${results.size} passwords checked",
+                        text = "This check sends the first 5 characters of each password's SHA-1 hash to the " +
+                            "Have I Been Pwned API. Your full passwords are never transmitted.",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.outline,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
                     )
                 }
             }
-            return
-        }
 
-        Text(
-            text = "${breached.size} breached ${if (breached.size == 1) "password" else "passwords"} found",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.error,
-        )
+            Spacer(modifier = Modifier.height(12.dp))
 
-        Spacer(modifier = Modifier.height(8.dp))
+            // Check All button
+            Button(
+                onClick = onCheckAll,
+                enabled = !isChecking,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Filled.Shield, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(if (isChecking) "Checking..." else "Check All Passwords")
+            }
 
-        val sorted = breached.sortedByDescending { it.result.breachCount }
+            // Progress bar
+            if (isChecking) {
+                Spacer(modifier = Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    text = "${(progress * 100).toInt()}%",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
 
-        LazyColumn {
-            items(sorted, key = { it.entry.uuid }) { entryResult ->
-                BreachResultRow(entryResult = entryResult, onClick = { onEntryClick(entryResult) })
-                HorizontalDivider()
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Results
+            if (results == null) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        "Click \"Check All Passwords\" to scan for breached passwords",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                return@Scaffold
+            }
+
+            val breached = results.filter { it.result.isBreached }
+
+            if (breached.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            Icons.Filled.CheckCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            "No breached passwords found!",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            "${results.size} passwords checked",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                }
+                return@Scaffold
+            }
+
+            Text(
+                text = "${breached.size} breached ${if (breached.size == 1) "password" else "passwords"} found",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val sorted = breached.sortedByDescending { it.result.breachCount }
+
+            LazyColumn {
+                items(sorted, key = { it.entry.uuid }) { entryResult ->
+                    BreachResultRow(entryResult = entryResult, onClick = { onEntryClick(entryResult) })
+                    HorizontalDivider()
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/KdfConfigScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/KdfConfigScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
@@ -16,11 +18,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,115 +55,128 @@ fun KdfConfigScreen(
 
     val isArgon2 = algorithm.startsWith("Argon2")
 
-    Column(modifier = modifier.fillMaxWidth().padding(16.dp)) {
-        Text("KDF Configuration", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "The Key Derivation Function slows down brute-force attacks. Higher values are more secure but slower to unlock.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        // KDF selector
-        var expanded by remember { mutableStateOf(false) }
-        val options = listOf("AES-KDF", "Argon2d", "Argon2id")
-        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
-            OutlinedTextField(
-                value = algorithm,
-                onValueChange = {},
-                readOnly = true,
-                label = { Text("KDF Algorithm") },
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("KDF Configuration") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
             )
-            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                options.forEach { option ->
-                    DropdownMenuItem(
-                        text = { Text(option) },
-                        onClick = {
-                            algorithm = option
-                            expanded = false
-                        },
-                    )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(16.dp)) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "The Key Derivation Function slows down brute-force attacks. Higher values are more secure but slower to unlock.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // KDF selector
+            var expanded by remember { mutableStateOf(false) }
+            val options = listOf("AES-KDF", "Argon2d", "Argon2id")
+            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+                OutlinedTextField(
+                    value = algorithm,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("KDF Algorithm") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    options.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option) },
+                            onClick = {
+                                algorithm = option
+                                expanded = false
+                            },
+                        )
+                    }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        // Parameters
-        if (isArgon2) {
-            OutlinedTextField(
-                value = iterations,
-                onValueChange = { if (it.all { c -> c.isDigit() }) iterations = it },
-                label = { Text("Iterations") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            OutlinedTextField(
-                value = memoryMb,
-                onValueChange = { if (it.all { c -> c.isDigit() }) memoryMb = it },
-                label = { Text("Memory (MB)") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            OutlinedTextField(
-                value = parallelism,
-                onValueChange = { if (it.all { c -> c.isDigit() }) parallelism = it },
-                label = { Text("Parallelism") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        } else {
-            OutlinedTextField(
-                value = iterations,
-                onValueChange = { if (it.all { c -> c.isDigit() }) iterations = it },
-                label = { Text("Transform Rounds") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Benchmark
-        OutlinedButton(onClick = onBenchmark, enabled = !isBenchmarking) {
-            if (isBenchmarking) {
-                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Benchmarking...")
-            } else {
-                Text("Benchmark (1 second delay)")
-            }
-        }
-        if (benchmarkResult != null) {
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = benchmarkResult,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            TextButton(onClick = onCancel) { Text("Cancel") }
-            Spacer(modifier = Modifier.width(8.dp))
-            Button(onClick = {
-                onSave(
-                    KdfConfig(
-                        algorithm = algorithm,
-                        iterations = iterations.toLongOrNull() ?: 10,
-                        memoryMb = memoryMb.toIntOrNull() ?: 64,
-                        parallelism = parallelism.toIntOrNull() ?: 2,
-                    ),
+            // Parameters
+            if (isArgon2) {
+                OutlinedTextField(
+                    value = iterations,
+                    onValueChange = { if (it.all { c -> c.isDigit() }) iterations = it },
+                    label = { Text("Iterations") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
                 )
-            }) { Text("Save") }
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = memoryMb,
+                    onValueChange = { if (it.all { c -> c.isDigit() }) memoryMb = it },
+                    label = { Text("Memory (MB)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = parallelism,
+                    onValueChange = { if (it.all { c -> c.isDigit() }) parallelism = it },
+                    label = { Text("Parallelism") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                OutlinedTextField(
+                    value = iterations,
+                    onValueChange = { if (it.all { c -> c.isDigit() }) iterations = it },
+                    label = { Text("Transform Rounds") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Benchmark
+            OutlinedButton(onClick = onBenchmark, enabled = !isBenchmarking) {
+                if (isBenchmarking) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Benchmarking...")
+                } else {
+                    Text("Benchmark (1 second delay)")
+                }
+            }
+            if (benchmarkResult != null) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = benchmarkResult,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onCancel) { Text("Cancel") }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = {
+                    onSave(
+                        KdfConfig(
+                            algorithm = algorithm,
+                            iterations = iterations.toLongOrNull() ?: 10,
+                            memoryMb = memoryMb.toIntOrNull() ?: 64,
+                            parallelism = parallelism.toIntOrNull() ?: 2,
+                        ),
+                    )
+                }) { Text("Save") }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ReportsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ReportsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Attachment
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Folder
@@ -23,10 +24,14 @@ import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.common.PasswordHealthAnalyzer
 import org.github.keepasscompose.core.common.PasswordStrength
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReportsScreen(
     report: PasswordHealthAnalyzer.HealthReport,
@@ -45,189 +51,203 @@ fun ReportsScreen(
     onReusedPasswords: () -> Unit = {},
     onExpiredEntries: () -> Unit = {},
     onHibpReport: () -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(24.dp)
-            .verticalScroll(rememberScrollState()),
-    ) {
-        Text("Database Reports", style = MaterialTheme.typography.headlineSmall)
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Summary statistics
-        Text("Overview", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier.fillMaxWidth(),
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Reports") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState()),
         ) {
-            StatCard(
-                icon = Icons.Filled.Key,
-                label = "Entries",
-                value = report.totalEntries.toString(),
-                modifier = Modifier.weight(1f),
-            )
-            StatCard(
-                icon = Icons.Filled.Folder,
-                label = "Groups",
-                value = totalGroups.toString(),
-                modifier = Modifier.weight(1f),
-            )
-            StatCard(
-                icon = Icons.Filled.Attachment,
-                label = "Attachments",
-                value = totalAttachments.toString(),
-                modifier = Modifier.weight(1f),
-            )
-        }
+            Spacer(modifier = Modifier.height(16.dp))
 
-        // Password health score
-        Spacer(modifier = Modifier.height(24.dp))
-        Text("Password Health", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(8.dp))
+            // Summary statistics
+            Text("Overview", style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(8.dp))
 
-        val strongCount = report.entries.count {
-            it.entry.password.isNotEmpty() &&
-                it.strength.level >= PasswordStrength.Level.STRONG
-        }
-        val healthScore = if (report.entriesWithPasswords > 0) {
-            strongCount.toFloat() / report.entriesWithPasswords
-        } else {
-            0f
-        }
-        val healthColor = when {
-            healthScore >= 0.8f -> MaterialTheme.colorScheme.primary
-            healthScore >= 0.5f -> MaterialTheme.colorScheme.tertiary
-            else -> MaterialTheme.colorScheme.error
-        }
-
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            ),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "${(healthScore * 100).toInt()}%",
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = healthColor,
-                    )
-                    Text(
-                        text = "Average: ${report.averageStrength.name.replace('_', ' ').lowercase()
-                            .replaceFirstChar { it.uppercase() }}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                LinearProgressIndicator(
-                    progress = { healthScore },
-                    modifier = Modifier.fillMaxWidth(),
-                    color = healthColor,
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                StatCard(
+                    icon = Icons.Filled.Key,
+                    label = "Entries",
+                    value = report.totalEntries.toString(),
+                    modifier = Modifier.weight(1f),
                 )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = "$strongCount of ${report.entriesWithPasswords} passwords are strong or better",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                StatCard(
+                    icon = Icons.Filled.Folder,
+                    label = "Groups",
+                    value = totalGroups.toString(),
+                    modifier = Modifier.weight(1f),
+                )
+                StatCard(
+                    icon = Icons.Filled.Attachment,
+                    label = "Attachments",
+                    value = totalAttachments.toString(),
+                    modifier = Modifier.weight(1f),
                 )
             }
-        }
 
-        // Strength distribution
-        Spacer(modifier = Modifier.height(16.dp))
-        Text("Strength Distribution", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(8.dp))
+            // Password health score
+            Spacer(modifier = Modifier.height(24.dp))
+            Text("Password Health", style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(8.dp))
 
-        val distribution = PasswordStrength.Level.entries.associateWith { level ->
-            report.entries.count {
-                it.entry.password.isNotEmpty() && it.strength.level == level
+            val strongCount = report.entries.count {
+                it.entry.password.isNotEmpty() &&
+                    it.strength.level >= PasswordStrength.Level.STRONG
             }
-        }
-
-        distribution.forEach { (level, count) ->
-            val fraction = if (report.entriesWithPasswords > 0) {
-                count.toFloat() / report.entriesWithPasswords
+            val healthScore = if (report.entriesWithPasswords > 0) {
+                strongCount.toFloat() / report.entriesWithPasswords
             } else {
                 0f
             }
-            val barColor = when (level) {
-                PasswordStrength.Level.VERY_WEAK -> MaterialTheme.colorScheme.error
-                PasswordStrength.Level.WEAK -> MaterialTheme.colorScheme.error
-                PasswordStrength.Level.FAIR -> MaterialTheme.colorScheme.tertiary
-                PasswordStrength.Level.STRONG -> MaterialTheme.colorScheme.primary
-                PasswordStrength.Level.VERY_STRONG -> MaterialTheme.colorScheme.primary
+            val healthColor = when {
+                healthScore >= 0.8f -> MaterialTheme.colorScheme.primary
+                healthScore >= 0.5f -> MaterialTheme.colorScheme.tertiary
+                else -> MaterialTheme.colorScheme.error
             }
 
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                ),
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(
-                    text = level.name.replace('_', ' ').lowercase()
-                        .replaceFirstChar { it.uppercase() },
-                    style = MaterialTheme.typography.labelSmall,
-                    modifier = Modifier.width(80.dp),
-                )
-                LinearProgressIndicator(
-                    progress = { fraction },
-                    modifier = Modifier.weight(1f).height(8.dp),
-                    color = barColor,
-                )
-                Text(
-                    text = count.toString(),
-                    style = MaterialTheme.typography.labelSmall,
-                    modifier = Modifier.width(32.dp).padding(start = 8.dp),
-                )
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "${(healthScore * 100).toInt()}%",
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = healthColor,
+                        )
+                        Text(
+                            text = "Average: ${report.averageStrength.name.replace('_', ' ').lowercase()
+                                .replaceFirstChar { it.uppercase() }}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LinearProgressIndicator(
+                        progress = { healthScore },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = healthColor,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "$strongCount of ${report.entriesWithPasswords} passwords are strong or better",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
+
+            // Strength distribution
+            Spacer(modifier = Modifier.height(16.dp))
+            Text("Strength Distribution", style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val distribution = PasswordStrength.Level.entries.associateWith { level ->
+                report.entries.count {
+                    it.entry.password.isNotEmpty() && it.strength.level == level
+                }
+            }
+
+            distribution.forEach { (level, count) ->
+                val fraction = if (report.entriesWithPasswords > 0) {
+                    count.toFloat() / report.entriesWithPasswords
+                } else {
+                    0f
+                }
+                val barColor = when (level) {
+                    PasswordStrength.Level.VERY_WEAK -> MaterialTheme.colorScheme.error
+                    PasswordStrength.Level.WEAK -> MaterialTheme.colorScheme.error
+                    PasswordStrength.Level.FAIR -> MaterialTheme.colorScheme.tertiary
+                    PasswordStrength.Level.STRONG -> MaterialTheme.colorScheme.primary
+                    PasswordStrength.Level.VERY_STRONG -> MaterialTheme.colorScheme.primary
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                ) {
+                    Text(
+                        text = level.name.replace('_', ' ').lowercase()
+                            .replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.width(80.dp),
+                    )
+                    LinearProgressIndicator(
+                        progress = { fraction },
+                        modifier = Modifier.weight(1f).height(8.dp),
+                        color = barColor,
+                    )
+                    Text(
+                        text = count.toString(),
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.width(32.dp).padding(start = 8.dp),
+                    )
+                }
+            }
+
+            // Report cards
+            Spacer(modifier = Modifier.height(24.dp))
+            Text("Reports", style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            ReportCard(
+                icon = Icons.Filled.Warning,
+                title = "Weak Passwords",
+                count = report.weakPasswords.size,
+                color = MaterialTheme.colorScheme.error,
+                onClick = onWeakPasswords,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ReportCard(
+                icon = Icons.Filled.Lock,
+                title = "Reused Passwords",
+                count = report.reusedPasswords.values.sumOf { it.size },
+                color = MaterialTheme.colorScheme.tertiary,
+                onClick = onReusedPasswords,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ReportCard(
+                icon = Icons.Filled.Event,
+                title = "Expired Entries",
+                count = report.expiredEntries.size + report.expiringSoonEntries.size,
+                color = MaterialTheme.colorScheme.error,
+                onClick = onExpiredEntries,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ReportCard(
+                icon = Icons.Filled.Shield,
+                title = "HIBP Breach Check",
+                count = null,
+                color = MaterialTheme.colorScheme.secondary,
+                onClick = onHibpReport,
+            )
         }
-
-        // Report cards
-        Spacer(modifier = Modifier.height(24.dp))
-        Text("Reports", style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(8.dp))
-
-        ReportCard(
-            icon = Icons.Filled.Warning,
-            title = "Weak Passwords",
-            count = report.weakPasswords.size,
-            color = MaterialTheme.colorScheme.error,
-            onClick = onWeakPasswords,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        ReportCard(
-            icon = Icons.Filled.Lock,
-            title = "Reused Passwords",
-            count = report.reusedPasswords.values.sumOf { it.size },
-            color = MaterialTheme.colorScheme.tertiary,
-            onClick = onReusedPasswords,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        ReportCard(
-            icon = Icons.Filled.Event,
-            title = "Expired Entries",
-            count = report.expiredEntries.size + report.expiringSoonEntries.size,
-            color = MaterialTheme.colorScheme.error,
-            onClick = onExpiredEntries,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        ReportCard(
-            icon = Icons.Filled.Shield,
-            title = "HIBP Breach Check",
-            count = null,
-            color = MaterialTheme.colorScheme.secondary,
-            onClick = onHibpReport,
-        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ReusedPasswordsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/ReusedPasswordsScreen.kt
@@ -14,12 +14,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,61 +32,76 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.common.PasswordHealthAnalyzer
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReusedPasswordsScreen(
     reusedGroups: Map<String, List<PasswordHealthAnalyzer.EntryHealth>>,
     onEntryClick: (PasswordHealthAnalyzer.EntryHealth) -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val totalEntries = reusedGroups.values.sumOf { it.size }
 
-    Column(modifier = modifier.fillMaxWidth().padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
-        Text("Reused Passwords", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = "$totalEntries ${if (totalEntries == 1) "entry" else "entries"} sharing " +
-                "${reusedGroups.size} ${if (reusedGroups.size == 1) "password" else "passwords"}",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Reused Passwords") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "$totalEntries ${if (totalEntries == 1) "entry" else "entries"} sharing " +
+                    "${reusedGroups.size} ${if (reusedGroups.size == 1) "password" else "passwords"}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
 
-        if (reusedGroups.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        Icons.Filled.CheckCircle,
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        "No reused passwords!",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+            if (reusedGroups.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            Icons.Filled.CheckCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            "No reused passwords!",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
+                return@Scaffold
             }
-            return
-        }
 
-        val sortedGroups = reusedGroups.entries.sortedByDescending { it.value.size }
+            val sortedGroups = reusedGroups.entries.sortedByDescending { it.value.size }
 
-        LazyColumn {
-            sortedGroups.forEachIndexed { groupIndex, (_, entries) ->
-                item(key = "header_$groupIndex") {
-                    Text(
-                        text = "Shared by ${entries.size} entries",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.tertiary,
-                        modifier = Modifier.padding(top = if (groupIndex > 0) 16.dp else 0.dp, bottom = 4.dp),
-                    )
-                }
+            LazyColumn {
+                sortedGroups.forEachIndexed { groupIndex, (_, entries) ->
+                    item(key = "header_$groupIndex") {
+                        Text(
+                            text = "Shared by ${entries.size} entries",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.padding(top = if (groupIndex > 0) 16.dp else 0.dp, bottom = 4.dp),
+                        )
+                    }
 
-                items(entries, key = { it.entry.uuid }) { entryHealth ->
-                    ReusedPasswordRow(entryHealth = entryHealth, onClick = { onEntryClick(entryHealth) })
-                    HorizontalDivider()
+                    items(entries, key = { it.entry.uuid }) { entryHealth ->
+                        ReusedPasswordRow(entryHealth = entryHealth, onClick = { onEntryClick(entryHealth) })
+                        HorizontalDivider()
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/SearchResultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/SearchResultsScreen.kt
@@ -15,12 +15,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.SearchOff
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,50 +37,66 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.common.SearchEngine
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchResultsScreen(
     results: List<SearchEngine.SearchResult>,
     query: String,
     onResultClick: (SearchEngine.SearchResult) -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    if (results.isEmpty()) {
-        Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Icon(
-                    Icons.Filled.SearchOff,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Search Results") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (results.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.Filled.SearchOff,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = if (query.isNotEmpty()) "No results for \"$query\"" else "Enter a search query",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            item {
                 Text(
-                    text = if (query.isNotEmpty()) "No results for \"$query\"" else "Enter a search query",
-                    style = MaterialTheme.typography.bodyLarge,
+                    text = "${results.size} result${if (results.size != 1) "s" else ""}",
+                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
             }
-        }
-        return
-    }
 
-    LazyColumn(modifier = modifier) {
-        item {
-            Text(
-                text = "${results.size} result${if (results.size != 1) "s" else ""}",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            )
-        }
-
-        items(results, key = { it.entry.uuid }) { result ->
-            SearchResultRow(
-                result = result,
-                query = query,
-                onClick = { onResultClick(result) },
-            )
-            HorizontalDivider()
+            items(results, key = { it.entry.uuid }) { result ->
+                SearchResultRow(
+                    result = result,
+                    query = query,
+                    onClick = { onResultClick(result) },
+                )
+                HorizontalDivider()
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/WeakPasswordsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/WeakPasswordsScreen.kt
@@ -15,13 +15,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,48 +35,63 @@ import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.common.PasswordHealthAnalyzer
 import org.github.keepasscompose.core.common.PasswordStrength
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeakPasswordsScreen(
     weakEntries: List<PasswordHealthAnalyzer.EntryHealth>,
     onEntryClick: (PasswordHealthAnalyzer.EntryHealth) -> Unit = {},
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth().padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
-        Text("Weak Passwords", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = "${weakEntries.size} ${if (weakEntries.size == 1) "entry" else "entries"} with weak passwords",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Weak Passwords") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxWidth().padding(padding).padding(top = 24.dp, start = 24.dp, end = 24.dp)) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "${weakEntries.size} ${if (weakEntries.size == 1) "entry" else "entries"} with weak passwords",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
 
-        if (weakEntries.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        Icons.Filled.CheckCircle,
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        "All passwords are strong!",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+            if (weakEntries.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            Icons.Filled.CheckCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            "All passwords are strong!",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
+                return@Scaffold
             }
-            return
-        }
 
-        val sorted = weakEntries.sortedBy { it.strength.level.ordinal }
+            val sorted = weakEntries.sortedBy { it.strength.level.ordinal }
 
-        LazyColumn {
-            items(sorted, key = { it.entry.uuid }) { entryHealth ->
-                WeakPasswordRow(entryHealth = entryHealth, onClick = { onEntryClick(entryHealth) })
-                HorizontalDivider()
+            LazyColumn {
+                items(sorted, key = { it.entry.uuid }) { entryHealth ->
+                    WeakPasswordRow(entryHealth = entryHealth, onClick = { onEntryClick(entryHealth) })
+                    HorizontalDivider()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wrap 14 secondary screens in `Scaffold` with `TopAppBar` containing title and back arrow
- Add `onBack` parameter to 7 screens that lacked any back/cancel callback
- Wire `onBack` in `AppNavigator` for Reports, Search, EntryHistory
- Visual consistency with ImportExportScreen which already had proper chrome

Closes #396

## Test plan
- [x] Build compiles, all tests pass
- [ ] Every secondary screen shows a top bar with title and back arrow
- [ ] Clicking back returns to previous screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)