### PR TITLE
[#400] Fix TopAppBar hidden behind window insets in MainScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/github/keepasscompose/ui/screens/MainScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -132,6 +133,7 @@ fun MainScreen(
         listPane = {
             AnimatedPane {
                 Scaffold(
+                    contentWindowInsets = WindowInsets(0),
                     topBar = {
                         Column {
                             TopAppBar(
@@ -205,6 +207,7 @@ fun MainScreen(
                     val entry = selectedEntry
                     if (entry != null) {
                         Scaffold(
+                            contentWindowInsets = WindowInsets(0),
                             topBar = {
                                 if (isListHidden) {
                                     TopAppBar(


### PR DESCRIPTION
## Summary
- Set `contentWindowInsets = WindowInsets(0)` on both inner Scaffolds inside `ListDetailPaneScaffold`
- Prevents double inset application that caused the TopAppBar (database name, search, lock, menu) to be hidden behind window decoration

Closes #400

## Test plan
- [x] Build compiles, all tests pass
- [ ] TopAppBar visible immediately after opening a database
- [ ] Database name, search icon, lock icon, and overflow menu all visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)