### PR TITLE
[#398] Expand all groups by default and persist expand state

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/common/AppSettings.kt
@@ -21,8 +21,11 @@ class AppSettings(private val dataStore: DataStore<Preferences>) {
         val THEME_PREFERENCE = stringPreferencesKey("theme_preference")
         val CLIPBOARD_CLEAR_TIMEOUT_SECONDS = intPreferencesKey("clipboard_clear_timeout_seconds")
         val RECENT_DATABASES = stringPreferencesKey("recent_databases")
+        val EXPANDED_GROUPS = stringPreferencesKey("expanded_groups")
         const val MAX_RECENT_DATABASES = 10
     }
+
+    fun databaseKeyFromPath(path: String): String = path.substringAfterLast('/').substringBeforeLast('.')
 
     @Serializable
     data class RecentDatabaseEntry(val path: String, val name: String, val lastOpened: String)
@@ -102,5 +105,30 @@ class AppSettings(private val dataStore: DataStore<Preferences>) {
         val current = recentDatabases.first().toMutableList()
         current.removeAll { it.path == path }
         dataStore.edit { it[RECENT_DATABASES] = Json.encodeToString(current.toList()) }
+    }
+
+    fun expandedGroupsForDatabase(databaseKey: String): Flow<Set<String>?> = dataStore.data.map { prefs ->
+        prefs[EXPANDED_GROUPS]?.let { json ->
+            try {
+                val map = Json.decodeFromString<Map<String, List<String>>>(json)
+                map[databaseKey]?.toSet()
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+
+    suspend fun setExpandedGroupsForDatabase(databaseKey: String, expandedUuids: Set<String>) {
+        dataStore.edit { prefs ->
+            val existing = prefs[EXPANDED_GROUPS]?.let { json ->
+                try {
+                    Json.decodeFromString<Map<String, List<String>>>(json).toMutableMap()
+                } catch (_: Exception) {
+                    mutableMapOf()
+                }
+            } ?: mutableMapOf()
+            existing[databaseKey] = expandedUuids.toList()
+            prefs[EXPANDED_GROUPS] = Json.encodeToString(existing.toMap())
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxGroup.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/core/model/KdbxGroup.kt
@@ -8,3 +8,11 @@ data class KdbxGroup(
     val groups: List<KdbxGroup> = emptyList(),
     val entries: List<KdbxEntry> = emptyList(),
 )
+
+fun KdbxGroup.collectAllUuids(): Set<String> = buildSet {
+    fun visit(group: KdbxGroup) {
+        add(group.uuid)
+        group.groups.forEach { visit(it) }
+    }
+    visit(this@collectAllUuids)
+}

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupTree.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/components/GroupTree.kt
@@ -35,10 +35,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.github.keepasscompose.core.model.KdbxEntry
 import org.github.keepasscompose.core.model.KdbxGroup
+import org.github.keepasscompose.core.model.collectAllUuids
 
 @Composable
 fun GroupTree(
     rootGroup: KdbxGroup,
+    initialExpandedGroups: Set<String>? = null,
+    onExpandedGroupsChanged: (Set<String>) -> Unit = {},
     selectedEntryUuid: String? = null,
     onEntrySelected: (KdbxEntry) -> Unit = {},
     onEditEntry: (KdbxEntry) -> Unit = {},
@@ -50,7 +53,11 @@ fun GroupTree(
     recycleBinUuid: String? = null,
     modifier: Modifier = Modifier,
 ) {
-    val expandedGroups = remember { mutableStateListOf(rootGroup.uuid) }
+    val expandedGroups = remember(initialExpandedGroups) {
+        mutableStateListOf<String>().apply {
+            addAll(initialExpandedGroups ?: rootGroup.collectAllUuids())
+        }
+    }
     val flattenedItems = remember(rootGroup, expandedGroups.toList()) {
         buildFlatTreeList(rootGroup, expandedGroups.toSet(), depth = 0)
     }
@@ -70,6 +77,7 @@ fun GroupTree(
                         } else {
                             expandedGroups.add(item.group.uuid)
                         }
+                        onExpandedGroupsChanged(expandedGroups.toSet())
                     },
                     onNewEntry = { onNewEntryInGroup(item.group) },
                     onNewSubGroup = { onNewSubGroup(item.group) },

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/navigation/AppNavigator.kt
@@ -196,6 +196,10 @@ fun AppNavigator() {
 
         is AppScreen.Main -> {
             val database by databaseViewModel.database.collectAsState()
+            val dbPath by databaseViewModel.filePath.collectAsState()
+            val databaseKey = dbPath?.let { appSettings.databaseKeyFromPath(it) } ?: ""
+            val persistedExpandedGroups by appSettings.expandedGroupsForDatabase(databaseKey)
+                .collectAsState(initial = null)
 
             MainScreen(
                 databaseName = database?.meta?.databaseName ?: "Database",
@@ -252,6 +256,14 @@ fun AppNavigator() {
                 onChangeKeyFile = { currentScreen = AppScreen.ChangeKeyFile },
                 hasRecycleBin = database?.meta?.recycleBinEnabled == true,
                 recycleBinUuid = database?.meta?.recycleBinUuid,
+                initialExpandedGroups = persistedExpandedGroups,
+                onExpandedGroupsChanged = { expandedUuids ->
+                    if (databaseKey.isNotEmpty()) {
+                        scope.launch {
+                            appSettings.setExpandedGroupsForDatabase(databaseKey, expandedUuids)
+                        }
+                    }
+                },
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -73,6 +73,8 @@ fun MainScreen(
     onDeleteGroup: (String) -> Unit = {},
     hasRecycleBin: Boolean = false,
     recycleBinUuid: String? = null,
+    initialExpandedGroups: Set<String>? = null,
+    onExpandedGroupsChanged: (Set<String>) -> Unit = {},
 ) {
     val navigator = rememberListDetailPaneScaffoldNavigator<String>()
     val scope = rememberCoroutineScope()
@@ -176,6 +178,8 @@ fun MainScreen(
                     if (rootGroup != null) {
                         GroupTree(
                             rootGroup = rootGroup,
+                            initialExpandedGroups = initialExpandedGroups,
+                            onExpandedGroupsChanged = onExpandedGroupsChanged,
                             selectedEntryUuid = navigator.currentDestination?.contentKey,
                             onEntrySelected = { entry ->
                                 scope.launch {


### PR DESCRIPTION
## Summary
- All groups expanded by default when opening a database for the first time
- Expand/collapse choices persist across app restarts (per-database, via DataStore)
- Add `collectAllUuids()` extension on KdbxGroup
- Add per-database expand state persistence in AppSettings

Closes #398

## Test plan
- [x] Build compiles, all tests pass
- [ ] Open database → all groups expanded
- [ ] Collapse some groups → lock → reopen → same groups still collapsed
- [ ] Different databases have independent expand state

🤖 Generated with [Claude Code](https://claude.com/claude-code)