### PR TITLE
[#402] Fix Android ActionBar overlapping Compose content

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:theme="@style/Theme.KeePassCompose"
         android:enableOnBackInvokedCallback="true">
         <activity
             android:exported="true"

--- a/androidApp/src/main/res/values/themes.xml
+++ b/androidApp/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.KeePassCompose" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- Create `Theme.KeePassCompose` with `Theme.Material.Light.NoActionBar` parent
- Set transparent status bar and navigation bar colors for edge-to-edge
- Apply theme in `AndroidManifest.xml` to remove the native "KeepassCompose" title bar

Closes #402

## Test plan
- [x] Build compiles, all tests pass
- [ ] No native ActionBar on Android mobile/tablet
- [ ] Compose TopAppBar fully visible and not overlapped
- [ ] Edge-to-edge rendering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)